### PR TITLE
feat: Reverse Holo now uses Cardmarket holo prices

### DIFF
--- a/backend/api/analytics.py
+++ b/backend/api/analytics.py
@@ -10,7 +10,7 @@ import datetime
 router = APIRouter()
 
 # Variants that use the Cardmarket holo price family
-HOLO_VARIANTS = {"Holo", "Holo Rare", "Holo V", "Holo VMAX", "Holo VSTAR", "Holo ex"}
+HOLO_VARIANTS = {"Holo", "Holo Rare", "Holo V", "Holo VMAX", "Holo VSTAR", "Holo ex", "Reverse Holo"}
 
 
 def _get_item_price(item):
@@ -18,7 +18,6 @@ def _get_item_price(item):
     card = item.card
     if not card:
         return 0
-    # Reverse Holo: uses standard non-holo CM price (reverse premium is TCGPlayer/USD only)
     if item.variant in HOLO_VARIANTS and card.price_market_holo is not None:
         return card.price_market_holo
     return card.price_market or 0

--- a/backend/api/collection.py
+++ b/backend/api/collection.py
@@ -11,7 +11,7 @@ import datetime
 router = APIRouter()
 
 # Variants that use the Cardmarket holo price family
-HOLO_VARIANTS = {"Holo", "Holo Rare", "Holo V", "Holo VMAX", "Holo VSTAR", "Holo ex"}
+HOLO_VARIANTS = {"Holo", "Holo Rare", "Holo V", "Holo VMAX", "Holo VSTAR", "Holo ex", "Reverse Holo"}
 
 
 def _get_item_price(item):
@@ -19,7 +19,6 @@ def _get_item_price(item):
     card = item.card
     if not card:
         return 0
-    # Reverse Holo: uses standard non-holo CM price (reverse premium is TCGPlayer/USD only)
     if item.variant in HOLO_VARIANTS and card.price_market_holo is not None:
         return card.price_market_holo
     return card.price_market or 0

--- a/backend/api/dashboard.py
+++ b/backend/api/dashboard.py
@@ -12,7 +12,7 @@ router = APIRouter()
 VALID_PRICE_FIELDS = {"price_market", "price_trend", "price_avg1", "price_avg7", "price_avg30"}
 
 # Variants that use the Cardmarket holo price family
-HOLO_VARIANTS = {"Holo", "Holo Rare", "Holo V", "Holo VMAX", "Holo VSTAR", "Holo ex"}
+HOLO_VARIANTS = {"Holo", "Holo Rare", "Holo V", "Holo VMAX", "Holo VSTAR", "Holo ex", "Reverse Holo"}
 
 # Maps each standard price field to its holo equivalent
 HOLO_FIELD_MAP = {


### PR DESCRIPTION
This change ensures that "Reverse Holo" variants utilize the dedicated Cardmarket holo price fields for value calculations, aligning with user expectations for a premium on these variants.

### Changes
- **Updated `HOLO_VARIANTS` sets**: Added `"Reverse Holo"` to the `HOLO_VARIANTS` set in `backend/api/dashboard.py`, `backend/api/collection.py`, and `backend/api/analytics.py`. This means the pricing logic will now look for `price_market_holo`, `price_trend_holo`, etc., for Reverse Holo cards.
- **Removed outdated comments**: Deleted the comments in `backend/api/collection.py` and `backend/api/analytics.py` that stated: `# Reverse Holo: uses standard non-holo CM price (reverse premium is TCGPlayer/USD only)`. This comment is no longer accurate after the change.

### Impact
- "Reverse Holo" cards will now show their specific Cardmarket holo prices where available, instead of falling back to non-holo prices.
- This primarily affects Cardmarket (EUR) price calculations within the app, as TCGPlayer (USD) already distinguishes between Holofoil and Reverse Holofoil prices.