### PR TITLE
fix: settings tab overlap + compact numbers on mobile

### DIFF
--- a/frontend/src/pages/HomeScreen.jsx
+++ b/frontend/src/pages/HomeScreen.jsx
@@ -16,6 +16,15 @@ import { format, parseISO } from 'date-fns'
 import { useTilt } from '../hooks/useTilt'
 import { resolveCardImageUrl } from '../utils/imageUrl'
 
+// Compact number formatter for mobile (1.2k, 3.4M, etc.)
+function compactNum(n) {
+  if (typeof n === 'string') return n // already formatted (e.g. price)
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1).replace(/\.0$/, '') + 'M'
+  if (n >= 10_000) return (n / 1_000).toFixed(1).replace(/\.0$/, '') + 'k'
+  if (n >= 1_000) return (n / 1_000).toFixed(1).replace(/\.0$/, '') + 'k'
+  return n.toLocaleString()
+}
+
 // ── Time-range definitions ────────────────────────────────────────────────────
 const PERIODS = [
   { key: '1W',  label: '1W',   apiPeriod: '1w' },
@@ -151,19 +160,19 @@ export default function HomeScreen() {
   const STAT_CARDS = [
     {
       icon: <Layers size={16} />,
-      value: data?.total_cards ?? 0,
+      value: compactNum(data?.total_cards ?? 0),
       label: t('home.cardsTotal'),
       color: '#4fc3f7',
     },
     {
       icon: <Grid2X2 size={16} />,
-      value: data?.owned_sets ?? 0,
+      value: compactNum(data?.owned_sets ?? 0),
       label: t('home.sets'),
       color: '#ce93d8',
     },
     {
       icon: <Star size={16} />,
-      value: data?.unique_cards ?? 0,
+      value: compactNum(data?.unique_cards ?? 0),
       label: t('home.unique'),
       color: '#81c784',
     },
@@ -289,7 +298,7 @@ export default function HomeScreen() {
         <div className="h-px bg-gradient-to-r from-transparent via-brand-red/30 to-transparent" />
 
         {/* ── STAT CARDS ROW ── */}
-        <div className="grid grid-cols-4 gap-2">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
           {STAT_CARDS.map(stat => (
             <div
               key={stat.label}
@@ -300,7 +309,7 @@ export default function HomeScreen() {
               }}
             >
               <span style={{ color: stat.color }}>{stat.icon}</span>
-              <p className="text-base font-black leading-none" style={{ color: stat.color }}>
+              <p className="text-sm sm:text-base font-black leading-none truncate max-w-full" style={{ color: stat.color }}>
                 {isLoading ? '—' : stat.value}
               </p>
               <p className="text-[10px] text-text-muted leading-tight">{stat.label}</p>

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -381,7 +381,7 @@ export default function Settings() {
         <h1 className="text-2xl font-black text-text-primary tracking-tight">{t('settings.title')}</h1>
         <p className="text-sm text-text-muted mt-1">{t('settings.appConfig')}</p>
       </div>
-      <div className="flex gap-2 border-b border-border px-1 overflow-x-auto scrollbar-none">
+      <div className="flex border-b border-border overflow-x-auto scrollbar-none -mx-4 px-4" style={{WebkitOverflowScrolling:"touch"}}>
         {[
           { key: 'general', label: t('settings.tabs.general') },
           { key: 'sync', label: t('settings.tabs.dataSync') },
@@ -391,7 +391,7 @@ export default function Settings() {
           <button
             key={tab.key}
             onClick={() => setActiveTab(tab.key)}
-            className={`px-4 py-2.5 text-sm font-semibold whitespace-nowrap transition-colors border-b-2 ${
+            className={`px-3 py-2 text-xs sm:text-sm font-semibold whitespace-nowrap transition-colors border-b-2 flex-shrink-0 ${
               activeTab === tab.key ? 'border-brand-red text-brand-red' : 'border-transparent text-text-muted hover:text-text-primary'
             }`}
           >


### PR DESCRIPTION
## Settings Tabs
- Tab text: `text-xs` on mobile, `text-sm` on sm+
- `flex-shrink-0` on buttons — prevents text compression/overlap
- Full-bleed scroll area (`-mx-4 px-4`) for edge-to-edge scrolling
- Touch scroll enabled

## HomeScreen Numbers
- New `compactNum()` formatter: 1,234 → 1.2k, 1,500,000 → 1.5M
- Applied to stat cards (total cards, sets, unique)
- Invested price still uses `formatPrice()` (already formatted)
- Stat value text smaller on mobile (`text-sm sm:text-base`)
- Grid: 2 columns on mobile, 4 on sm+