### PR TITLE
feat: macOS-style login, logout everywhere, mobile overflow fixes

### DIFF
--- a/frontend/src/components/BottomNav.jsx
+++ b/frontend/src/components/BottomNav.jsx
@@ -3,14 +3,16 @@ import { NavLink, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import {
   LayoutDashboard, Search, Library, Grid2X2, MoreHorizontal,
-  Heart, BookOpen, BarChart3, ShoppingBag, Settings, X, Zap
+  Heart, BookOpen, BarChart3, ShoppingBag, Settings, X, Zap, LogOut
 } from 'lucide-react'
 import { getCustomMatches } from '../api/client'
+import { useAuth } from '../contexts/AuthContext'
 import { useSettings } from '../contexts/SettingsContext'
 import clsx from 'clsx'
 
 export default function BottomNav() {
   const { t } = useSettings()
+  const { logout } = useAuth()
   const [showMore, setShowMore] = useState(false)
   const navigate = useNavigate()
 
@@ -42,6 +44,12 @@ export default function BottomNav() {
   const handleMoreNav = (to) => {
     setShowMore(false)
     navigate(to)
+  }
+
+  const handleLogout = () => {
+    setShowMore(false)
+    logout()
+    navigate('/login')
   }
 
   return (
@@ -109,7 +117,7 @@ export default function BottomNav() {
             </div>
 
             {/* Grid of nav items */}
-            <div className="grid grid-cols-3 gap-2 p-4 safe-area-bottom">
+            <div className="grid grid-cols-3 gap-2 p-4">
               {moreNav.map(({ to, icon: Icon, label, badge }) => (
                 <button
                   key={to}
@@ -127,6 +135,16 @@ export default function BottomNav() {
                   <span className="text-xs text-text-muted text-center leading-tight">{label}</span>
                 </button>
               ))}
+            </div>
+
+            <div className="border-t border-border px-4 pb-4 pt-3 safe-area-bottom">
+              <button
+                onClick={handleLogout}
+                className="flex w-full items-center justify-center gap-2 rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm font-medium text-red-400 transition-colors hover:bg-red-500/15 hover:text-red-300"
+              >
+                <LogOut size={18} />
+                <span>{t('auth.logout')}</span>
+              </button>
             </div>
           </div>
         </>

--- a/frontend/src/i18n/de.js
+++ b/frontend/src/i18n/de.js
@@ -85,6 +85,8 @@ const de = {
     loginFailed: 'Anmeldung fehlgeschlagen',
     signingIn: 'Anmelden...',
     signInToCollection: 'Melde dich bei deiner Sammlung an',
+    switchUser: 'Anderer Benutzer',
+    welcomeBack: 'Willkommen zurück',
   },
 
   // Home Screen

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -85,6 +85,8 @@ const en = {
     loginFailed: 'Login failed',
     signingIn: 'Signing in...',
     signInToCollection: 'Sign in to your collection',
+    switchUser: 'Switch User',
+    welcomeBack: 'Welcome back',
   },
 
   // Home Screen

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,12 +1,15 @@
 import { useState } from 'react'
 import { Navigate, useNavigate } from 'react-router-dom'
+import { User } from 'lucide-react'
 import toast from 'react-hot-toast'
 import { login } from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
 import { useSettings } from '../contexts/SettingsContext'
 
 export default function Login() {
-  const [username, setUsername] = useState('')
+  const [lastUser] = useState(() => localStorage.getItem('lastUser') || '')
+  const [showSwitchUser, setShowSwitchUser] = useState(() => !localStorage.getItem('lastUser'))
+  const [username, setUsername] = useState(() => localStorage.getItem('lastUser') || '')
   const [password, setPassword] = useState('')
   const [loading, setLoading] = useState(false)
   const { user, loginUser } = useAuth()
@@ -23,6 +26,7 @@ export default function Login() {
 
     try {
       const data = await login(username, password)
+      localStorage.setItem('lastUser', username)
       loginUser(data.access_token, data.user)
       navigate('/')
     } catch (err) {
@@ -33,45 +37,102 @@ export default function Login() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-bg-primary p-4">
-      <div className="w-full max-w-sm bg-bg-card border border-border rounded-xl p-6 shadow-xl">
-        <div className="text-center mb-6">
-          <h1 className="text-2xl font-bold text-text-primary">PokéCollector</h1>
-          <p className="text-text-muted text-sm mt-1">{t('auth.signInToCollection')}</p>
+    <div className="relative min-h-screen overflow-hidden bg-bg-primary">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.08),_transparent_32%),radial-gradient(circle_at_bottom_right,_rgba(227,0,11,0.18),_transparent_28%)]" />
+      <div className="absolute inset-0 backdrop-blur-[2px]" />
+
+      <div className="relative flex min-h-screen items-center justify-center p-4 sm:p-6">
+        <div
+          className="w-full max-w-md rounded-[2rem] border border-border bg-bg-card p-6 shadow-2xl backdrop-blur-xl sm:p-8"
+          style={{ backgroundColor: 'rgba(26, 26, 46, 0.78)' }}
+        >
+          <div className="mb-8 text-center">
+            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-text-muted">PokéCollector</p>
+            <h1 className="mt-4 text-3xl font-semibold text-text-primary">
+              {lastUser && !showSwitchUser ? t('auth.welcomeBack') : t('auth.login')}
+            </h1>
+            <p className="mt-2 text-sm text-text-muted">{t('auth.signInToCollection')}</p>
+          </div>
+
+          {lastUser && !showSwitchUser ? (
+            <form onSubmit={handleSubmit} className="space-y-5">
+              <div className="flex flex-col items-center text-center">
+                <div
+                  className="flex h-24 w-24 items-center justify-center rounded-full border border-white/10 bg-bg-primary shadow-[0_20px_50px_rgba(0,0,0,0.35)]"
+                  style={{ backgroundColor: 'rgba(10, 10, 15, 0.82)' }}
+                >
+                  <User size={40} className="text-text-primary" />
+                </div>
+                <p className="mt-4 text-xl font-semibold text-text-primary">{lastUser}</p>
+              </div>
+
+              <div>
+                <label className="mb-1 block text-xs text-text-secondary">{t('auth.password')}</label>
+                <input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="input w-full"
+                  autoFocus
+                  required
+                />
+              </div>
+
+              <button
+                type="submit"
+                disabled={loading || !password}
+                className="btn-primary w-full"
+              >
+                {loading ? t('auth.signingIn') : t('auth.login')}
+              </button>
+
+              <button
+                type="button"
+                onClick={() => {
+                  setShowSwitchUser(true)
+                  setUsername('')
+                  setPassword('')
+                }}
+                className="mx-auto block text-sm text-text-muted transition-colors hover:text-text-primary"
+              >
+                {t('auth.switchUser')}
+              </button>
+            </form>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label className="mb-1 block text-xs text-text-secondary">{t('auth.username')}</label>
+                <input
+                  type="text"
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  className="input w-full"
+                  autoFocus
+                  required
+                />
+              </div>
+
+              <div>
+                <label className="mb-1 block text-xs text-text-secondary">{t('auth.password')}</label>
+                <input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="input w-full"
+                  required
+                />
+              </div>
+
+              <button
+                type="submit"
+                disabled={loading || !username || !password}
+                className="btn-primary w-full"
+              >
+                {loading ? t('auth.signingIn') : t('auth.login')}
+              </button>
+            </form>
+          )}
         </div>
-
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label className="text-xs text-text-secondary mb-1 block">{t('auth.username')}</label>
-            <input
-              type="text"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              className="input w-full"
-              autoFocus
-              required
-            />
-          </div>
-
-          <div>
-            <label className="text-xs text-text-secondary mb-1 block">{t('auth.password')}</label>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className="input w-full"
-              required
-            />
-          </div>
-
-          <button
-            type="submit"
-            disabled={loading || !username || !password}
-            className="btn-primary w-full"
-          >
-            {loading ? t('auth.signingIn') : t('auth.login')}
-          </button>
-        </form>
       </div>
     </div>
   )


### PR DESCRIPTION
## Changes

### Login Page — macOS Lock Screen Style
- Dark blurred background with radial gradients
- **Returning user**: large avatar icon + username, password-only field, "Switch User" link
- **New/switched user**: full username + password form
- Last logged-in username stored in `localStorage.lastUser`
- Frosted glass card with `rounded-[2rem]`

### Logout Button — Visible Everywhere
- **HomeScreen**: logout button top-left (next to sync button top-right)
- **All subpages (AppNav)**: LogOut icon in top-right of sticky header
- **Mobile BottomNav**: red logout button in More sheet (separated with border)

### Mobile Text Overflow Fixes
- Trainer greeting: `truncate` + `max-w-[90vw]`
- Stat card labels: `truncate`
- Navigation portal grid labels: `truncate` + `leading-tight`
- AppNav page title: `truncate`

### i18n Fixes
- New keys: `auth.switchUser`, `auth.welcomeBack` (de + en)
- Fixed 4x hardcoded `Error` in Settings.jsx → `t("common.error")`
- All keys verified complete in both de.js and en.js