### PR TITLE
fix: manual card inherits language from selected set (#42)

### DIFF
--- a/backend/api/cards.py
+++ b/backend/api/cards.py
@@ -204,11 +204,23 @@ def create_custom_card(data: CardCustomCreate, db: Session = Depends(get_db)):
             detail=f"Eine Karte mit der ID '{card_id}' existiert bereits."
         )
 
+    # Derive language from the set if not explicitly provided
+    card_lang = data.lang
+    if not card_lang and data.set_id:
+        existing_set = db.query(Set).filter(
+            (Set.tcg_set_id == data.set_id) | (Set.id == data.set_id)
+        ).first()
+        if existing_set:
+            card_lang = existing_set.lang
+    card_lang = card_lang or "en"
+
     # Ensure set record exists if set_id given
     if data.set_id:
-        existing_set = db.query(Set).filter(Set.id == data.set_id).first()
+        existing_set = db.query(Set).filter(
+            (Set.tcg_set_id == data.set_id) | (Set.id == data.set_id)
+        ).first()
         if not existing_set:
-            db.add(Set(id=data.set_id, name=data.set_id, total=0, tcg_set_id=data.set_id, lang=data.lang or "en"))
+            db.add(Set(id=data.set_id, name=data.set_id, total=0, tcg_set_id=data.set_id, lang=card_lang))
 
     # image_url is stored as images_small and images_large (unchanged, not TCGdex)
     card = Card(
@@ -223,7 +235,7 @@ def create_custom_card(data: CardCustomCreate, db: Session = Depends(get_db)):
         images_small=data.image_url or None,
         images_large=data.image_url or None,
         is_custom=True,
-        lang=data.lang or "en",
+        lang=card_lang,
     )
     db.add(card)
     try:

--- a/frontend/src/components/CardItem.jsx
+++ b/frontend/src/components/CardItem.jsx
@@ -118,9 +118,11 @@ export function CustomCardModal({ onClose, onCreated, sets: setsProp = [], autoA
     if (!name.trim()) return
     const effectiveSetId = setChoice === '__custom__' ? customSetId.trim() : setChoice || undefined
     const selectedSet = effectiveSetId ? sets.find(s => s.id === effectiveSetId) : null
+    // Use the original TCGdex set ID (tcg_set_id) for cards.set_id, not the composite DB key
+    const setIdForCard = selectedSet?.tcg_set_id || effectiveSetId || undefined
     const payload = {
       name: name.trim(),
-      set_id: effectiveSetId || undefined,
+      set_id: setIdForCard,
       number: number.trim() || undefined,
       rarity: rarity || undefined,
       types: selectedTypes.length > 0 ? selectedTypes : undefined,


### PR DESCRIPTION
Closes #42

## Changes

**Frontend (`CardItem.jsx`):**
- Send `tcg_set_id` (original TCGdex ID) instead of composite DB key as `set_id` when creating manual cards
- This ensures `cards.set_id` matches the expected format and set relationships work correctly

**Backend (`api/cards.py`):**
- Derive card language from the existing set record when `lang` is not explicitly provided in the request
- Look up sets by `tcg_set_id` OR `id` for robustness (handles both composite and original IDs)

## Root Cause
When selecting a German set (e.g. Paldea Fates DE), the frontend was sending the composite DB key (`pfl_de`) as `set_id` and the `lang` field relied solely on the frontend. If `lang` was missing, the backend defaulted to `"en"`. Now the backend also checks the set record as a fallback.