### PR TITLE
fix: custom cards searchable by set abbreviation + number (#43)

### DIFF
--- a/backend/api/cards.py
+++ b/backend/api/cards.py
@@ -158,17 +158,23 @@ def _search_by_code_number(
                 cards = db.query(Card).filter(*stripped_filters).all()
 
     # Also search custom cards matching set_id + number
+    custom_set_ids = {
+        identifier.upper()
+        for set_obj in set_objs
+        for identifier in (set_obj.tcg_set_id, set_obj.abbreviation, set_obj.id)
+        if identifier
+    }
     custom_cards = db.query(Card).filter(
         Card.is_custom,
         Card.number == card_number,
-        func.upper(Card.set_id) == set_code_upper,
+        func.upper(Card.set_id).in_(custom_set_ids),
     ).all()
     if not custom_cards and card_number != (card_number.lstrip("0") or "0"):
         card_number_stripped = card_number.lstrip("0") or "0"
         custom_cards = db.query(Card).filter(
             Card.is_custom,
             Card.number == card_number_stripped,
-            func.upper(Card.set_id) == set_code_upper,
+            func.upper(Card.set_id).in_(custom_set_ids),
         ).all()
 
     existing_ids = {c.id for c in cards}


### PR DESCRIPTION
Closes #43

## Problem
Searching `MEP 022` did not find custom cards because the search matched `Card.set_id` directly against the search code (`MEP`), but custom cards store `set_id` as the TCGdex ID (e.g. `sv08`).

## Fix
In `_search_by_code_number()`, build a set of all possible identifiers from matched Set objects (`tcg_set_id`, `abbreviation`, `id`) and match custom cards against that full set.

## Files changed
- `backend/api/cards.py` — custom card search section in `_search_by_code_number()`