### PR TITLE
feat: profile name editing in Settings

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -233,3 +233,18 @@ def change_avatar(data: dict, current_user: User = Depends(get_current_user), db
     current_user.avatar_id = avatar_id
     db.commit()
     return {"id": current_user.id, "username": current_user.username, "role": current_user.role, "avatar_id": current_user.avatar_id}
+
+
+@router.put("/me/username")
+def change_username(data: dict, current_user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    new_username = (data.get("username") or "").strip()
+    if not new_username or len(new_username) < 2:
+        raise HTTPException(status_code=400, detail="Username must be at least 2 characters")
+    if len(new_username) > 32:
+        raise HTTPException(status_code=400, detail="Username must be at most 32 characters")
+    existing = db.query(User).filter(User.username == new_username, User.id != current_user.id).first()
+    if existing:
+        raise HTTPException(status_code=409, detail="Username already taken")
+    current_user.username = new_username
+    db.commit()
+    return {"id": current_user.id, "username": current_user.username, "role": current_user.role, "avatar_id": current_user.avatar_id}

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -49,6 +49,7 @@ export const updateUser = (id, data) => api.put(`/auth/users/${id}`, data).then(
 export const deleteUser = (id) => api.delete(`/auth/users/${id}`).then(r => r.data)
 export const changePassword = (data) => api.put('/auth/me/password', data).then(r => r.data)
 export const changeAvatar = (avatarId) => api.put('/auth/me/avatar', { avatar_id: avatarId }).then(r => r.data)
+export const changeUsername = (username) => api.put('/auth/me/username', { username }).then(r => r.data)
 
 // Cards
 export const searchCards = (params) => api.get('/cards/search', { params })

--- a/frontend/src/i18n/de.js
+++ b/frontend/src/i18n/de.js
@@ -474,6 +474,8 @@ const de = {
     // Settings page row labels
     multiUserMode: 'Mehrspieler-Modus',
     multiUserModeDesc: 'Login-Bildschirm und Benutzerverwaltung aktivieren',
+    username: 'Benutzername',
+    usernameDesc: 'Dein angezeigter Name',
     trainerName: 'Trainer-Name',
     trainerNameDesc: 'Wird auf dem Startbildschirm angezeigt',
     languageDesc: 'App-Sprache ändern',

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -474,6 +474,8 @@ const en = {
     // Settings page row labels
     multiUserMode: 'Multi-User Mode',
     multiUserModeDesc: 'Enable login screen and user management',
+    username: 'Username',
+    usernameDesc: 'Your display name',
     trainerName: 'Trainer Name',
     trainerNameDesc: 'Displayed on the home screen',
     languageDesc: 'Change app language',

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -5,7 +5,7 @@ import {
   getSyncStatus, triggerSync, triggerPriceSync, rescheduleFullSync, reschedulePriceSync,
   downloadBackup, restoreBackup, exportCSV,
   getSetting, setSetting, getTelegramStatus, saveSettings, setAuthMode,
-  getUsers, createUser, updateUser, deleteUser, changePassword, changeAvatar,
+  getUsers, createUser, updateUser, deleteUser, changePassword, changeAvatar, changeUsername,
 } from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
 import { useTheme } from '../hooks/useTheme'
@@ -122,6 +122,8 @@ export default function Settings() {
   const fileInputRef = useRef(null)
   const [restoring, setRestoring] = useState(false)
   const [showAvatarPicker, setShowAvatarPicker] = useState(false)
+  const [editingUsername, setEditingUsername] = useState(false)
+  const [usernameInput, setUsernameInput] = useState('')
   const queryClient = useQueryClient()
   const { user, updateCurrentUser, multiUser } = useAuth()
   const { settings, updateSettings, t } = useSettings()
@@ -340,6 +342,16 @@ export default function Settings() {
   const currentCurrency = settings.currency || 'EUR'
   const currentPriceType = settings.price_primary || 'trend'
 
+  const usernameMutation = useMutation({
+    mutationFn: (username) => changeUsername(username),
+    onSuccess: (updatedUser) => {
+      updateCurrentUser(updatedUser)
+      setEditingUsername(false)
+      toast.success(t('common.saved'))
+    },
+    onError: () => toast.error(t('common.error')),
+  })
+
   const handleAvatarSelect = (avatarId) => {
     avatarMutation.mutate(avatarId)
   }
@@ -382,7 +394,6 @@ export default function Settings() {
               <SettingsRow
                 label={t('auth.chooseAvatar')}
                 description={user?.username || 'Trainer'}
-                last
               >
                 <button
                   type="button"
@@ -404,6 +415,34 @@ export default function Settings() {
                     {avatarMutation.isPending ? t('common.loading') : t('common.edit')}
                   </span>
                 </button>
+              </SettingsRow>
+              <SettingsRow label={t('settings.username')} description={t('settings.usernameDesc')} last>
+                {editingUsername ? (
+                  <form className="flex items-center gap-2" onSubmit={(e) => { e.preventDefault(); usernameInput.trim() && usernameMutation.mutate(usernameInput.trim()) }}>
+                    <input
+                      type="text"
+                      value={usernameInput}
+                      onChange={(e) => setUsernameInput(e.target.value)}
+                      className="w-32 rounded-lg border border-border bg-bg-primary px-2 py-1.5 text-xs text-text-primary outline-none focus:border-brand-red"
+                      autoFocus
+                      maxLength={32}
+                    />
+                    <button type="submit" disabled={usernameMutation.isPending} className="rounded-lg bg-brand-red px-2 py-1.5 text-xs font-semibold text-white">
+                      {usernameMutation.isPending ? '...' : '✓'}
+                    </button>
+                    <button type="button" onClick={() => setEditingUsername(false)} className="rounded-lg border border-border px-2 py-1.5 text-xs text-text-muted">
+                      ✕
+                    </button>
+                  </form>
+                ) : (
+                  <button
+                    onClick={() => { setUsernameInput(user?.username || ''); setEditingUsername(true) }}
+                    className="flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-semibold text-text-primary transition-colors hover:border-brand-red/50"
+                  >
+                    <Pencil size={12} />
+                    {user?.username || 'Trainer'}
+                  </button>
+                )}
               </SettingsRow>
 
             </SettingsCard>


### PR DESCRIPTION
Adds a username edit field in the Trainer section of Settings, so users can change their display name — including in single-user mode.

### Changes
- **Backend**: `PUT /api/auth/me/username` — validates 2-32 chars, checks uniqueness
- **Frontend**: Inline edit button with text input + confirm/cancel in Trainer section
- **i18n**: DE (Benutzername) + EN (Username) keys

Works in both single-user and multi-user mode.