### PR TITLE
fix: language toggle stretching full width

### DIFF
--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -76,7 +76,7 @@ function Toggle({ value, onChange }) {
 function SegmentedControl({ value, options, onChange }) {
   return (
     <div
-      className="flex rounded-lg overflow-hidden"
+      className="flex w-fit rounded-lg overflow-hidden"
       style={{ border: '1px solid rgba(255,255,255,0.1)' }}
     >
       {options.map((opt, i) => (


### PR DESCRIPTION
Adds `w-fit` to the `SegmentedControl` container so the DE/EN toggle shrinks to its content instead of filling the entire row width.

1-line CSS fix.