### PR TITLE
fix: broken images on home page + mobile layout overflow

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -6,7 +6,7 @@ export default function Layout() {
   const isHome = location.pathname === '/'
 
   return (
-    <div className="min-h-dvh flex flex-col bg-bg">
+    <div className="min-h-dvh flex flex-col bg-bg overflow-x-hidden">
       {!isHome && <AppNav />}
       <main className={`flex-1 ${!isHome ? 'w-full px-4 pb-8' : ''}`}>
         <Outlet />

--- a/frontend/src/pages/Collection.jsx
+++ b/frontend/src/pages/Collection.jsx
@@ -161,7 +161,7 @@ function CollectionEditModal({ item, onClose }) {
   const [lang, setLang] = useState(item.lang || 'en')
   const [price, setPrice] = useState(item.purchase_price ? String(item.purchase_price) : '')
 
-  const cardImage = card?.images_large || card?.images_small || (card?.image ? `${card.image}/high.webp` : null)
+  const cardImage = resolveCardImageUrl(card, 'large')
 
   const updateMutation = useMutation({
     mutationFn: () => updateCollectionItem(item.id, {
@@ -629,7 +629,7 @@ export default function Collection() {
                       <div
                         className="aspect-[2.5/3.5] relative rounded-xl overflow-hidden flex-shrink-0"
                       >
-                        {card?.images_small
+                        {resolveCardImageUrl(card)
                           ? <img
                               src={resolveCardImageUrl(card)}
                               alt={card?.name}
@@ -749,7 +749,7 @@ export default function Collection() {
                           <td className="px-4 py-3">
                             <div className="flex items-center gap-3">
                               <div className="w-8 h-10 flex-shrink-0 rounded overflow-hidden">
-                                {card?.images_small ? (
+                                {resolveCardImageUrl(card) ? (
                                   <img src={resolveCardImageUrl(card)} alt={card?.name} className="w-full h-full object-cover" />
                                 ) : (
                                   <div className="w-full h-full bg-border" />
@@ -857,7 +857,7 @@ export default function Collection() {
                   return (
                     <CardListItem
                       key={item.id}
-                      image={card?.images_small}
+                      image={resolveCardImageUrl(card)}
                       name={card?.name}
                       subtext={[card?.set_ref?.name, card?.number ? `#${card.number}` : null].filter(Boolean).join(' · ') || '-'}
                       badges={badges}

--- a/frontend/src/pages/HomeScreen.jsx
+++ b/frontend/src/pages/HomeScreen.jsx
@@ -234,7 +234,7 @@ export default function HomeScreen() {
           {isLoading ? (
             <div className="skeleton h-14 w-48 mx-auto rounded-xl" />
           ) : (
-            <p className="text-5xl font-black tracking-tight"
+            <p className="text-4xl sm:text-5xl font-black tracking-tight"
               style={{ color: '#f5c842', textShadow: '0 0 40px rgba(245,200,66,0.25)' }}>
               {formatPrice(totalValue)}
             </p>
@@ -380,7 +380,7 @@ export default function HomeScreen() {
         {/* ── NAVIGATION PORTAL GRID ── */}
         <div>
           <p className="text-xs font-bold text-white uppercase tracking-wider mb-3">{t('home.navigation')}</p>
-          <div className="grid grid-cols-4 gap-2.5">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2.5">
             {PORTAL_ITEMS.map(({ to, icon: Icon, label, color }) => (
               <button
                 key={to}

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -41,13 +41,13 @@ function SettingsCard({ children }) {
 function SettingsRow({ label, description, children, last }) {
   return (
     <div
-      className="flex items-center justify-between gap-4 px-4 py-3.5"
+      className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 sm:gap-4 px-4 py-3.5"
       style={!last ? { borderBottom: '1px solid rgba(255,255,255,0.05)' } : {}}
     >
       <div className="flex-1 min-w-0">
         <p className="text-sm font-semibold text-text-primary">{label}</p>
         {description && (
-          <p className="text-xs text-text-muted mt-0.5">{description}</p>
+          <p className="text-xs text-text-muted mt-0.5" style={{overflowWrap:"anywhere"}}>{description}</p>
         )}
       </div>
       <div className="flex-shrink-0">{children}</div>

--- a/frontend/src/utils/imageUrl.js
+++ b/frontend/src/utils/imageUrl.js
@@ -5,7 +5,10 @@ export const setImageUrl = (setId, imageType) =>
   setId ? `/api/images/set/${encodeURIComponent(setId)}/${imageType}` : null
 
 export const resolveCardImageUrl = (card, size = 'small') => {
-  if (card?.id) return cardImageUrl(card.id, size)
+  // card_id is the actual card identifier (e.g. "sv1-1_de")
+  // id might be a collection item integer ID, so prefer card_id or string id
+  const cid = card?.card_id || (typeof card?.id === 'string' ? card.id : null)
+  if (cid) return cardImageUrl(cid, size)
 
   if (size === 'large') {
     return card?.images?.large


### PR DESCRIPTION
## Image Fix
- `resolveCardImageUrl()` now prefers `card_id` over `id` — fixes broken images on HomeScreen "recently added" section where the API returns collection item integer IDs instead of card string IDs
- Collection.jsx: remaining direct `images_small` references switched to proxy helper

## Mobile Layout Fixes
- **Layout.jsx**: `overflow-x-hidden` on root — eliminates horizontal scroll globally
- **HomeScreen**: stat cards use `grid-cols-2 sm:grid-cols-4` (was always 4, cramped on mobile); portfolio value text `text-4xl sm:text-5xl`
- **Settings**: `SettingsRow` stacks vertically on mobile (`flex-col sm:flex-row`); description text uses `overflow-wrap: anywhere` to prevent long German words (e.g. "Nicht konfiguriert — eBay Developer Account benötigt") from displaying vertically