### PR TITLE
feat: lazy image cache — store card/set images in PostgreSQL

### DIFF
--- a/backend/api/images.py
+++ b/backend/api/images.py
@@ -1,0 +1,78 @@
+from fastapi import APIRouter, Depends, HTTPException, Response
+import httpx
+from sqlalchemy.orm import Session
+
+from database import get_db
+from models import Card, ImageCache, Set
+
+router = APIRouter()
+
+_client = httpx.Client(timeout=15, follow_redirects=True)
+
+
+def _get_or_fetch(db: Session, key: str, url: str) -> tuple[bytes, str]:
+    cached = db.query(ImageCache).filter(ImageCache.image_key == key).first()
+    if cached:
+        return cached.data, cached.content_type
+
+    try:
+        resp = _client.get(url)
+        resp.raise_for_status()
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail="Failed to fetch image from upstream") from exc
+
+    content_type = resp.headers.get("content-type", "image/webp")
+    entry = ImageCache(image_key=key, data=resp.content, content_type=content_type)
+    db.add(entry)
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        cached = db.query(ImageCache).filter(ImageCache.image_key == key).first()
+        if cached:
+            return cached.data, cached.content_type
+        raise
+
+    return resp.content, content_type
+
+
+@router.get("/card/{card_id}/{size}")
+def get_card_image(card_id: str, size: str, db: Session = Depends(get_db)):
+    if size not in ("small", "large"):
+        raise HTTPException(status_code=400, detail="size must be small or large")
+
+    card = db.query(Card).filter(Card.id == card_id).first()
+    if not card:
+        raise HTTPException(status_code=404, detail="Card not found")
+
+    url = card.images_small if size == "small" else card.images_large
+    if not url:
+        raise HTTPException(status_code=404, detail="No image URL for this card")
+
+    data, content_type = _get_or_fetch(db, f"card:{card_id}:{size}", url)
+    return Response(
+        content=data,
+        media_type=content_type,
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
+
+
+@router.get("/set/{set_id}/{image_type}")
+def get_set_image(set_id: str, image_type: str, db: Session = Depends(get_db)):
+    if image_type not in ("logo", "symbol"):
+        raise HTTPException(status_code=400, detail="image_type must be logo or symbol")
+
+    card_set = db.query(Set).filter(Set.id == set_id).first()
+    if not card_set:
+        raise HTTPException(status_code=404, detail="Set not found")
+
+    url = card_set.images_logo if image_type == "logo" else card_set.images_symbol
+    if not url:
+        raise HTTPException(status_code=404, detail="No image URL for this set")
+
+    data, content_type = _get_or_fetch(db, f"set:{set_id}:{image_type}", url)
+    return Response(
+        content=data,
+        media_type=content_type,
+        headers={"Cache-Control": "public, max-age=86400"},
+    )

--- a/backend/database.py
+++ b/backend/database.py
@@ -61,6 +61,14 @@ def _run_migrations(conn):
             matched_at TIMESTAMP DEFAULT NOW(),
             status VARCHAR DEFAULT 'pending'
         )""",
+        """CREATE TABLE IF NOT EXISTS image_cache (
+            id SERIAL PRIMARY KEY,
+            image_key VARCHAR UNIQUE NOT NULL,
+            data BYTEA NOT NULL,
+            content_type VARCHAR DEFAULT 'image/webp',
+            cached_at TIMESTAMP DEFAULT NOW()
+        )""",
+        "CREATE INDEX IF NOT EXISTS idx_image_cache_key ON image_cache(image_key)",
         # v31: Add lang column to collection table (fixed card language per item)
         "ALTER TABLE collection ADD COLUMN IF NOT EXISTS lang VARCHAR DEFAULT 'en'",
         # v31: Add lang column to sets table (tracks which language APIs have this set)

--- a/backend/main.py
+++ b/backend/main.py
@@ -52,7 +52,7 @@ app.add_middleware(
 )
 
 # Include routers
-from api import auth, cards, collection, sets, wishlist, binders, dashboard, analytics, sync, products, export, backup, settings
+from api import auth, cards, collection, sets, wishlist, binders, dashboard, analytics, sync, products, export, backup, settings, images
 from api.recognize import router as recognize_router
 from api.ebay import router as ebay_router
 
@@ -71,6 +71,7 @@ app.include_router(export.router, prefix="/api/export", tags=["export"])
 app.include_router(backup.router, prefix="/api/backup", tags=["backup"])
 app.include_router(settings.router, prefix="/api/settings", tags=["settings"])
 app.include_router(ebay_router, prefix="/api/ebay", tags=["ebay"])
+app.include_router(images.router, prefix="/api/images", tags=["images"])
 
 
 @app.get("/api/health")

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,6 +1,6 @@
 from sqlalchemy import (
     Column, String, Integer, Float, DateTime, Date, Boolean,
-    ForeignKey, Text, JSON, UniqueConstraint
+    ForeignKey, Text, JSON, UniqueConstraint, LargeBinary
 )
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
@@ -253,3 +253,13 @@ class CustomCardMatch(Base):
     status = Column(String, default="pending")  # pending / migrated / dismissed
 
     custom_card = relationship("Card", foreign_keys=[custom_card_id])
+
+
+class ImageCache(Base):
+    __tablename__ = "image_cache"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    image_key = Column(String, unique=True, nullable=False, index=True)
+    data = Column(LargeBinary, nullable=False)
+    content_type = Column(String, default="image/webp")
+    cached_at = Column(DateTime, default=func.now())

--- a/frontend/src/components/CardItem.jsx
+++ b/frontend/src/components/CardItem.jsx
@@ -7,6 +7,7 @@ import PeriodSelector, { CARD_PERIODS, PERIOD_PRICE_FIELD } from './PeriodSelect
 import toast from 'react-hot-toast'
 import clsx from 'clsx'
 import { useTilt } from '../hooks/useTilt'
+import { resolveCardImageUrl } from '../utils/imageUrl'
 
 const RARITY_COLORS = {
   'Common': 'text-text-secondary',
@@ -303,8 +304,8 @@ export function CustomCardModal({ onClose, onCreated, sets: setsProp = [], autoA
           ) : (
             <div className="space-y-4">
               <div className="flex items-center gap-4 p-3 bg-bg-card rounded-xl border border-border">
-                {createdCard.images_small ? (
-                  <img src={createdCard.images_small} alt={createdCard.name} className="w-16 h-20 object-cover rounded" />
+                {resolveCardImageUrl(createdCard) ? (
+                  <img src={resolveCardImageUrl(createdCard)} alt={createdCard.name} className="w-16 h-20 object-cover rounded" />
                 ) : (
                   <div className="w-16 h-20 bg-bg-surface rounded flex items-center justify-center text-text-muted text-xl">🃏</div>
                 )}
@@ -385,7 +386,7 @@ export function CardItem({ card, showActions = true, onAddToBinder = null, compa
     onError: () => toast.error(t('card.wishlistFailed')),
   })
 
-  const cardImage = card.images?.small || card.images_small || (card.image ? `${card.image}/low.webp` : null)
+  const cardImage = card.images?.small || resolveCardImageUrl(card) || (card.image ? `${card.image}/low.webp` : null)
   const cardName = card.name
   const cardRarity = card.rarity
   const setName = card.set?.name || card.set_ref?.name || ''
@@ -555,7 +556,7 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
     }
   }
 
-  const cardImage = card.images?.large || card.images_large || (card.image ? `${card.image}/high.webp` : null) || card.images?.small || card.images_small
+  const cardImage = card.images?.large || resolveCardImageUrl(card, 'large') || (card.image ? `${card.image}/high.webp` : null) || card.images?.small || resolveCardImageUrl(card)
   const setName = card.set?.name || card.set_ref?.name
 
   const addMutation = useMutation({

--- a/frontend/src/pages/Analytics.jsx
+++ b/frontend/src/pages/Analytics.jsx
@@ -16,6 +16,7 @@ import { format, parseISO } from 'date-fns'
 import clsx from 'clsx'
 import PeriodSelector, { CARD_PERIODS, PERIOD_DAYS } from '../components/PeriodSelector'
 import toast from 'react-hot-toast'
+import { resolveCardImageUrl } from '../utils/imageUrl'
 
 const RARITY_COLORS = [
   '#EF1515', '#3b82f6', '#22c55e', '#eab308', '#8b5cf6',
@@ -273,8 +274,8 @@ export default function Analytics() {
                       <tr key={item.id} className="border-b border-border/50 hover:bg-bg-elevated/50">
                         <td className="px-4 py-3">
                           <div className="flex items-center gap-3">
-                            {item.images_small && (
-                              <img src={item.images_small} alt={item.name} className="w-8 h-10 object-cover rounded flex-shrink-0" loading="lazy" />
+                            {resolveCardImageUrl(item) && (
+                              <img src={resolveCardImageUrl(item)} alt={item.name} className="w-8 h-10 object-cover rounded flex-shrink-0" loading="lazy" />
                             )}
                             <span className="text-sm font-medium text-text-primary">{item.name}</span>
                           </div>
@@ -293,7 +294,7 @@ export default function Analytics() {
                 {duplicates.map((item) => (
                   <CardListItem
                     key={item.id}
-                    image={item.images_small}
+                    image={resolveCardImageUrl(item)}
                     name={item.name}
                     subtext={item.set_name || '-'}
                     badges={[
@@ -325,8 +326,8 @@ export default function Analytics() {
             <div className="space-y-2">
               {topMovers.map((card) => (
                 <div key={card.card_id} className="card flex items-center gap-4">
-                  {card.images_small && (
-                    <img src={card.images_small} alt={card.name} className="w-10 h-14 object-cover rounded flex-shrink-0" loading="lazy" />
+                  {resolveCardImageUrl(card) && (
+                    <img src={resolveCardImageUrl(card)} alt={card.name} className="w-10 h-14 object-cover rounded flex-shrink-0" loading="lazy" />
                   )}
                   <div className="flex-1 min-w-0">
                     <p className="text-sm font-medium text-text-primary truncate">{card.name}</p>

--- a/frontend/src/pages/BinderDetail.jsx
+++ b/frontend/src/pages/BinderDetail.jsx
@@ -6,6 +6,7 @@ import { getBinderCards, removeCardFromBinder, addCardToBinder, searchCards, get
 import { useSettings } from '../contexts/SettingsContext'
 import toast from 'react-hot-toast'
 import { useTilt } from '../hooks/useTilt'
+import { resolveCardImageUrl } from '../utils/imageUrl'
 
 function TiltBinderCard({ className, onClick, children }) {
   const { ref, onMouseMove, onMouseEnter, onMouseLeave } = useTilt(10)
@@ -157,8 +158,8 @@ export default function BinderDetail() {
                       <div key={card.id}
                         className={`relative rounded-lg overflow-hidden cursor-pointer group ${alreadyAdded ? 'opacity-40' : ''}`}
                         onClick={() => !alreadyAdded && addMutation.mutate(card.id)}>
-                        {(card.images?.small || card.images_small || card.image) ? (
-                          <img src={card.images?.small || card.images_small || `${card.image}/low.webp`}
+                        {(card.images?.small || resolveCardImageUrl(card) || card.image) ? (
+                          <img src={resolveCardImageUrl(card)}
                             alt={card.name} className="w-full aspect-[2.5/3.5] object-cover" loading="lazy" />
                         ) : (
                           <div className="w-full aspect-[2.5/3.5] bg-bg-card flex items-center justify-center text-xs text-text-muted p-1 text-center">
@@ -194,8 +195,8 @@ export default function BinderDetail() {
                         className={`relative rounded-lg overflow-hidden cursor-pointer group ${alreadyAdded ? 'opacity-40' : ''}`}
                         onClick={() => !alreadyAdded && addMutation.mutate(card.id)}
                         title={`${card.name}${item.variant ? ` (${item.variant})` : ''} · ${item.quantity}x`}>
-                        {card.images_small ? (
-                          <img src={card.images_small} alt={card.name} className="w-full aspect-[2.5/3.5] object-cover" loading="lazy" />
+                        {resolveCardImageUrl(card) ? (
+                          <img src={resolveCardImageUrl(card)} alt={card.name} className="w-full aspect-[2.5/3.5] object-cover" loading="lazy" />
                         ) : (
                           <div className="w-full aspect-[2.5/3.5] bg-bg-card flex items-center justify-center text-xs text-text-muted p-1 text-center">
                             {card.name}
@@ -238,8 +239,8 @@ export default function BinderDetail() {
 
             return (
               <TiltBinderCard key={card.id} className="relative group rounded-xl overflow-hidden card p-0">
-                {card.images_small ? (
-                  <img src={card.images_small} alt={card.name}
+                {resolveCardImageUrl(card) ? (
+                  <img src={resolveCardImageUrl(card)} alt={card.name}
                     className={`w-full aspect-[2.5/3.5] object-cover transition-all ${isMissing ? 'grayscale opacity-60' : ''}`}
                     loading="lazy" />
                 ) : (

--- a/frontend/src/pages/CardMigration.jsx
+++ b/frontend/src/pages/CardMigration.jsx
@@ -5,6 +5,7 @@ import { getCustomMatches, migrateCustomCard, dismissCustomMatch } from '../api/
 import { useSettings } from '../contexts/SettingsContext'
 import { format, parseISO } from 'date-fns'
 import toast from 'react-hot-toast'
+import { resolveCardImageUrl } from '../utils/imageUrl'
 
 function CardPreview({ card, label }) {
   const { t } = useSettings()
@@ -20,8 +21,8 @@ function CardPreview({ card, label }) {
   return (
     <div className="flex flex-col items-center gap-2">
       <div className="w-24 h-32 rounded-lg overflow-hidden bg-bg-card border border-border flex-shrink-0">
-        {card.images_small ? (
-          <img src={card.images_small} alt={card.name} className="w-full h-full object-cover" />
+        {resolveCardImageUrl(card) ? (
+          <img src={resolveCardImageUrl(card)} alt={card.name} className="w-full h-full object-cover" />
         ) : (
           <div className="w-full h-full flex items-center justify-center">
             <span className="text-xs text-text-muted">{t('migration.noImage')}</span>

--- a/frontend/src/pages/Collection.jsx
+++ b/frontend/src/pages/Collection.jsx
@@ -8,6 +8,7 @@ import CardListItem from '../components/CardListItem'
 import toast from 'react-hot-toast'
 import clsx from 'clsx'
 import { useTilt } from '../hooks/useTilt'
+import { resolveCardImageUrl } from '../utils/imageUrl'
 
 function TiltBinderCard({ className, onClick, children }) {
   const { ref, onMouseMove, onMouseEnter, onMouseLeave } = useTilt(10)
@@ -630,7 +631,7 @@ export default function Collection() {
                       >
                         {card?.images_small
                           ? <img
-                              src={card.images_small}
+                              src={resolveCardImageUrl(card)}
                               alt={card?.name}
                               className="w-full h-full object-cover"
                               loading="lazy"
@@ -749,7 +750,7 @@ export default function Collection() {
                             <div className="flex items-center gap-3">
                               <div className="w-8 h-10 flex-shrink-0 rounded overflow-hidden">
                                 {card?.images_small ? (
-                                  <img src={card.images_small} alt={card?.name} className="w-full h-full object-cover" />
+                                  <img src={resolveCardImageUrl(card)} alt={card?.name} className="w-full h-full object-cover" />
                                 ) : (
                                   <div className="w-full h-full bg-border" />
                                 )}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -12,6 +12,7 @@ import { format, parseISO } from 'date-fns'
 import PeriodSelector, { CARD_PERIODS, PERIOD_PRICE_FIELD } from '../components/PeriodSelector'
 import TrainerCard from '../components/TrainerCard'
 import PokeBallLoader from '../components/PokeBallLoader'
+import { resolveCardImageUrl } from '../utils/imageUrl'
 
 const CustomTooltip = ({ active, payload, label }) => {
   const { formatPrice } = useSettings()
@@ -130,8 +131,8 @@ export default function Dashboard() {
             {data.recent_additions.slice(0, 12).map(card => (
               <div key={card.id} className="flex-shrink-0 w-20 group cursor-pointer">
                 <div className="aspect-[2.5/3.5] rounded-lg overflow-hidden shadow-lg ring-1 ring-white/5 group-hover:ring-brand-red/50 group-hover:scale-[1.03] transition-all duration-150 transform-gpu origin-center">
-                  {card.images_small
-                    ? <img src={card.images_small} alt={card.name} className="w-full h-full object-cover" loading="lazy" />
+                  {resolveCardImageUrl(card)
+                    ? <img src={resolveCardImageUrl(card)} alt={card.name} className="w-full h-full object-cover" loading="lazy" />
                     : <div className="w-full h-full bg-bg-elevated flex items-center justify-center">
                         <span className="text-[9px] text-text-muted text-center p-1 leading-tight">{card.name}</span>
                       </div>
@@ -182,8 +183,8 @@ export default function Dashboard() {
               <div key={card.id} className="flex-shrink-0 w-24 group cursor-pointer">
                 <div className="relative">
                   <div className="aspect-[2.5/3.5] rounded-lg overflow-hidden shadow-lg ring-1 ring-white/5 group-hover:scale-[1.03] transition-all duration-150 group-hover:ring-gold/40 transform-gpu origin-center">
-                    {card.images_small
-                      ? <img src={card.images_small} alt={card.name} className="w-full h-full object-cover" loading="lazy" />
+                    {resolveCardImageUrl(card)
+                      ? <img src={resolveCardImageUrl(card)} alt={card.name} className="w-full h-full object-cover" loading="lazy" />
                       : <div className="w-full h-full bg-bg-elevated" />
                     }
                   </div>

--- a/frontend/src/pages/HomeScreen.jsx
+++ b/frontend/src/pages/HomeScreen.jsx
@@ -14,6 +14,7 @@ import { useAuth } from '../contexts/AuthContext'
 import toast from 'react-hot-toast'
 import { format, parseISO } from 'date-fns'
 import { useTilt } from '../hooks/useTilt'
+import { resolveCardImageUrl } from '../utils/imageUrl'
 
 // ── Time-range definitions ────────────────────────────────────────────────────
 const PERIODS = [
@@ -39,7 +40,7 @@ function ChartTooltip({ active, payload, label }) {
 
 // ── Card thumbnail ────────────────────────────────────────────────────────────
 function CardThumb({ card, onClick }) {
-  const img = card.images_small || card.image_url
+  const img = resolveCardImageUrl(card)
   const { ref, onMouseMove, onMouseEnter, onMouseLeave } = useTilt(8)
   return (
     <div ref={ref} className="flex-shrink-0 w-[72px] cursor-pointer group" onClick={onClick} onMouseMove={onMouseMove} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
@@ -442,8 +443,8 @@ export default function HomeScreen() {
                     <div className="aspect-[2.5/3.5] rounded-xl overflow-hidden shadow-lg transition-all duration-150
                       group-hover:scale-[1.03]"
                       style={{ border:'1px solid rgba(245,200,66,0.2)', boxShadow:'0 4px 16px rgba(0,0,0,0.5)' }}>
-                      {card.images_small
-                        ? <img src={card.images_small} alt={card.name} className="w-full h-full object-cover" loading="lazy" />
+                      {resolveCardImageUrl(card)
+                        ? <img src={resolveCardImageUrl(card)} alt={card.name} className="w-full h-full object-cover" loading="lazy" />
                         : <div className="w-full h-full bg-bg-elevated" />
                       }
                     </div>

--- a/frontend/src/pages/SetDetail.jsx
+++ b/frontend/src/pages/SetDetail.jsx
@@ -6,6 +6,7 @@ import { getSetChecklist, addToCollection } from '../api/client'
 import { useSettings } from '../contexts/SettingsContext'
 import toast from 'react-hot-toast'
 import clsx from 'clsx'
+import { resolveCardImageUrl, resolveSetImageUrl } from '../utils/imageUrl'
 
 export default function SetDetail() {
   const { setId } = useParams()
@@ -71,8 +72,8 @@ export default function SetDetail() {
       {/* Set Header */}
       <div className="card">
         <div className="flex items-start gap-4">
-          {set?.images_logo && (
-            <img src={set.images_logo} alt={set.name} className="h-12 sm:h-16 object-contain flex-shrink-0 max-w-[120px]" />
+          {resolveSetImageUrl(set, 'logo') && (
+            <img src={resolveSetImageUrl(set, 'logo')} alt={set.name} className="h-12 sm:h-16 object-contain flex-shrink-0 max-w-[120px]" />
           )}
           <div className="flex-1 min-w-0">
             <h1 className="text-xl font-bold text-text-primary truncate">{set?.name}</h1>
@@ -150,8 +151,8 @@ export default function SetDetail() {
                 ? 'ring-2 ring-green/50 hover:ring-green cursor-default'
                 : 'opacity-60 hover:opacity-90 ring-1 ring-brand-red/30 hover:ring-brand-red/60 cursor-pointer'
             )}>
-            {card.images_small ? (
-              <img src={card.images_small} alt={card.name} className="w-full aspect-[2.5/3.5] object-cover" loading="lazy" />
+            {resolveCardImageUrl(card) ? (
+              <img src={resolveCardImageUrl(card)} alt={card.name} className="w-full aspect-[2.5/3.5] object-cover" loading="lazy" />
             ) : (
               <div className="w-full aspect-[2.5/3.5] bg-bg-card flex items-center justify-center text-xs text-text-muted p-1 text-center">
                 {card.name}

--- a/frontend/src/pages/Sets.jsx
+++ b/frontend/src/pages/Sets.jsx
@@ -5,6 +5,7 @@ import { Search, Bell, BellOff, SortAsc, Filter, ChevronUp, ChevronDown } from '
 import { getSets, markSetsSeen } from '../api/client'
 import { useSettings } from '../contexts/SettingsContext'
 import toast from 'react-hot-toast'
+import { resolveSetImageUrl } from '../utils/imageUrl'
 
 export default function Sets() {
   const navigate = useNavigate()
@@ -215,8 +216,8 @@ export default function Sets() {
                 </div>
               </div>
               <div className="flex-shrink-0 w-36 h-28 flex items-center justify-center">
-                {hero.images_logo
-                  ? <img src={hero.images_logo} alt={hero.name} className="set-hero-logo group-hover:scale-105 transition-transform duration-300" />
+                {resolveSetImageUrl(hero, 'logo')
+                  ? <img src={resolveSetImageUrl(hero, 'logo')} alt={hero.name} className="set-hero-logo group-hover:scale-105 transition-transform duration-300" />
                   : <div className="text-text-muted text-xs text-center">{hero.name}</div>
                 }
               </div>
@@ -268,24 +269,24 @@ export default function Sets() {
                     }}
                   />
                   {/* Subtle background symbol */}
-                  {set.images_symbol && (
+                  {resolveSetImageUrl(set, 'symbol') && (
                     <img
-                      src={set.images_symbol}
+                      src={resolveSetImageUrl(set, 'symbol')}
                       alt=""
                       className="absolute inset-0 w-full h-full object-contain opacity-[0.04] scale-150 pointer-events-none"
                     />
                   )}
 
-                  {set.images_logo ? (
+                  {resolveSetImageUrl(set, 'logo') ? (
                     <img
-                      src={set.images_logo}
+                      src={resolveSetImageUrl(set, 'logo')}
                       alt={set.name}
                       className="max-h-[80%] max-w-[75%] object-contain group-hover:scale-105 transition-transform duration-300 relative z-10"
                       loading="lazy"
                     />
-                  ) : set.images_symbol ? (
+                  ) : resolveSetImageUrl(set, 'symbol') ? (
                     <img
-                      src={set.images_symbol}
+                      src={resolveSetImageUrl(set, 'symbol')}
                       alt={set.name}
                       className="h-12 object-contain opacity-60 group-hover:scale-110 transition-transform duration-300 relative z-10"
                       loading="lazy"

--- a/frontend/src/pages/Wishlist.jsx
+++ b/frontend/src/pages/Wishlist.jsx
@@ -5,6 +5,7 @@ import { getWishlist, removeFromWishlist, updateWishlistItem, addToCollection } 
 import { useSettings } from '../contexts/SettingsContext'
 import CardListItem from '../components/CardListItem'
 import toast from 'react-hot-toast'
+import { resolveCardImageUrl } from '../utils/imageUrl'
 
 function AlertEditor({ item, onDone }) {
   const [above, setAbove] = useState(item.price_alert_above || '')
@@ -246,8 +247,8 @@ export default function Wishlist() {
                           <td className="px-4 py-3">
                             <div className="flex items-center gap-3">
                               <div className="w-8 h-10 flex-shrink-0 rounded overflow-hidden">
-                                {card?.images_small ? (
-                                  <img src={card.images_small} alt={card?.name} className="w-full h-full object-cover" />
+                                {resolveCardImageUrl(card) ? (
+                                  <img src={resolveCardImageUrl(card)} alt={card?.name} className="w-full h-full object-cover" />
                                 ) : (
                                   <div className="w-full h-full bg-border" />
                                 )}
@@ -339,7 +340,7 @@ export default function Wishlist() {
                   return (
                     <CardListItem
                       key={item.id}
-                      image={card?.images_small}
+                      image={resolveCardImageUrl(card)}
                       name={card?.name}
                       subtext={card?.set_ref?.name || '-'}
                       badges={badges}

--- a/frontend/src/utils/imageUrl.js
+++ b/frontend/src/utils/imageUrl.js
@@ -1,0 +1,30 @@
+export const cardImageUrl = (cardId, size = 'small') =>
+  cardId ? `/api/images/card/${encodeURIComponent(cardId)}/${size}` : null
+
+export const setImageUrl = (setId, imageType) =>
+  setId ? `/api/images/set/${encodeURIComponent(setId)}/${imageType}` : null
+
+export const resolveCardImageUrl = (card, size = 'small') => {
+  if (card?.id) return cardImageUrl(card.id, size)
+
+  if (size === 'large') {
+    return card?.images?.large
+      || card?.images_large
+      || (card?.image ? `${card.image}/high.webp` : null)
+      || card?.images?.small
+      || card?.images_small
+      || card?.image_url
+      || null
+  }
+
+  return card?.images?.small
+    || card?.images_small
+    || card?.image_url
+    || (card?.image ? `${card.image}/low.webp` : null)
+    || null
+}
+
+export const resolveSetImageUrl = (set, imageType) => {
+  if (set?.id) return setImageUrl(set.id, imageType)
+  return imageType === 'logo' ? (set?.images_logo || null) : (set?.images_symbol || null)
+}


### PR DESCRIPTION
## Image Cache System

All card and set images are now proxied through the backend and cached in PostgreSQL as binary data. Images are fetched lazily on first view, then served from DB on subsequent requests.

### How it works
1. Frontend requests `/api/images/card/{id}/small` instead of direct TCGdex URL
2. Backend checks `image_cache` table for existing entry
3. **Cache hit**: returns binary data directly (fast, no external call)
4. **Cache miss**: fetches from TCGdex, stores in DB, returns to client
5. Response includes `Cache-Control: public, max-age=86400` for browser caching

### Backend
- New `ImageCache` model: `image_key` (unique), `data` (BYTEA), `content_type`, `cached_at`
- `GET /api/images/card/{card_id}/{size}` — size: small/large
- `GET /api/images/set/{set_id}/{image_type}` — type: logo/symbol
- Race-condition safe (rollback + re-read on duplicate insert)
- Uses `httpx` (already in requirements) with 15s timeout

### Frontend
- New `utils/imageUrl.js` with helper functions:
  - `resolveCardImageUrl(card, size)` — returns local proxy URL
  - `resolveSetImageUrl(set, imageType)` — returns local proxy URL
  - Fallback chain for edge cases (custom cards without DB entry)
- **All 11 frontend files** updated to use proxy URLs

### Storage estimate
- ~18 KB per card thumbnail, ~65 KB per full image
- Only viewed images are cached (lazy, not bulk)
- Typical collection browsing: a few hundred MB over time

### Migration
- `CREATE TABLE image_cache` + index — idempotent
- No data migration needed — cache builds itself on use