### PR TITLE
feat: Pokemon type color themes + settings cleanup

### DIFF
--- a/frontend/src/hooks/useTheme.js
+++ b/frontend/src/hooks/useTheme.js
@@ -1,0 +1,30 @@
+import { useState, useEffect, useCallback } from 'react'
+
+const THEMES = [
+  { id: 'default', label: 'Pokémon Red', color: '#e3000b', emoji: '🔴' },
+  { id: 'fire', label: 'Fire', color: '#ff6b35', emoji: '🔥' },
+  { id: 'water', label: 'Water', color: '#4fc3f7', emoji: '💧' },
+  { id: 'grass', label: 'Grass', color: '#66bb6a', emoji: '🌿' },
+  { id: 'electric', label: 'Electric', color: '#fdd835', emoji: '⚡' },
+  { id: 'psychic', label: 'Psychic', color: '#ce93d8', emoji: '🔮' },
+  { id: 'dragon', label: 'Dragon', color: '#9575cd', emoji: '🐉' },
+  { id: 'dark', label: 'Dark', color: '#78909c', emoji: '🌑' },
+  { id: 'fairy', label: 'Fairy', color: '#f48fb1', emoji: '🧚' },
+]
+
+export function useTheme() {
+  const [theme, setThemeState] = useState(() => localStorage.getItem('theme') || 'default')
+
+  useEffect(() => {
+    if (theme === 'default') {
+      document.documentElement.removeAttribute('data-theme')
+    } else {
+      document.documentElement.setAttribute('data-theme', theme)
+    }
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  const setTheme = useCallback((t) => setThemeState(t), [])
+
+  return { theme, setTheme, themes: THEMES }
+}

--- a/frontend/src/i18n/de.js
+++ b/frontend/src/i18n/de.js
@@ -461,6 +461,8 @@ const de = {
     saved: 'Gespeichert',
     saveFailed: 'Fehler beim Speichern',
     // Settings page section headers
+    theme: 'Farbthema',
+    sectionTheme: 'Thema',
     sectionTrainer: 'Trainer',
     sectionAppearance: 'Darstellung',
     sectionSync: 'Synchronisation',

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -461,6 +461,8 @@ const en = {
     saved: 'Saved',
     saveFailed: 'Failed to save',
     // Settings page section headers
+    theme: 'Color Theme',
+    sectionTheme: 'Theme',
     sectionTrainer: 'Trainer',
     sectionAppearance: 'Appearance',
     sectionSync: 'Synchronization',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -717,3 +717,84 @@ body {
 .energy-colorless { background: rgba(158,158,158,0.2); color: #9e9e9e; border: 1px solid rgba(158,158,158,0.3); }
 .energy-rare    { background: rgba(245,200,66,0.15); color: #f5c842; border: 1px solid rgba(245,200,66,0.35); }
 .energy-ultra   { background: rgba(227,0,11,0.15); color: #ff5252; border: 1px solid rgba(227,0,11,0.35); }
+
+/* ─── Pokemon Type Themes ────────────────────────────────────────────────── */
+[data-theme="fire"] {
+  --color-bg:          #0f0805;
+  --color-surface:     #1a0f08;
+  --color-card:        #221408;
+  --color-elevated:    #2e1a0a;
+  --color-brand-red:   #ff6b35;
+  --color-brand-red-light: #ff9466;
+  --color-brand-red-dark:  #cc5528;
+}
+
+[data-theme="water"] {
+  --color-bg:          #050a10;
+  --color-surface:     #081220;
+  --color-card:        #0c1a2e;
+  --color-elevated:    #10223a;
+  --color-brand-red:   #4fc3f7;
+  --color-brand-red-light: #81d4fa;
+  --color-brand-red-dark:  #2196f3;
+}
+
+[data-theme="grass"] {
+  --color-bg:          #050f08;
+  --color-surface:     #081a0f;
+  --color-card:        #0c2214;
+  --color-elevated:    #102e1a;
+  --color-brand-red:   #66bb6a;
+  --color-brand-red-light: #81c784;
+  --color-brand-red-dark:  #43a047;
+}
+
+[data-theme="electric"] {
+  --color-bg:          #0f0d05;
+  --color-surface:     #1a1608;
+  --color-card:        #221e0a;
+  --color-elevated:    #2e280e;
+  --color-brand-red:   #fdd835;
+  --color-brand-red-light: #ffee58;
+  --color-brand-red-dark:  #f9a825;
+}
+
+[data-theme="psychic"] {
+  --color-bg:          #0d050f;
+  --color-surface:     #16081a;
+  --color-card:        #1e0c22;
+  --color-elevated:    #28102e;
+  --color-brand-red:   #ce93d8;
+  --color-brand-red-light: #e1bee7;
+  --color-brand-red-dark:  #ab47bc;
+}
+
+[data-theme="dragon"] {
+  --color-bg:          #08050f;
+  --color-surface:     #100a1a;
+  --color-card:        #180f24;
+  --color-elevated:    #20142e;
+  --color-brand-red:   #9575cd;
+  --color-brand-red-light: #b39ddb;
+  --color-brand-red-dark:  #7e57c2;
+}
+
+[data-theme="dark"] {
+  --color-bg:          #050505;
+  --color-surface:     #0a0a0a;
+  --color-card:        #121212;
+  --color-elevated:    #1a1a1a;
+  --color-brand-red:   #78909c;
+  --color-brand-red-light: #90a4ae;
+  --color-brand-red-dark:  #546e7a;
+}
+
+[data-theme="fairy"] {
+  --color-bg:          #0f050a;
+  --color-surface:     #1a0812;
+  --color-card:        #220c18;
+  --color-elevated:    #2e1020;
+  --color-brand-red:   #f48fb1;
+  --color-brand-red-light: #f8bbd0;
+  --color-brand-red-dark:  #ec407a;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,6 +5,12 @@ import { Toaster } from 'react-hot-toast'
 import App from './App.jsx'
 import './index.css'
 
+// Apply saved theme before first paint to prevent flash
+const savedTheme = localStorage.getItem('theme')
+if (savedTheme && savedTheme !== 'default') {
+  document.documentElement.setAttribute('data-theme', savedTheme)
+}
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -8,6 +8,7 @@ import {
 import { TrendingUp, TrendingDown } from 'lucide-react'
 import { getDashboard } from '../api/client'
 import { useSettings } from '../contexts/SettingsContext'
+import { useAuth } from '../contexts/AuthContext'
 import { format, parseISO } from 'date-fns'
 import PeriodSelector, { CARD_PERIODS, PERIOD_PRICE_FIELD } from '../components/PeriodSelector'
 import TrainerCard from '../components/TrainerCard'
@@ -103,7 +104,7 @@ export default function Dashboard() {
       {/* ─── 1. TRAINER CARD HERO ──────────────────────────────────── */}
       {data && (
         <TrainerCard
-          trainerName="Gilles"
+          trainerName={user?.username || "Trainer"}
           totalCards={totalCards}
           totalValue={totalValue}
           collectedSets={ownedSets}

--- a/frontend/src/pages/HomeScreen.jsx
+++ b/frontend/src/pages/HomeScreen.jsx
@@ -8,7 +8,7 @@ import {
 import {
   AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer,
 } from 'recharts'
-import { getDashboard, triggerPriceSync, getSyncStatus, getInvestmentTracker, getSetting } from '../api/client'
+import { getDashboard, triggerPriceSync, getSyncStatus, getInvestmentTracker } from '../api/client'
 import { useSettings } from '../contexts/SettingsContext'
 import { useAuth } from '../contexts/AuthContext'
 import toast from 'react-hot-toast'
@@ -95,12 +95,7 @@ export default function HomeScreen() {
     refetchInterval: 120000,
   })
 
-  const { data: trainerNameData } = useQuery({
-    queryKey: ['setting', 'trainer_name'],
-    queryFn: () => getSetting('trainer_name').catch(() => ({ value: 'Trainer' })),
-    staleTime: 60000,
-  })
-  const trainerName = trainerNameData?.value || 'Trainer'
+  const trainerName = user?.username || 'Trainer'
 
   const syncMutation = useMutation({
     mutationFn: triggerPriceSync,

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -8,6 +8,7 @@ import {
   getUsers, createUser, updateUser, deleteUser, changePassword, changeAvatar,
 } from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
+import { useTheme } from '../hooks/useTheme'
 import { useSettings } from '../contexts/SettingsContext'
 import Modal from '../components/ui/Modal'
 import AvatarPicker from '../components/AvatarPicker'
@@ -50,7 +51,7 @@ function SettingsRow({ label, description, children, last }) {
           <p className="text-xs text-text-muted mt-0.5" style={{overflowWrap:"anywhere"}}>{description}</p>
         )}
       </div>
-      <div className="flex-shrink-0">{children}</div>
+      <div className="flex-shrink-0 w-full sm:w-auto">{children}</div>
     </div>
   )
 }
@@ -126,9 +127,6 @@ export default function Settings() {
   const { settings, updateSettings, t } = useSettings()
   const [activeTab, setActiveTab] = useState('general')
 
-  // Trainer name
-  const [trainerName, setTrainerName] = useState('')
-  const [trainerDirty, setTrainerDirty] = useState(false)
   const [geminiKey, setGeminiKey] = useState('')
   const [geminiDirty, setGeminiDirty] = useState(false)
 
@@ -141,11 +139,6 @@ export default function Settings() {
   const [alertThreshold, setAlertThreshold] = useState('10')
 
   // Load individual settings from backend
-  const { data: trainerData } = useQuery({
-    queryKey: ['setting', 'trainer_name'],
-    queryFn: () => getSetting('trainer_name').catch(() => ({ value: 'TRAINER' })),
-  })
-
   const { data: fullSyncIntervalData } = useQuery({
     queryKey: ['setting', 'full_sync_interval_days'],
     queryFn: () => getSetting('full_sync_interval_days').catch(() => ({ value: '5' })),
@@ -206,12 +199,6 @@ export default function Settings() {
   })
 
   // Sync fetched data → local state
-  useEffect(() => {
-    if (trainerData?.value !== undefined && !trainerDirty) {
-      setTrainerName(trainerData.value)
-    }
-  }, [trainerData])
-
   useEffect(() => {
     if (fullSyncIntervalData?.value) setFullSyncIntervalDays(fullSyncIntervalData.value)
   }, [fullSyncIntervalData])
@@ -286,12 +273,6 @@ export default function Settings() {
     } catch {
       toast.error(t('settings.saveFailed'))
     }
-  }
-
-  const handleSaveTrainerName = async () => {
-    await saveSetting('trainer_name', trainerName)
-    queryClient.invalidateQueries({ queryKey: ['setting', 'trainer_name'] })
-    setTrainerDirty(false)
   }
 
   const handleFullSyncIntervalChange = async (val) => {
@@ -408,7 +389,8 @@ export default function Settings() {
             <SettingsCard>
               <SettingsRow
                 label={t('auth.chooseAvatar')}
-                description={user?.username || trainerName || 'Trainer'}
+                description={user?.username || 'Trainer'}
+                last
               >
                 <button
                   type="button"
@@ -431,42 +413,42 @@ export default function Settings() {
                   </span>
                 </button>
               </SettingsRow>
-              <SettingsRow
-                label={t('settings.trainerName')}
-                description={t('settings.trainerNameDesc')}
-                last
-              >
-                <div className="flex items-center gap-2">
-                  <input
-                    type="text"
-                    value={trainerName}
-                    onChange={(e) => {
-                      setTrainerName(e.target.value)
-                      setTrainerDirty(true)
-                    }}
-                    onBlur={() => { if (trainerDirty) handleSaveTrainerName() }}
-                    onKeyDown={(e) => { if (e.key === 'Enter') handleSaveTrainerName() }}
-                    placeholder="TRAINER"
-                    className="text-xs font-semibold text-text-primary rounded-lg px-3 py-1.5 outline-none w-32 text-right"
-                    style={{
-                      background: 'rgba(255,255,255,0.07)',
-                      border: '1px solid rgba(255,255,255,0.1)',
-                    }}
-                  />
-                  {trainerDirty && (
-                    <button
-                      onClick={handleSaveTrainerName}
-                      className="text-xs font-semibold text-brand-red hover:opacity-80 transition-opacity"
-                    >
-                      {t('common.save')}
-                    </button>
-                  )}
-                </div>
-              </SettingsRow>
+
             </SettingsCard>
           </section>
 
-          {/* ── 2. DARSTELLUNG ── */}
+          {/* ── 2. THEME ── */}
+          <section className="space-y-1">
+            <SectionHeader title={t('settings.sectionTheme')} />
+            <SettingsCard>
+              <div className="px-4 py-3.5">
+                <p className="text-sm font-semibold text-text-primary mb-3">{t('settings.theme')}</p>
+                <div className="grid grid-cols-3 sm:grid-cols-5 gap-2">
+                  {themes.map((th) => (
+                    <button
+                      key={th.id}
+                      onClick={() => setTheme(th.id)}
+                      className={`flex flex-col items-center gap-1.5 rounded-xl p-3 transition-all ${
+                        theme === th.id
+                          ? 'ring-2 ring-offset-1 ring-offset-transparent'
+                          : 'hover:bg-bg-elevated'
+                      }`}
+                      style={{
+                        background: theme === th.id ? `${th.color}15` : 'rgba(255,255,255,0.03)',
+                        border: `1px solid ${theme === th.id ? `${th.color}50` : 'rgba(255,255,255,0.05)'}`,
+                        ...(theme === th.id ? { ringColor: th.color } : {}),
+                      }}
+                    >
+                      <span className="text-xl">{th.emoji}</span>
+                      <span className="text-[10px] font-semibold text-text-secondary">{th.label}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </SettingsCard>
+          </section>
+
+          {/* ── 3. DARSTELLUNG ── */}
           <section className="space-y-1">
             <SectionHeader title={t('settings.sectionAppearance')} />
             <SettingsCard>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -10,10 +10,10 @@ export default {
       colors: {
         // Dark theme backgrounds — deep blue-black
         bg: {
-          DEFAULT: '#08080f',
-          surface: '#0f0f1a',
-          card: '#141422',
-          elevated: '#1a1a2e',
+          DEFAULT: 'var(--color-bg)',
+          surface: 'var(--color-surface)',
+          card: 'var(--color-card)',
+          elevated: 'var(--color-elevated)',
         },
         border: {
           DEFAULT: 'rgba(255,255,255,0.07)',
@@ -26,9 +26,9 @@ export default {
         },
         // Pokemon brand — richer, more saturated
         brand: {
-          red: '#e3000b',
-          'red-light': '#ff4d4d',
-          'red-dark': '#b80009',
+          red: 'var(--color-brand-red)',
+          'red-light': 'var(--color-brand-red-light)',
+          'red-dark': 'var(--color-brand-red-dark)',
           'red-glow': 'rgba(227,0,11,0.35)',
         },
         // Status — keeping legacy names for backward compat


### PR DESCRIPTION
## 🎨 Pokemon Type Themes

9 themes that change background tones and accent colors:

| Theme | Accent | Emoji |
|-------|--------|-------|
| Pokémon Red (default) | #e3000b | 🔴 |
| Fire | #ff6b35 | 🔥 |
| Water | #4fc3f7 | 💧 |
| Grass | #66bb6a | 🌿 |
| Electric | #fdd835 | ⚡ |
| Psychic | #ce93d8 | 🔮 |
| Dragon | #9575cd | 🐉 |
| Dark | #78909c | 🌑 |
| Fairy | #f48fb1 | 🧚 |

### How it works
- CSS custom properties (`--color-bg`, `--color-brand-red`, etc.) in `:root`
- `[data-theme="fire"]` etc. overrides in index.css
- Tailwind config references CSS vars instead of hardcoded colors
- Stored in `localStorage` (per-device, instant)
- Applied before React renders → no theme flash
- Grid picker in Settings → General

## 🧹 Settings Cleanup
- **Removed trainer name** — uses `username` from auth context instead
- HomeScreen greeting uses username
- Dashboard TrainerCard uses username (was hardcoded "Gilles")
- **Mobile fix**: SettingsRow children use `w-full sm:w-auto` to prevent select stretching