### PR TITLE
fix: CardScanner build error — stray <div> from grading removal

### DIFF
--- a/frontend/src/components/CardScanner.jsx
+++ b/frontend/src/components/CardScanner.jsx
@@ -129,7 +129,6 @@ function ScanAddModal({ match, defaultLang, onClose, onAdded }) {
               </select>
             </div>
 
-            <div>
 
             {/* Purchase price */}
             <div>


### PR DESCRIPTION
Empty `<div>` left behind when the grade selector was removed in PR #71. Caused unclosed JSX element → esbuild parse error.

One line deleted.