### PR TITLE
feat: single-user / multi-user mode toggle

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -1,10 +1,10 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from jose import JWTError
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from database import get_db
+from database import get_db, get_setting, save_setting
 from models import User
 from services.auth import create_access_token, decode_token, hash_password, verify_password
 
@@ -51,6 +51,14 @@ def field_was_set(model: BaseModel, field_name: str) -> bool:
 
 def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)) -> User:
     if not token:
+        multi = get_setting("multi_user_mode")
+        if multi is None:
+            user_count = db.query(User).count()
+            multi = "true" if user_count > 1 else "false"
+        if str(multi).lower() != "true":
+            admin = db.query(User).filter(User.role == "admin", User.is_active == True).first()
+            if admin:
+                return admin
         raise HTTPException(status_code=401, detail="Not authenticated")
     try:
         payload = decode_token(token)
@@ -94,6 +102,26 @@ def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depend
 @router.get("/me")
 def get_me(current_user: User = Depends(get_current_user)):
     return {"id": current_user.id, "username": current_user.username, "role": current_user.role, "avatar_id": current_user.avatar_id}
+
+
+@router.get("/mode")
+def get_auth_mode(db: Session = Depends(get_db)):
+    multi = get_setting("multi_user_mode")
+    if multi is None:
+        multi = "true" if db.query(User).count() > 1 else "false"
+    return {"multi_user": str(multi).lower() == "true"}
+
+
+@router.put("/mode")
+def set_auth_mode(
+    enabled: bool = Body(..., embed=True),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if current_user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin only")
+    save_setting("multi_user_mode", str(enabled).lower())
+    return {"multi_user": enabled}
 
 
 @router.get("/users")

--- a/backend/database.py
+++ b/backend/database.py
@@ -25,6 +25,7 @@ DEFAULT_SETTINGS = {
     "language": "de",
     "price_display": '["trend", "avg1", "avg7", "avg30", "low"]',
     "price_primary": "trend",
+    "multi_user_mode": "false",
 }
 
 
@@ -299,5 +300,23 @@ def get_setting(key: str, default=None):
         from models import Setting
         row = db.query(Setting).filter(Setting.key == key).first()
         return row.value if row else default
+    finally:
+        db.close()
+
+
+def save_setting(key: str, value):
+    """Create or update a single setting value in the database."""
+    db = SessionLocal()
+    try:
+        from models import Setting
+        row = db.query(Setting).filter(Setting.key == key).first()
+        if row:
+            row.value = str(value)
+        else:
+            db.add(Setting(key=key, value=str(value)))
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
     finally:
         db.close()

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -22,7 +22,7 @@ import Compare from './pages/Compare'
 import Achievements from './pages/Achievements'
 
 function ProtectedRoutes() {
-  const { user, loading } = useAuth()
+  const { user, loading, multiUser } = useAuth()
 
   if (loading) {
     return (
@@ -32,8 +32,16 @@ function ProtectedRoutes() {
     )
   }
 
-  if (!user) {
+  if (!user && multiUser) {
     return <Navigate to="/login" replace />
+  }
+
+  if (!user) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-bg-primary">
+        <PokeBallLoader size={48} />
+      </div>
+    )
   }
 
   return (

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -20,9 +20,10 @@ api.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response?.status === 401) {
+      const token = localStorage.getItem('token')
       localStorage.removeItem('token')
       localStorage.removeItem('user')
-      if (window.location.pathname !== '/login') {
+      if (token && window.location.pathname !== '/login') {
         window.location.href = '/login'
       }
     }
@@ -40,6 +41,8 @@ export const login = (username, password) => {
 }
 
 export const getMe = () => api.get('/auth/me').then(r => r.data)
+export const getAuthMode = () => api.get('/auth/mode').then(r => r.data)
+export const setAuthMode = (enabled) => api.put('/auth/mode', { enabled }).then(r => r.data)
 export const getUsers = () => api.get('/auth/users').then(r => r.data)
 export const createUser = (data) => api.post('/auth/users', data).then(r => r.data)
 export const updateUser = (id, data) => api.put(`/auth/users/${id}`, data).then(r => r.data)
@@ -129,10 +132,13 @@ export const getProductsSummary = () => api.get('/products/summary')
 // Export
 export const exportCSV = () => {
   const token = localStorage.getItem('token')
-  return api.get('/export/csv', {
+  const config = {
     responseType: 'blob',
-    headers: { Authorization: `Bearer ${token}` },
-  }).then(r => {
+  }
+  if (token) {
+    config.headers = { Authorization: `Bearer ${token}` }
+  }
+  return api.get('/export/csv', config).then(r => {
     const url = window.URL.createObjectURL(r.data)
     const a = document.createElement('a')
     a.href = url
@@ -143,10 +149,13 @@ export const exportCSV = () => {
 }
 export const exportPDF = () => {
   const token = localStorage.getItem('token')
-  return api.get('/export/pdf', {
+  const config = {
     responseType: 'blob',
-    headers: { Authorization: `Bearer ${token}` },
-  }).then(r => {
+  }
+  if (token) {
+    config.headers = { Authorization: `Bearer ${token}` }
+  }
+  return api.get('/export/pdf', config).then(r => {
     const url = window.URL.createObjectURL(r.data)
     const a = document.createElement('a')
     a.href = url
@@ -159,10 +168,13 @@ export const exportPDF = () => {
 // Backup
 export const downloadBackup = () => {
   const token = localStorage.getItem('token')
-  return api.get('/backup/download', {
+  const config = {
     responseType: 'blob',
-    headers: { Authorization: `Bearer ${token}` },
-  }).then(r => {
+  }
+  if (token) {
+    config.headers = { Authorization: `Bearer ${token}` }
+  }
+  return api.get('/backup/download', config).then(r => {
     const url = window.URL.createObjectURL(r.data)
     const a = document.createElement('a')
     a.href = url

--- a/frontend/src/components/AppNav.jsx
+++ b/frontend/src/components/AppNav.jsx
@@ -21,7 +21,7 @@ const PAGE_TITLE_KEYS = {
 export default function AppNav() {
   const navigate = useNavigate()
   const location = useLocation()
-  const { user, logout } = useAuth()
+  const { user, logout, multiUser } = useAuth()
   const { t } = useSettings()
 
   const handleLogout = () => { logout(); navigate('/login') }
@@ -43,20 +43,24 @@ export default function AppNav() {
           <p className="text-[11px] font-black uppercase tracking-[0.2em] text-text-muted text-center truncate flex-1 min-w-0">
             {title}
           </p>
-          <button
-            onClick={handleLogout}
-            className="flex h-8 min-w-8 items-center justify-center gap-1.5 rounded-lg px-1.5 text-text-muted transition-colors hover:text-brand-red pointer-events-auto"
-            aria-label={t('auth.logout')}
-          >
-            {user?.avatar_id ? (
-              <img
-                src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-v/black-white/animated/${user.avatar_id}.gif`}
-                alt={`${user.username} avatar`}
-                className="h-5 w-5 pixelated"
-              />
-            ) : null}
-            <LogOut size={16} />
-          </button>
+          {multiUser ? (
+            <button
+              onClick={handleLogout}
+              className="flex h-8 min-w-8 items-center justify-center gap-1.5 rounded-lg px-1.5 text-text-muted transition-colors hover:text-brand-red pointer-events-auto"
+              aria-label={t('auth.logout')}
+            >
+              {user?.avatar_id ? (
+                <img
+                  src={`https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/versions/generation-v/black-white/animated/${user.avatar_id}.gif`}
+                  alt={`${user.username} avatar`}
+                  className="h-5 w-5 pixelated"
+                />
+              ) : null}
+              <LogOut size={16} />
+            </button>
+          ) : (
+            <div className="w-8" />
+          )}
         </div>
       )}
 

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState } from 'react'
-import { getMe } from '../api/client'
+import { getAuthMode, getMe } from '../api/client'
 
 const AuthContext = createContext(null)
 
@@ -15,18 +15,29 @@ export function AuthProvider({ children }) {
     }
   })
   const [loading, setLoading] = useState(true)
+  const [multiUser, setMultiUser] = useState(true)
 
   useEffect(() => {
-    const token = localStorage.getItem('token')
-    if (!token) {
-      setLoading(false)
-      return
-    }
-
-    getMe()
-      .then((currentUser) => {
-        setUser(currentUser)
-        localStorage.setItem('user', JSON.stringify(currentUser))
+    getAuthMode()
+      .then(({ multi_user }) => {
+        setMultiUser(multi_user)
+        const token = localStorage.getItem('token')
+        if (!multi_user || token) {
+          return getMe().then((currentUser) => {
+            setUser(currentUser)
+            localStorage.setItem('user', JSON.stringify(currentUser))
+          })
+        }
+        setUser(null)
+      })
+      .catch(() => {
+        const token = localStorage.getItem('token')
+        if (token) {
+          return getMe().then((currentUser) => {
+            setUser(currentUser)
+            localStorage.setItem('user', JSON.stringify(currentUser))
+          })
+        }
       })
       .catch(() => {
         localStorage.removeItem('token')
@@ -59,7 +70,7 @@ export function AuthProvider({ children }) {
   }
 
   return (
-    <AuthContext.Provider value={{ user, loading, loginUser, updateCurrentUser, logout }}>
+    <AuthContext.Provider value={{ user, loading, multiUser, loginUser, updateCurrentUser, logout }}>
       {children}
     </AuthContext.Provider>
   )

--- a/frontend/src/i18n/de.js
+++ b/frontend/src/i18n/de.js
@@ -463,6 +463,7 @@ const de = {
     // Settings page section headers
     theme: 'Farbthema',
     sectionTheme: 'Thema',
+    sectionMultiUser: 'Mehrspieler',
     sectionTrainer: 'Trainer',
     sectionAppearance: 'Darstellung',
     sectionSync: 'Synchronisation',
@@ -471,6 +472,8 @@ const de = {
     sectionAI: 'KI / Karten-Scanner',
     sectionAbout: 'Über die App',
     // Settings page row labels
+    multiUserMode: 'Mehrspieler-Modus',
+    multiUserModeDesc: 'Login-Bildschirm und Benutzerverwaltung aktivieren',
     trainerName: 'Trainer-Name',
     trainerNameDesc: 'Wird auf dem Startbildschirm angezeigt',
     languageDesc: 'App-Sprache ändern',

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -463,6 +463,7 @@ const en = {
     // Settings page section headers
     theme: 'Color Theme',
     sectionTheme: 'Theme',
+    sectionMultiUser: 'Multi-User',
     sectionTrainer: 'Trainer',
     sectionAppearance: 'Appearance',
     sectionSync: 'Synchronization',
@@ -471,6 +472,8 @@ const en = {
     sectionAI: 'AI / Card Scanner',
     sectionAbout: 'About the App',
     // Settings page row labels
+    multiUserMode: 'Multi-User Mode',
+    multiUserModeDesc: 'Enable login screen and user management',
     trainerName: 'Trainer Name',
     trainerNameDesc: 'Displayed on the home screen',
     languageDesc: 'Change app language',

--- a/frontend/src/pages/Achievements.jsx
+++ b/frontend/src/pages/Achievements.jsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { Navigate, useParams, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { Award, ArrowLeft, Trophy } from 'lucide-react'
 import { getAchievements } from '../api/client'
@@ -24,7 +24,7 @@ function TrainerAvatar({ avatarId, username }) {
 export default function Achievements() {
   const { userId } = useParams()
   const navigate = useNavigate()
-  const { user } = useAuth()
+  const { user, multiUser } = useAuth()
   const { t } = useSettings()
   const SOCIAL_TABS = [
     { to: '/leaderboard', label: t('nav.leaderboard'), icon: Trophy },
@@ -44,6 +44,10 @@ export default function Achievements() {
     const total = Number(data?.total ?? 20)
     return `${earned}/${total} ${t('achievements.earned')}`
   }, [data, t])
+
+  if (!multiUser) {
+    return <Navigate to="/" replace />
+  }
 
   return (
     <div className="page-container">

--- a/frontend/src/pages/Compare.jsx
+++ b/frontend/src/pages/Compare.jsx
@@ -1,9 +1,10 @@
 import { useMemo } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { Navigate, useNavigate, useParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { ArrowLeftRight } from 'lucide-react'
 import { compareUsers } from '../api/client'
 import { useSettings } from '../contexts/SettingsContext'
+import { useAuth } from '../contexts/AuthContext'
 import { resolveCardImageUrl } from '../utils/imageUrl'
 
 function TrainerAvatar({ avatarId, username }) {
@@ -81,6 +82,7 @@ export default function Compare() {
   const { userId } = useParams()
   const navigate = useNavigate()
   const { t, formatPrice } = useSettings()
+  const { multiUser } = useAuth()
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['compare', userId],
@@ -93,6 +95,10 @@ export default function Compare() {
     if (!total) return 0
     return (Number(data?.overlap ?? 0) / total) * 100
   }, [data])
+
+  if (!multiUser) {
+    return <Navigate to="/" replace />
+  }
 
   return (
     <div className="page-container">

--- a/frontend/src/pages/HomeScreen.jsx
+++ b/frontend/src/pages/HomeScreen.jsx
@@ -72,7 +72,7 @@ export default function HomeScreen() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const { formatPrice, t } = useSettings()
-  const { user, logout } = useAuth()
+  const { user, logout, multiUser } = useAuth()
   const [chartPeriod, setChartPeriod] = useState('1M')
 
   const { data, isLoading } = useQuery({
@@ -146,7 +146,7 @@ export default function HomeScreen() {
     { to: '/search',     icon: Search,     label: t('nav.cardSearch'),  color: '#ce93d8' },
     { to: '/sets',       icon: Grid2X2,    label: t('nav.sets'),        color: '#81c784' },
     { to: '/analytics',  icon: BarChart3,  label: t('nav.analytics'),   color: '#f5c842' },
-    { to: '/leaderboard', icon: Trophy,    label: t('nav.leaderboard'), color: '#ffd54f' },
+    ...(multiUser ? [{ to: '/leaderboard', icon: Trophy, label: t('nav.leaderboard'), color: '#ffd54f' }] : []),
     { to: '/settings',   icon: Settings,   label: t('nav.settings'),    color: '#b0bec5' },
   ]
 
@@ -194,14 +194,18 @@ export default function HomeScreen() {
 
         {/* ── TOP BAR: Logout + Sync ── */}
         <div className="flex items-center justify-between">
-          <button
-            onClick={() => { logout(); navigate('/login') }}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-xs font-semibold text-text-muted hover:text-brand-red transition-colors"
-            style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.07)' }}
-          >
-            <LogOut size={12} />
-            {t('auth.logout')}
-          </button>
+          {multiUser ? (
+            <button
+              onClick={() => { logout(); navigate('/login') }}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-xs font-semibold text-text-muted hover:text-brand-red transition-colors"
+              style={{ background: 'rgba(255,255,255,0.04)', border: '1px solid rgba(255,255,255,0.07)' }}
+            >
+              <LogOut size={12} />
+              {t('auth.logout')}
+            </button>
+          ) : (
+            <div />
+          )}
           <button
             onClick={() => syncMutation.mutate()}
             disabled={isRunning}

--- a/frontend/src/pages/Leaderboard.jsx
+++ b/frontend/src/pages/Leaderboard.jsx
@@ -1,9 +1,10 @@
 import { useMemo, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { Navigate, useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { ArrowUpDown, Trophy, Award } from 'lucide-react'
 import { getLeaderboard } from '../api/client'
 import { useSettings } from '../contexts/SettingsContext'
+import { useAuth } from '../contexts/AuthContext'
 import TabNav from '../components/TabNav'
 import { resolveCardImageUrl } from '../utils/imageUrl'
 
@@ -33,6 +34,7 @@ function TrainerAvatar({ avatarId, username }) {
 export default function Leaderboard() {
   const navigate = useNavigate()
   const { t, formatPrice } = useSettings()
+  const { multiUser } = useAuth()
   const [sortBy, setSortBy] = useState('total_value')
   const SOCIAL_TABS = [
     { to: '/leaderboard', label: t('nav.leaderboard'), icon: Trophy },
@@ -52,6 +54,10 @@ export default function Leaderboard() {
       return Number(b?.total_value ?? 0) - Number(a?.total_value ?? 0)
     })
   }, [data, sortBy])
+
+  if (!multiUser) {
+    return <Navigate to="/" replace />
+  }
 
   return (
     <div className="page-container">

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -13,11 +13,11 @@ export default function Login() {
   const [username, setUsername] = useState(() => localStorage.getItem('lastUser') || '')
   const [password, setPassword] = useState('')
   const [loading, setLoading] = useState(false)
-  const { user, loginUser } = useAuth()
+  const { user, loginUser, multiUser } = useAuth()
   const { t } = useSettings()
   const navigate = useNavigate()
 
-  if (user) {
+  if (user || !multiUser) {
     return <Navigate to="/" replace />
   }
 

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -4,7 +4,7 @@ import { RefreshCw, Download, Upload, Plus, Pencil, Trash2, User, UserCheck, Use
 import {
   getSyncStatus, triggerSync, triggerPriceSync, rescheduleFullSync, reschedulePriceSync,
   downloadBackup, restoreBackup, exportCSV,
-  getSetting, setSetting, getTelegramStatus, saveSettings,
+  getSetting, setSetting, getTelegramStatus, saveSettings, setAuthMode,
   getUsers, createUser, updateUser, deleteUser, changePassword, changeAvatar,
 } from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
@@ -123,7 +123,7 @@ export default function Settings() {
   const [restoring, setRestoring] = useState(false)
   const [showAvatarPicker, setShowAvatarPicker] = useState(false)
   const queryClient = useQueryClient()
-  const { user, updateCurrentUser } = useAuth()
+  const { user, updateCurrentUser, multiUser } = useAuth()
   const { settings, updateSettings, t } = useSettings()
   const { theme, setTheme, themes } = useTheme()
   const [activeTab, setActiveTab] = useState('general')
@@ -359,7 +359,7 @@ export default function Settings() {
           { key: 'general', label: t('settings.tabs.general') },
           { key: 'sync', label: t('settings.tabs.dataSync') },
           { key: 'notifications', label: t('settings.tabs.notifications') },
-          ...(user?.role === 'admin' ? [{ key: 'users', label: t('settings.tabs.users') }] : []),
+          ...(user?.role === 'admin' && multiUser ? [{ key: 'users', label: t('settings.tabs.users') }] : []),
         ].map((tab) => (
           <button
             key={tab.key}
@@ -439,6 +439,31 @@ export default function Settings() {
               </div>
             </SettingsCard>
           </section>
+
+          {user?.role === 'admin' && (
+            <section className="space-y-1">
+              <SectionHeader title={t('settings.sectionMultiUser')} />
+              <SettingsCard>
+                <SettingsRow
+                  label={t('settings.multiUserMode')}
+                  description={t('settings.multiUserModeDesc')}
+                  last
+                >
+                  <Toggle
+                    value={multiUser}
+                    onChange={async (val) => {
+                      try {
+                        await setAuthMode(val)
+                        window.location.reload()
+                      } catch {
+                        toast.error(t('common.error'))
+                      }
+                    }}
+                  />
+                </SettingsRow>
+              </SettingsCard>
+            </section>
+          )}
 
           {/* ── 3. DARSTELLUNG ── */}
           <section className="space-y-1">
@@ -764,7 +789,7 @@ export default function Settings() {
         </>
       )}
 
-      {activeTab === 'users' && user?.role === 'admin' && (
+      {activeTab === 'users' && user?.role === 'admin' && multiUser && (
         <UsersTab t={t} queryClient={queryClient} />
       )}
 


### PR DESCRIPTION
## Single-User vs Multi-User Mode

New toggle in Settings (admin only) to switch between single-user and multi-user mode.

### Single-User Mode (default for new installs)
- **No login required** — auto-authenticates as admin
- **Social features hidden**: Leaderboard, Compare, Achievements
- **No logout button** in HomeScreen or AppNav
- **Users tab hidden** in Settings

### Multi-User Mode
- Everything works as before: login screen, user management, social features
- **Auto-detected**: if >1 user exists and no setting is saved, defaults to multi-user

### How it works

| Layer | What happens |
|-------|-------------|
| Backend `GET /api/auth/mode` | Returns `{ multi_user: bool }` (no auth needed) |
| Backend `PUT /api/auth/mode` | Admin-only toggle, persisted in settings table |
| Backend `get_current_user` | In single-user mode, returns admin without token |
| Frontend `AuthContext` | Fetches mode on boot, exposes `multiUser` flag |
| Frontend pages | Conditionally hide social features + login UI |

### Files changed (14)
- `backend/api/auth.py` — mode endpoints + auto-auth logic
- `backend/database.py` — `save_setting()` helper + default setting
- `frontend/src/contexts/AuthContext.jsx` — mode-aware auth flow
- `frontend/src/App.jsx` — ProtectedRoutes handles single-user
- `frontend/src/api/client.js` — mode API + token-optional exports
- `frontend/src/components/AppNav.jsx` — hide logout
- `frontend/src/pages/HomeScreen.jsx` — hide social portal + logout
- `frontend/src/pages/Leaderboard.jsx` — redirect if !multiUser
- `frontend/src/pages/Compare.jsx` — redirect if !multiUser
- `frontend/src/pages/Achievements.jsx` — redirect if !multiUser
- `frontend/src/pages/Login.jsx` — redirect if !multiUser
- `frontend/src/pages/Settings.jsx` — toggle + hide Users tab
- `frontend/src/i18n/de.js` + `en.js` — 3 new keys each