### PR TITLE
fix: custom cards only in custom section, deduplicated + code search (#43)

### DIFF
--- a/backend/api/cards.py
+++ b/backend/api/cards.py
@@ -157,37 +157,14 @@ def _search_by_code_number(
                     stripped_filters.append(Card.lang == lang)
                 cards = db.query(Card).filter(*stripped_filters).all()
 
-    # Also search custom cards matching set_id + number
-    custom_set_ids = {
-        identifier.upper()
-        for set_obj in set_objs
-        for identifier in (set_obj.tcg_set_id, set_obj.abbreviation, set_obj.id)
-        if identifier
-    }
-    custom_cards = db.query(Card).filter(
-        Card.is_custom,
-        Card.number == card_number,
-        func.upper(Card.set_id).in_(custom_set_ids),
-    ).all()
-    if not custom_cards and card_number != (card_number.lstrip("0") or "0"):
-        card_number_stripped = card_number.lstrip("0") or "0"
-        custom_cards = db.query(Card).filter(
-            Card.is_custom,
-            Card.number == card_number_stripped,
-            func.upper(Card.set_id).in_(custom_set_ids),
-        ).all()
-
-    existing_ids = {c.id for c in cards}
-    all_cards = cards + [c for c in custom_cards if c.id not in existing_ids]
-
-    if not all_cards:
+    if not cards:
         return {"data": [], "total_count": 0, "page": page, "page_size": page_size}
 
     start = (page - 1) * page_size
-    page_cards = all_cards[start:start + page_size]
+    page_cards = cards[start:start + page_size]
     return {
         "data": [_card_to_dict(c) for c in page_cards],
-        "total_count": len(all_cards),
+        "total_count": len(cards),
         "page": page,
         "page_size": page_size,
     }

--- a/frontend/src/pages/CardSearch.jsx
+++ b/frontend/src/pages/CardSearch.jsx
@@ -217,6 +217,45 @@ export default function CardSearch() {
     queryClient.invalidateQueries({ queryKey: ['custom-cards'] })
   }
 
+  const matchedCustomCards = useMemo(() => {
+    const searchTerm = filters.name.trim()
+    if (!searchTerm) return []
+
+    const lowerSearchTerm = searchTerm.toLowerCase()
+    const codeMatch = CODE_NUMBER_RE.exec(searchTerm)
+
+    return recentCustomCards.filter((card) => {
+      if (card.name.toLowerCase().includes(lowerSearchTerm)) {
+        return true
+      }
+
+      if (!codeMatch) {
+        return false
+      }
+
+      const [, rawSetCode, rawNumber] = codeMatch
+      const normalizedSetCode = rawSetCode.toLowerCase()
+      const normalizedNumber = String(parseInt(rawNumber, 10))
+      const matchingSet = allSets.find((set) => (
+        set.tcg_set_id?.toLowerCase() === card.set_id?.toLowerCase() ||
+        set.id?.toLowerCase() === card.set_id?.toLowerCase()
+      ))
+      const setMatches = [
+        card.set_id,
+        matchingSet?.abbreviation,
+        matchingSet?.tcg_set_id,
+        matchingSet?.id,
+      ].some((value) => value?.toLowerCase() === normalizedSetCode)
+      const cardNumber = card.number ?? ''
+      const numberMatches = (
+        cardNumber === rawNumber ||
+        (cardNumber.replace(/^0+/, '') || '0') === normalizedNumber
+      )
+
+      return setMatches && numberMatches
+    })
+  }, [allSets, filters.name, recentCustomCards])
+
   const filterFormProps = { filters, setFilter, allSeries, setsForSeries, toggleSortOrder, t }
 
   return (
@@ -379,26 +418,16 @@ export default function CardSearch() {
         </div>
       )}
 
-      {recentCustomCards.length > 0 && filters.name.trim() && (
+      {matchedCustomCards.length > 0 && filters.name.trim() && (
         <div>
-          {(() => {
-            const matched = recentCustomCards.filter(c =>
-              c.name.toLowerCase().includes(filters.name.toLowerCase())
-            )
-            if (!matched.length) return null
-            return (
-              <>
-                <p className="text-xs text-yellow font-medium mb-2 flex items-center gap-1">
-                  <PenLine size={12} /> {t('cardSearch.customCard')}
-                </p>
-                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-                  {matched.map((card) => (
-                    <CardItem key={card.id} card={card} />
-                  ))}
-                </div>
-              </>
-            )
-          })()}
+          <p className="text-xs text-yellow font-medium mb-2 flex items-center gap-1">
+            <PenLine size={12} /> {t('cardSearch.customCard')}
+          </p>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+            {matchedCustomCards.map((card) => (
+              <CardItem key={card.id} card={card} />
+            ))}
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
Closes #43

## Problems fixed
1. **Duplicate cards**: Custom cards appeared multiple times in search results (once per collection entry)
2. **Wrong section**: Custom cards showed as normal search results instead of the ✏️ custom cards section
3. **No code+number match**: Searching "MEP 022" didn't find custom cards in the custom section

## Changes

**Backend (`api/cards.py`):**
- Removed custom card logic from `_search_by_code_number()` — custom cards no longer appear in normal search results

**Frontend (`CardSearch.jsx`):**
- New `matchedCustomCards` useMemo that matches by name AND by set code+number pattern
- Code+number matching resolves set abbreviation, tcg_set_id, and composite id against the card's set_id
- Handles leading zeros ("022" matches "22")
- Custom cards section now uses this memoized filter instead of inline IIFE