### PR TITLE
fix: back button on achievements when viewing another user

### DIFF
--- a/frontend/src/i18n/de.js
+++ b/frontend/src/i18n/de.js
@@ -21,6 +21,7 @@ const de = {
 
   // Common / General
   common: {
+    back: 'Zurück',
     loading: 'Laden...',
     noResults: 'Keine Ergebnisse',
     save: 'Speichern',
@@ -643,6 +644,7 @@ const de = {
   ebay: {
     gradedPrice: 'Graded-Preis',
     fetchPrice: 'Preis abrufen',
+    back: 'Zurück',
     loading: 'Lädt…',
     notConfigured: 'eBay API nicht konfiguriert',
     avgPrice: 'Durchschnitt',

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -21,6 +21,7 @@ const en = {
 
   // Common / General
   common: {
+    back: 'Back',
     loading: 'Loading...',
     noResults: 'No results',
     save: 'Save',
@@ -643,6 +644,7 @@ const en = {
   ebay: {
     gradedPrice: 'Graded Price',
     fetchPrice: 'Fetch Price',
+    back: 'Back',
     loading: 'Loading…',
     notConfigured: 'eBay API not configured',
     avgPrice: 'Average',

--- a/frontend/src/pages/Achievements.jsx
+++ b/frontend/src/pages/Achievements.jsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { Award } from 'lucide-react'
+import { Award, ArrowLeft } from 'lucide-react'
 import { getAchievements } from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
 import { useSettings } from '../contexts/SettingsContext'
@@ -22,9 +22,11 @@ function TrainerAvatar({ avatarId, username }) {
 
 export default function Achievements() {
   const { userId } = useParams()
+  const navigate = useNavigate()
   const { user } = useAuth()
   const { t } = useSettings()
   const activeUserId = userId || user?.id
+  const isOtherUser = userId && Number(userId) !== user?.id
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['achievements', activeUserId],
@@ -43,6 +45,11 @@ export default function Achievements() {
       <div className="card relative overflow-hidden">
         <div className="absolute inset-0 pointer-events-none bg-[radial-gradient(circle_at_top_right,rgba(255,138,101,0.16),transparent_40%)]" />
         <div className="relative flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            {isOtherUser && (
+              <button onClick={() => navigate(-1)} className="flex items-center gap-1.5 text-sm text-text-muted hover:text-text-primary transition-colors mb-2 sm:mb-0 sm:absolute sm:-top-1 sm:left-0">
+                <ArrowLeft size={14} /> {t('common.back')}
+              </button>
+            )}
           <div className="flex items-center gap-3">
             <TrainerAvatar avatarId={data?.avatar_id || user?.avatar_id} username={data?.username || user?.username || 'Trainer'} />
             <div>


### PR DESCRIPTION
Adds a back button on the Achievements page when viewing another user's achievements (e.g. navigated from leaderboard compare). Uses `navigate(-1)` to go back.

Also adds `common.back` i18n key (DE: "Zurück", EN: "Back").

### Pages checked:
- ✅ SetDetail — has back → Sets
- ✅ BinderDetail — has back → Binders
- ✅ Compare — has back → Leaderboard
- ✅ Achievements (other user) — **now has back button**
- ✅ Top-level pages (Leaderboard, Collection, etc.) — AppNav with Pokeball home handles navigation