### PR TITLE
fix: replace passlib with direct bcrypt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,4 +14,3 @@ pillow==12.1.1
 alembic==1.13.1
 bcrypt
 python-jose[cryptography]
-passlib[bcrypt]

--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -3,8 +3,8 @@ import os
 import secrets
 from datetime import datetime, timedelta
 
+import bcrypt
 from jose import JWTError, jwt
-from passlib.context import CryptContext
 from sqlalchemy.orm import Session
 
 from models import User
@@ -15,15 +15,13 @@ SECRET_KEY = os.getenv("JWT_SECRET_KEY", secrets.token_urlsafe(32))
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24 * 7  # 7 days
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-
 
 def hash_password(password: str) -> str:
-    return pwd_context.hash(password)
+    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
-    return pwd_context.verify(plain_password, hashed_password)
+    return bcrypt.checkpw(plain_password.encode("utf-8"), hashed_password.encode("utf-8"))
 
 
 def create_access_token(data: dict, expires_delta: timedelta = None) -> str:


### PR DESCRIPTION
passlib is unmaintained and incompatible with bcrypt>=4.1. Replaced with direct bcrypt calls.