### PR TITLE
cleanup: remove grading UI (no longer needed without eBay)

### DIFF
--- a/frontend/src/components/CardItem.jsx
+++ b/frontend/src/components/CardItem.jsx
@@ -520,7 +520,6 @@ const CARD_VARIANTS = [
   'Art Rare', 'Ultra Rare', 'Secret Rare', 'Shiny',
 ]
 
-const GRADE_OPTIONS = ['raw', 'PSA 9', 'PSA 10', 'BGS 9', 'BGS 9.5', 'CGC 9', 'CGC 10']
 
 export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
   const [quantity, setQuantity] = useState(1)
@@ -528,7 +527,6 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
   const [variant, setVariant] = useState('')
   const [purchasePrice, setPurchasePrice] = useState('')
   const [modalPeriod, setModalPeriod] = useState('total')
-  const [grade, setGrade] = useState('raw')
   const [resolvedCardId, setResolvedCardId] = useState(card.id)
   const { t, formatPrice } = useSettings()
   const queryClient = useQueryClient()
@@ -738,24 +736,6 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
             )}
 
             <div className="space-y-3">
-              {/* Grade selector */}
-              <div>
-                <label className="text-xs text-text-muted mb-1.5 block font-medium">
-                  🏅 {t('card.grade')}
-                </label>
-                <select
-                  value={grade}
-                  onChange={(e) => setGrade(e.target.value)}
-                  className="select"
-                >
-                  {GRADE_OPTIONS.map(g => (
-                    <option key={g} value={g}>
-                      {g === 'raw' ? t('card.gradeRaw') : g}
-                    </option>
-                  ))}
-                </select>
-              </div>
-
               <div className="grid grid-cols-2 gap-3">
                 <div>
                   <label className="text-xs text-text-muted mb-1 block">{t('card.quantity')}</label>
@@ -788,7 +768,6 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
                   variant: variant || null,
                   purchase_price: purchasePrice ? parseFloat(purchasePrice) : undefined,
                   lang: card.lang || 'en',
-                  grade: grade || 'raw',
                 })} disabled={addMutation.isPending}>
                   <Plus size={16} /> {addMutation.isPending ? t('card.adding') : t('card.addToCollection')}
                 </button>

--- a/frontend/src/components/CardScanner.jsx
+++ b/frontend/src/components/CardScanner.jsx
@@ -11,7 +11,6 @@ const CARD_VARIANTS = [
   'Illustration Rare', 'Special Illustration Rare', 'Crown Rare', 'Promo',
   'Art Rare', 'Ultra Rare', 'Secret Rare', 'Shiny',
 ]
-const GRADE_OPTIONS = ['raw', 'PSA 9', 'PSA 10', 'BGS 9', 'BGS 9.5', 'CGC 9', 'CGC 10']
 
 // ─── Add-to-Collection Modal für Scan-Ergebnis ──────────────────────────────
 function ScanAddModal({ match, defaultLang, onClose, onAdded }) {
@@ -19,7 +18,6 @@ function ScanAddModal({ match, defaultLang, onClose, onAdded }) {
   const [quantity, setQuantity] = useState(1)
   const [condition, setCondition] = useState('NM')
   const [variant, setVariant] = useState('')
-  const [grade, setGrade] = useState('raw')
   const [lang, setLang] = useState(match.lang || defaultLang || 'en')
   const [purchasePrice, setPurchasePrice] = useState('')
   const [adding, setAdding] = useState(false)
@@ -33,7 +31,6 @@ function ScanAddModal({ match, defaultLang, onClose, onAdded }) {
         quantity,
         condition,
         variant: variant || null,
-        grade: grade || 'raw',
         lang,
         purchase_price: purchasePrice ? parseFloat(purchasePrice) : undefined,
       })
@@ -132,13 +129,7 @@ function ScanAddModal({ match, defaultLang, onClose, onAdded }) {
               </select>
             </div>
 
-            {/* Grade */}
             <div>
-              <label className="text-xs text-text-muted mb-1 block">🏅 {t('card.grade')}</label>
-              <select value={grade} onChange={e => setGrade(e.target.value)} className="select">
-                {GRADE_OPTIONS.map(g => <option key={g} value={g}>{g === 'raw' ? t('card.gradeRaw') : g}</option>)}
-              </select>
-            </div>
 
             {/* Purchase price */}
             <div>

--- a/frontend/src/i18n/de.js
+++ b/frontend/src/i18n/de.js
@@ -633,8 +633,6 @@ const de = {
     addedToWishlist: 'zur Wunschliste hinzugefügt!',
     wishlistFailed: 'Fehler beim Hinzufügen zur Wunschliste',
     editCard: 'Karte bearbeiten',
-    grade: 'Grade (PSA/BGS/CGC)',
-    gradeRaw: 'Roh (ungegraded)',
   },
 
 

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -633,8 +633,6 @@ const en = {
     addedToWishlist: 'added to wishlist!',
     wishlistFailed: 'Failed to add to wishlist',
     editCard: 'Edit card',
-    grade: 'Grade (PSA/BGS/CGC)',
-    gradeRaw: 'Raw (ungraded)',
   },
 
 

--- a/frontend/src/pages/Collection.jsx
+++ b/frontend/src/pages/Collection.jsx
@@ -57,7 +57,6 @@ const VARIANT_COLORS = {
   'Normal': 'badge-gray',
 }
 
-const GRADE_OPTIONS = ['raw', 'PSA 9', 'PSA 10', 'BGS 9', 'BGS 9.5', 'CGC 9', 'CGC 10']
 
 const HOLO_VARIANTS = new Set(['Holo', 'Holo Rare', 'Holo V', 'Holo VMAX', 'Holo VSTAR', 'Holo ex'])
 const HOLO_FIELD_MAP = {
@@ -157,7 +156,6 @@ function CollectionEditModal({ item, onClose }) {
   const [quantity, setQuantity] = useState(item.quantity)
   const [condition, setCondition] = useState(item.condition || 'NM')
   const [variant, setVariant] = useState(item.variant || '')
-  const [grade, setGrade] = useState(item.grade || 'raw')
   const [lang, setLang] = useState(item.lang || 'en')
   const [price, setPrice] = useState(item.purchase_price ? String(item.purchase_price) : '')
 
@@ -168,7 +166,6 @@ function CollectionEditModal({ item, onClose }) {
       quantity,
       condition,
       variant: variant || null,
-      grade: grade || 'raw',
       lang,
       purchase_price: price ? parseFloat(price) : null,
     }),
@@ -269,12 +266,7 @@ function CollectionEditModal({ item, onClose }) {
               </select>
             </div>
 
-            <div>
-              <label className="text-xs text-text-muted mb-1 block">🏅 {t('card.grade')}</label>
-              <select value={grade} onChange={e => setGrade(e.target.value)} className="select">
-                {GRADE_OPTIONS.map(g => <option key={g} value={g}>{g === 'raw' ? t('card.gradeRaw') : g}</option>)}
-              </select>
-            </div>
+            
 
             <div>
               <label className="text-xs text-text-muted mb-1.5 block">🌐 {t('lang.selectLabel')}</label>
@@ -674,11 +666,6 @@ export default function Collection() {
                             ✨ {item.variant}
                           </span>
                         )}
-                        {item.grade && item.grade !== 'raw' && (
-                          <span className="inline-flex items-center text-[10px] font-bold px-1.5 py-0.5 rounded-full bg-amber-500/20 text-amber-400 border border-amber-500/40">
-                            🏅 {item.grade}
-                          </span>
-                        )}
                         {item.lang && (
                           <span className={`text-[10px] font-black px-1.5 py-0.5 rounded-full ${
                             item.lang === 'de'
@@ -772,12 +759,6 @@ export default function Collection() {
                                       {item.lang.toUpperCase()}
                                     </span>
                                   )}
-                                  {item.grade && item.grade !== 'raw' && (
-                                    <span className="text-[9px] font-black px-1 py-0.5 rounded leading-none"
-                                      style={{ background: 'rgba(184,134,11,0.2)', color: '#b8860b', border: '1px solid rgba(184,134,11,0.4)' }}>
-                                      {item.grade}
-                                    </span>
-                                  )}
                                 </div>
                                 {(() => {
                                   const abbr = card?.set_ref?.abbreviation
@@ -848,7 +829,6 @@ export default function Collection() {
 
                   const badges = []
                   if (item.lang) badges.push({ label: item.lang.toUpperCase(), variant: item.lang === 'de' ? 'yellow' : 'blue' })
-                  if (item.grade && item.grade !== 'raw') badges.push({ label: item.grade, variant: 'gold' })
                   if (item.variant) badges.push({ label: item.variant, variant: 'purple' })
                   if (item.condition) badges.push({ label: item.condition, variant: item.condition === 'Mint' ? 'green' : item.condition === 'NM' ? 'blue' : 'yellow' })
                   if (item.quantity > 1) badges.push({ label: `×${item.quantity}`, variant: 'red' })


### PR DESCRIPTION
Removes the grade selector and grade badges from all frontend forms and displays. The grading feature only made sense with eBay price lookup which was removed in PR #70.

**Removed from:**
- CardItem modal — grade dropdown + state
- CardScanner — grade dropdown + state
- Collection page — grade in edit form + badge display in grid/list/table views
- i18n — `card.grade` and `card.gradeRaw` keys (DE + EN)

**Kept:** DB column `grade` on `collection` table (defaults to `raw`, harmless, avoids migration issues).

-55 lines.