### PR TITLE
fix: settings page blank — missing useTheme() call

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -125,6 +125,7 @@ export default function Settings() {
   const queryClient = useQueryClient()
   const { user, updateCurrentUser } = useAuth()
   const { settings, updateSettings, t } = useSettings()
+  const { theme, setTheme, themes } = useTheme()
   const [activeTab, setActiveTab] = useState('general')
 
   const [geminiKey, setGeminiKey] = useState('')


### PR DESCRIPTION
The `useTheme` hook was imported but never called in the component body. The template referenced `theme`, `setTheme`, and `themes` which were undefined, causing a runtime crash → blank page.

One-line fix: added `const { theme, setTheme, themes } = useTheme()` after the other hook calls.