### PR TITLE
feat: delete custom cards with cascade (#44)

### DIFF
--- a/backend/api/cards.py
+++ b/backend/api/cards.py
@@ -250,6 +250,30 @@ def update_custom_card(card_id: str, update: CustomCardUpdate, db: Session = Dep
     return card
 
 
+@router.delete("/custom/{card_id}")
+def delete_custom_card(card_id: str, db: Session = Depends(get_db)):
+    """Delete a custom card and all related records."""
+    card = db.query(Card).filter(Card.id == card_id).first()
+    if not card:
+        raise HTTPException(status_code=404, detail="Card not found")
+    if not card.is_custom:
+        raise HTTPException(status_code=400, detail="Card is not custom")
+
+    try:
+        db.query(CollectionItem).filter(CollectionItem.card_id == card_id).delete(synchronize_session=False)
+        db.query(WishlistItem).filter(WishlistItem.card_id == card_id).delete(synchronize_session=False)
+        db.query(BinderCard).filter(BinderCard.card_id == card_id).delete(synchronize_session=False)
+        db.query(PriceHistory).filter(PriceHistory.card_id == card_id).delete(synchronize_session=False)
+        db.query(CustomCardMatch).filter(CustomCardMatch.custom_card_id == card_id).delete(synchronize_session=False)
+        db.delete(card)
+        db.commit()
+    except Exception as e:
+        db.rollback()
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return {"message": "Custom card deleted"}
+
+
 @router.get("/custom", response_model=List[CardBase])
 def list_custom_cards(db: Session = Depends(get_db)):
     """Return all manually created custom cards."""

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -15,6 +15,7 @@ export const getCardInLang = (cardId, lang) => api.get(`/cards/${cardId}/lang/${
 export const getPriceHistory = (id) => api.get(`/cards/${id}/price-history`)
 export const createCustomCard = (data) => api.post('/cards/custom', data)
 export const updateCustomCard = (cardId, data) => api.put(`/cards/custom/${cardId}`, data).then(r => r.data)
+export const deleteCustomCard = (cardId) => api.delete(`/cards/custom/${cardId}`)
 export const getCustomCards = () => api.get('/cards/custom')
 
 // Card recognition via Gemini Vision

--- a/frontend/src/components/CardItem.jsx
+++ b/frontend/src/components/CardItem.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query'
-import { Plus, Check, Heart, BookOpen, X, PenLine, Pencil, TrendingUp } from 'lucide-react'
-import { addToCollection, addToWishlist, createCustomCard, updateCustomCard, getEbayGradedPrice, getSetting, getSets } from '../api/client'
+import { Plus, Check, Heart, BookOpen, X, PenLine, Pencil, TrendingUp, Trash2 } from 'lucide-react'
+import { addToCollection, addToWishlist, createCustomCard, updateCustomCard, deleteCustomCard, getEbayGradedPrice, getSetting, getSets } from '../api/client'
 import { useSettings } from '../contexts/SettingsContext'
 import PeriodSelector, { CARD_PERIODS, PERIOD_PRICE_FIELD } from './PeriodSelector'
 import toast from 'react-hot-toast'
@@ -111,6 +111,21 @@ export function CustomCardModal({ onClose, onCreated, sets: setsProp = [], autoA
     },
   })
 
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteCustomCard(editCard.id),
+    onSuccess: (res) => {
+      toast.success(res?.data?.message || t('common.success'))
+      queryClient.invalidateQueries({ queryKey: ['collection'] })
+      queryClient.invalidateQueries({ queryKey: ['card-search'] })
+      queryClient.invalidateQueries({ queryKey: ['custom-cards'] })
+      onClose()
+    },
+    onError: (err) => {
+      const detail = err?.response?.data?.detail || t('common.error')
+      toast.error(detail)
+    },
+  })
+
   const addMutation = useMutation({
     mutationFn: (data) => addToCollection(data),
     onSuccess: () => {
@@ -161,6 +176,12 @@ export function CustomCardModal({ onClose, onCreated, sets: setsProp = [], autoA
 
   const toggleType = (tp) => {
     setSelectedTypes(prev => prev.includes(tp) ? prev.filter(t => t !== tp) : [...prev, tp])
+  }
+
+  const handleDelete = () => {
+    if (!editCard) return
+    if (!window.confirm(t('common.confirm_delete'))) return
+    deleteMutation.mutate()
   }
 
   return (
@@ -260,6 +281,16 @@ export function CustomCardModal({ onClose, onCreated, sets: setsProp = [], autoA
                 )}
               </div>
               <div className="flex gap-3 pt-2">
+                {isEditMode && (
+                  <button
+                    type="button"
+                    onClick={handleDelete}
+                    disabled={deleteMutation.isPending}
+                    className="btn-ghost text-brand-red border-brand-red/30 hover:bg-brand-red/10 px-3"
+                  >
+                    <Trash2 size={16} /> {deleteMutation.isPending ? t('common.deleting') : t('common.delete')}
+                  </button>
+                )}
                 <button type="submit" disabled={(isEditMode ? updateMutation.isPending : createMutation.isPending) || !name.trim()} className="btn-primary flex-1">
                   {isEditMode
                     ? (updateMutation.isPending ? t('common.saving') : t('common.save'))


### PR DESCRIPTION
Closes #44

## Changes

**Backend (`api/cards.py`):**
- New `DELETE /api/cards/custom/{card_id}` endpoint
- Cascading delete: removes CollectionItems, WishlistItems, BinderCards, PriceHistory, CustomCardMatches before deleting the Card
- Returns 404 if card not found, 400 if card is not custom

**Frontend (`client.js`):**
- New `deleteCustomCard(cardId)` API function

**Frontend (`CardItem.jsx`):**
- Red delete button (Trash2 icon) in CustomCardModal when editing
- Confirm dialog before deletion
- On success: toast, invalidate queries, close modal