### PR TITLE
feat: compact navigation — 6 portal items with tabbed groups

### DIFF
--- a/frontend/src/components/TabNav.jsx
+++ b/frontend/src/components/TabNav.jsx
@@ -1,0 +1,28 @@
+import { useNavigate, useLocation } from 'react-router-dom'
+
+export default function TabNav({ tabs }) {
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  return (
+    <div className="flex border-b border-border overflow-x-auto scrollbar-none -mx-4 px-4 mb-4" style={{ WebkitOverflowScrolling: 'touch' }}>
+      {tabs.map((tab) => {
+        const active = location.pathname === tab.to || location.pathname.startsWith(`${tab.to}/`)
+        return (
+          <button
+            key={tab.to}
+            onClick={() => navigate(tab.to)}
+            className={`flex items-center gap-1.5 px-4 py-2.5 text-xs sm:text-sm font-semibold whitespace-nowrap transition-colors border-b-2 flex-shrink-0 ${
+              active
+                ? 'border-brand-red text-brand-red'
+                : 'border-transparent text-text-muted hover:text-text-primary'
+            }`}
+          >
+            {tab.icon && <tab.icon size={14} />}
+            {tab.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/pages/Achievements.jsx
+++ b/frontend/src/pages/Achievements.jsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { Award, ArrowLeft } from 'lucide-react'
+import { Award, ArrowLeft, Trophy } from 'lucide-react'
 import { getAchievements } from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
 import { useSettings } from '../contexts/SettingsContext'
+import TabNav from '../components/TabNav'
 
 function TrainerAvatar({ avatarId, username }) {
   if (!avatarId) {
@@ -25,6 +26,10 @@ export default function Achievements() {
   const navigate = useNavigate()
   const { user } = useAuth()
   const { t } = useSettings()
+  const SOCIAL_TABS = [
+    { to: '/leaderboard', label: t('nav.leaderboard'), icon: Trophy },
+    { to: '/achievements', label: t('nav.achievements'), icon: Award },
+  ]
   const activeUserId = userId || user?.id
   const isOtherUser = userId && Number(userId) !== user?.id
 
@@ -42,6 +47,7 @@ export default function Achievements() {
 
   return (
     <div className="page-container">
+      <TabNav tabs={SOCIAL_TABS} />
       <div className="card relative overflow-hidden">
         <div className="absolute inset-0 pointer-events-none bg-[radial-gradient(circle_at_top_right,rgba(255,138,101,0.16),transparent_40%)]" />
         <div className="relative flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/frontend/src/pages/Analytics.jsx
+++ b/frontend/src/pages/Analytics.jsx
@@ -5,7 +5,7 @@ import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid,
   AreaChart, Area
 } from 'recharts'
-import { TrendingUp, TrendingDown, Copy, BarChart3, Activity, Plus, X, ShoppingCart } from 'lucide-react'
+import { TrendingUp, TrendingDown, Copy, BarChart3, Activity, Plus, X, ShoppingCart, ShoppingBag, LayoutDashboard } from 'lucide-react'
 import {
   getDuplicates, getTopMovers, getRarityStats,
   getInvestmentTracker, getAnalyticsNewSets, getProducts, createProduct
@@ -15,6 +15,7 @@ import CardListItem from '../components/CardListItem'
 import { format, parseISO } from 'date-fns'
 import clsx from 'clsx'
 import PeriodSelector, { CARD_PERIODS, PERIOD_DAYS } from '../components/PeriodSelector'
+import TabNav from '../components/TabNav'
 import toast from 'react-hot-toast'
 import { resolveCardImageUrl } from '../utils/imageUrl'
 
@@ -159,6 +160,11 @@ export default function Analytics() {
   const [activeTab, setActiveTab] = useState('duplicates')
   const [showExpenseModal, setShowExpenseModal] = useState(false)
   const queryClient = useQueryClient()
+  const ANALYTICS_TABS = [
+    { to: '/analytics', label: t('nav.analytics'), icon: BarChart3 },
+    { to: '/products', label: t('nav.products'), icon: ShoppingBag },
+    { to: '/dashboard', label: t('nav.dashboard'), icon: LayoutDashboard },
+  ]
 
   const { data: duplicates = [], isLoading: dupLoading } = useQuery({
     queryKey: ['duplicates'],
@@ -217,6 +223,7 @@ export default function Analytics() {
 
   return (
     <div className="space-y-4 pb-2">
+      <TabNav tabs={ANALYTICS_TABS} />
       <div>
         <h1 className="text-xl font-bold text-text-primary">{t('analytics.title')}</h1>
         <p className="text-sm text-text-secondary mt-1">{t('analytics.subtitle')}</p>

--- a/frontend/src/pages/Binders.jsx
+++ b/frontend/src/pages/Binders.jsx
@@ -1,9 +1,10 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
-import { Plus, Trash2, Edit2, BookOpen, Star, Package, Check, X } from 'lucide-react'
+import { Plus, Trash2, Edit2, BookOpen, Star, Package, Check, X, Library, Heart } from 'lucide-react'
 import { getBinders, createBinder, updateBinder, deleteBinder } from '../api/client'
 import { useSettings } from '../contexts/SettingsContext'
+import TabNav from '../components/TabNav'
 import toast from 'react-hot-toast'
 
 const BINDER_COLORS = [
@@ -82,6 +83,11 @@ export default function Binders() {
   const queryClient = useQueryClient()
   const [creating, setCreating] = useState(false)
   const [editingId, setEditingId] = useState(null)
+  const COLLECTION_TABS = [
+    { to: '/collection', label: t('nav.collection'), icon: Library },
+    { to: '/binders', label: t('nav.binders'), icon: BookOpen },
+    { to: '/wishlist', label: t('nav.wishlist'), icon: Heart },
+  ]
 
   const { data: binders = [], isLoading } = useQuery({
     queryKey: ['binders'],
@@ -118,6 +124,7 @@ export default function Binders() {
 
   return (
     <div className="space-y-4 pb-2">
+      <TabNav tabs={COLLECTION_TABS} />
       <div className="flex items-center justify-between gap-2 mb-4 flex-wrap">
         <div className="min-w-0">
           <h1 className="text-xl font-bold text-text-primary">{t('binders.title')}</h1>

--- a/frontend/src/pages/Collection.jsx
+++ b/frontend/src/pages/Collection.jsx
@@ -1,10 +1,11 @@
 import { useState, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Trash2, Check, X, Filter, SortAsc, Download, ChevronUp, ChevronDown, Search, PenLine, Grid2X2, List } from 'lucide-react'
+import { Trash2, Check, X, Filter, SortAsc, Download, ChevronUp, ChevronDown, Search, PenLine, Grid2X2, List, Library, BookOpen, Heart } from 'lucide-react'
 import { getCollection, updateCollectionItem, removeFromCollection, exportCSV, exportPDF, getSets } from '../api/client'
 import { CustomCardModal } from '../components/CardItem'
 import { useSettings } from '../contexts/SettingsContext'
 import CardListItem from '../components/CardListItem'
+import TabNav from '../components/TabNav'
 import toast from 'react-hot-toast'
 import clsx from 'clsx'
 import { useTilt } from '../hooks/useTilt'
@@ -332,6 +333,11 @@ function CollectionEditModal({ item, onClose }) {
 
 export default function Collection() {
   const { t, formatPrice } = useSettings()
+  const COLLECTION_TABS = [
+    { to: '/collection', label: t('nav.collection'), icon: Library },
+    { to: '/binders', label: t('nav.binders'), icon: BookOpen },
+    { to: '/wishlist', label: t('nav.wishlist'), icon: Heart },
+  ]
   const [viewMode, setViewMode] = useState('grid')
   const [editingCollectionItem, setEditingCollectionItem] = useState(null) // for CollectionEditModal
   const [showCustomModal, setShowCustomModal] = useState(false)
@@ -441,6 +447,7 @@ export default function Collection() {
   if (isLoading) {
     return (
       <div className="space-y-4">
+        <TabNav tabs={COLLECTION_TABS} />
         <div className="skeleton h-8 w-48 rounded" />
         {[...Array(5)].map((_, i) => <div key={i} className="skeleton h-16 rounded-xl" />)}
       </div>
@@ -449,6 +456,7 @@ export default function Collection() {
 
   return (
     <div className="space-y-4 pb-2">
+      <TabNav tabs={COLLECTION_TABS} />
 
       {/* ─── Header ───────────────────────────────────────────────── */}
       <div className="flex items-center justify-between gap-2 mb-4 flex-wrap">

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -5,7 +5,7 @@ import {
   XAxis, YAxis, CartesianGrid, Tooltip,
   ResponsiveContainer, Area, AreaChart
 } from 'recharts'
-import { TrendingUp, TrendingDown } from 'lucide-react'
+import { TrendingUp, TrendingDown, BarChart3, ShoppingBag, LayoutDashboard } from 'lucide-react'
 import { getDashboard } from '../api/client'
 import { useSettings } from '../contexts/SettingsContext'
 import { useAuth } from '../contexts/AuthContext'
@@ -13,6 +13,7 @@ import { format, parseISO } from 'date-fns'
 import PeriodSelector, { CARD_PERIODS, PERIOD_PRICE_FIELD } from '../components/PeriodSelector'
 import TrainerCard from '../components/TrainerCard'
 import PokeBallLoader from '../components/PokeBallLoader'
+import TabNav from '../components/TabNav'
 import { resolveCardImageUrl } from '../utils/imageUrl'
 
 const CustomTooltip = ({ active, payload, label }) => {
@@ -34,8 +35,14 @@ const CustomTooltip = ({ active, payload, label }) => {
 
 export default function Dashboard() {
   const { t, formatPrice } = useSettings()
+  const { user } = useAuth()
   const navigate = useNavigate()
   const [period, setPeriod] = useState('total')
+  const ANALYTICS_TABS = [
+    { to: '/analytics', label: t('nav.analytics'), icon: BarChart3 },
+    { to: '/products', label: t('nav.products'), icon: ShoppingBag },
+    { to: '/dashboard', label: t('nav.dashboard'), icon: LayoutDashboard },
+  ]
 
   const priceField = PERIOD_PRICE_FIELD[period] || 'price_trend'
 
@@ -48,6 +55,7 @@ export default function Dashboard() {
   if (isLoading) {
     return (
       <div className="space-y-5 animate-pulse pb-4">
+        <TabNav tabs={ANALYTICS_TABS} />
         {/* Trainer card skeleton */}
         <div className="rounded-2xl overflow-hidden border-2 border-gold/20" style={{ background: 'linear-gradient(135deg, #1a2040, #0d1530)' }}>
           <div className="h-9 bg-brand-red/70" />
@@ -76,9 +84,12 @@ export default function Dashboard() {
 
   if (error) {
     return (
-      <div className="card text-center py-12">
-        <PokeBallLoader size={48} className="mb-4 opacity-40" />
-        <p className="text-brand-red">{t('dashboard.backendError')}</p>
+      <div className="space-y-5 pb-2">
+        <TabNav tabs={ANALYTICS_TABS} />
+        <div className="card text-center py-12">
+          <PokeBallLoader size={48} className="mb-4 opacity-40" />
+          <p className="text-brand-red">{t('dashboard.backendError')}</p>
+        </div>
       </div>
     )
   }
@@ -100,6 +111,7 @@ export default function Dashboard() {
 
   return (
     <div className="space-y-5 pb-2">
+      <TabNav tabs={ANALYTICS_TABS} />
 
       {/* ─── 1. TRAINER CARD HERO ──────────────────────────────────── */}
       {data && (

--- a/frontend/src/pages/HomeScreen.jsx
+++ b/frontend/src/pages/HomeScreen.jsx
@@ -2,8 +2,8 @@ import { useState, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
-  RefreshCw, TrendingUp, TrendingDown, Layers, BookOpen, Star, Wallet, LogOut,
-  LayoutDashboard, Search, Library, Grid2X2, Heart, BarChart3, ShoppingBag, Settings, Trophy, Award,
+  RefreshCw, TrendingUp, TrendingDown, Layers, Star, Wallet, LogOut,
+  Search, Library, Grid2X2, BarChart3, Settings, Trophy,
 } from 'lucide-react'
 import {
   AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer,
@@ -146,11 +146,7 @@ export default function HomeScreen() {
     { to: '/search',     icon: Search,     label: t('nav.cardSearch'),  color: '#ce93d8' },
     { to: '/sets',       icon: Grid2X2,    label: t('nav.sets'),        color: '#81c784' },
     { to: '/analytics',  icon: BarChart3,  label: t('nav.analytics'),   color: '#f5c842' },
-    { to: '/wishlist',   icon: Heart,      label: t('nav.wishlist'),     color: '#f48fb1' },
-    { to: '/binders',    icon: BookOpen,   label: t('nav.binders'),     color: '#ffcc80' },
-    { to: '/products',   icon: ShoppingBag, label: t('nav.products'),   color: '#80cbc4' },
     { to: '/leaderboard', icon: Trophy,    label: t('nav.leaderboard'), color: '#ffd54f' },
-    { to: '/achievements', icon: Award,    label: t('nav.achievements'), color: '#ff8a65' },
     { to: '/settings',   icon: Settings,   label: t('nav.settings'),    color: '#b0bec5' },
   ]
 

--- a/frontend/src/pages/Leaderboard.jsx
+++ b/frontend/src/pages/Leaderboard.jsx
@@ -1,9 +1,10 @@
 import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { ArrowUpDown, Trophy } from 'lucide-react'
+import { ArrowUpDown, Trophy, Award } from 'lucide-react'
 import { getLeaderboard } from '../api/client'
 import { useSettings } from '../contexts/SettingsContext'
+import TabNav from '../components/TabNav'
 import { resolveCardImageUrl } from '../utils/imageUrl'
 
 const SORT_OPTIONS = ['total_value', 'total_cards', 'unique_cards', 'sets_completed', 'pnl']
@@ -33,6 +34,10 @@ export default function Leaderboard() {
   const navigate = useNavigate()
   const { t, formatPrice } = useSettings()
   const [sortBy, setSortBy] = useState('total_value')
+  const SOCIAL_TABS = [
+    { to: '/leaderboard', label: t('nav.leaderboard'), icon: Trophy },
+    { to: '/achievements', label: t('nav.achievements'), icon: Award },
+  ]
 
   const { data = [], isLoading, error } = useQuery({
     queryKey: ['leaderboard'],
@@ -50,6 +55,7 @@ export default function Leaderboard() {
 
   return (
     <div className="page-container">
+      <TabNav tabs={SOCIAL_TABS} />
       <div className="card relative overflow-hidden">
         <div className="absolute inset-0 pointer-events-none bg-[radial-gradient(circle_at_top_right,rgba(255,213,79,0.16),transparent_40%)]" />
         <div className="relative flex items-start justify-between gap-3">

--- a/frontend/src/pages/Products.jsx
+++ b/frontend/src/pages/Products.jsx
@@ -4,11 +4,12 @@ import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
   ResponsiveContainer, Cell
 } from 'recharts'
-import { Plus, Trash2, Edit2, TrendingUp, TrendingDown, Package, Check, X, SortAsc, Filter, ChevronUp, ChevronDown } from 'lucide-react'
+import { Plus, Trash2, Edit2, TrendingUp, TrendingDown, Package, Check, X, SortAsc, Filter, ChevronUp, ChevronDown, BarChart3, ShoppingBag, LayoutDashboard } from 'lucide-react'
 import { getProducts, createProduct, updateProduct, deleteProduct, getProductsSummary } from '../api/client'
 import { useSettings } from '../contexts/SettingsContext'
 import CardListItem from '../components/CardListItem'
 import PeriodSelector, { PRODUCT_PERIODS, getPeriodCutoff } from '../components/PeriodSelector'
+import TabNav from '../components/TabNav'
 import toast from 'react-hot-toast'
 import clsx from 'clsx'
 
@@ -102,6 +103,11 @@ export default function Products() {
   const [filterPnl, setFilterPnl] = useState('all')
   const [showFilters, setShowFilters] = useState(false)
   const queryClient = useQueryClient()
+  const ANALYTICS_TABS = [
+    { to: '/analytics', label: t('nav.analytics'), icon: BarChart3 },
+    { to: '/products', label: t('nav.products'), icon: ShoppingBag },
+    { to: '/dashboard', label: t('nav.dashboard'), icon: LayoutDashboard },
+  ]
 
   const { data: products = [], isLoading } = useQuery({
     queryKey: ['products'],
@@ -198,6 +204,7 @@ export default function Products() {
 
   return (
     <div className="space-y-4 pb-2">
+      <TabNav tabs={ANALYTICS_TABS} />
       <div className="flex items-center justify-between gap-2 mb-4 flex-wrap">
         <div className="min-w-0">
           <h1 className="text-xl font-bold text-text-primary">{t('products.title')}</h1>

--- a/frontend/src/pages/Wishlist.jsx
+++ b/frontend/src/pages/Wishlist.jsx
@@ -1,9 +1,10 @@
 import { useState, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Trash2, Bell, BellOff, Edit2, Check, X, Heart, Filter, SortAsc, ChevronUp, ChevronDown } from 'lucide-react'
+import { Trash2, Bell, BellOff, Edit2, Check, X, Heart, Filter, SortAsc, ChevronUp, ChevronDown, Library, BookOpen } from 'lucide-react'
 import { getWishlist, removeFromWishlist, updateWishlistItem, addToCollection } from '../api/client'
 import { useSettings } from '../contexts/SettingsContext'
 import CardListItem from '../components/CardListItem'
+import TabNav from '../components/TabNav'
 import toast from 'react-hot-toast'
 import { resolveCardImageUrl } from '../utils/imageUrl'
 
@@ -59,6 +60,11 @@ export default function Wishlist() {
   const [filterHasAlert, setFilterHasAlert] = useState(false)
   const [showFilters, setShowFilters] = useState(false)
   const queryClient = useQueryClient()
+  const COLLECTION_TABS = [
+    { to: '/collection', label: t('nav.collection'), icon: Library },
+    { to: '/binders', label: t('nav.binders'), icon: BookOpen },
+    { to: '/wishlist', label: t('nav.wishlist'), icon: Heart },
+  ]
 
   const { data: items = [], isLoading } = useQuery({
     queryKey: ['wishlist'],
@@ -127,6 +133,7 @@ export default function Wishlist() {
 
   return (
     <div className="space-y-4 pb-2">
+      <TabNav tabs={COLLECTION_TABS} />
       <div className="flex items-center justify-between gap-2 mb-4 flex-wrap">
         <div className="min-w-0">
           <h1 className="text-xl font-bold text-text-primary flex items-center gap-2">


### PR DESCRIPTION
## Before: 10 menu items
Collection, Search, Sets, Analytics, Wishlist, Binders, Products, Leaderboard, Achievements, Settings

## After: 6 menu items
| Portal | Contains | Tab Navigation |
|--------|----------|----------------|
| 📚 Collection | Collection, Binders, Wishlist | ← → tabs |
| 🔍 Search | Card Search | standalone |
| 📦 Sets | Set Browser | standalone |
| 📊 Analytics | Analytics, Products, Dashboard | ← → tabs |
| 🏆 Social | Leaderboard, Achievements | ← → tabs |
| ⚙️ Settings | Settings | standalone |

### How it works
- New `TabNav` component renders a horizontal tab bar at the top of grouped pages
- Each page in a group shows the same tabs — clicking navigates to that route
- Active tab highlighted based on current URL (including nested routes like `/achievements/:userId`)
- All original routes unchanged — no breaking changes, bookmarks still work
- Mobile-friendly: scrollable tabs, same style as Settings tabs

### Files
- `TabNav.jsx` — new shared component (28 lines)
- 8 pages updated with TabNav (Collection, Binders, Wishlist, Analytics, Products, Dashboard, Leaderboard, Achievements)
- HomeScreen reduced from 10 to 6 portal items
- Unused icon imports cleaned up