### PR TITLE
docs: comprehensive README update + remove dead VITE_API_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 Everything below (and in this repo) is unapologetically vibecoded.
 Expect vibes, not guarantees. Proceed with good humor and version control.  
 
-Contributions are welcome. Open a pull request for fixes, features, or docs. Not sure where to start? Open an issue and we’ll chat. Small improvements are great.
+Contributions are welcome. Open a pull request for fixes, features, or docs. Not sure where to start? Open an issue and we'll chat. Small improvements are great.
 
 Found a bug or have an idea? Open an issue. Include steps to reproduce, expected vs. actual behavior. Screenshots or logs help.
 
-Fork, branch, and submit a focused PR. Add or update tests and docs as needed. Explain the “why” and link related issues. Make sure checks pass.
+Fork, branch, and submit a focused PR. Add or update tests and docs as needed. Explain the "why" and link related issues. Make sure checks pass.
 
 Be kind. Be clear. Assume good intent. Keep feedback constructive.
 
@@ -22,7 +22,7 @@ Be kind. Be clear. Assume good intent. Keep feedback constructive.
 ## ✨ Features
 
 ### 📦 Collection Management
-- Add cards with **quantity**, **condition** (Mint / NM / LP / MP / HP), **variant** (Holo, Reverse Holo, First Edition, Alt Art, etc.), **purchase price**, and **grade** (PSA, BGS, CGC)
+- Add cards with **quantity**, **condition** (Mint / NM / LP / MP / HP), **variant** (Holo, Reverse Holo, First Edition, Alt Art, etc.), and **purchase price**
 - Track **German and English** card versions separately
 - Manually create custom cards not in TCGdex
 
@@ -65,19 +65,22 @@ Be kind. Be clear. Assume good intent. Keep feedback constructive.
 - Collection binder type: only shows cards you own
 - Checklist binder type: shows all cards, highlights owned ones
 
-### 👥 Multi-User
-- Multiple user accounts with JWT authentication
-- Admin and Trainer roles
-- Per-user collections, wishlists, and portfolio tracking
-- Animated Pokémon avatar selection (Gen 1 sprites)
+### 👤 Single-User & Multi-User Mode
+- **Single-user mode** (default): no login required, auto-authenticates as admin
+- **Multi-user mode**: enable in Settings → toggle requires admin privileges
+  - Multiple user accounts with JWT authentication
+  - Admin and Trainer roles
+  - Per-user collections, wishlists, and portfolio tracking
+  - Animated Pokémon avatar selection (Gen 1 sprites)
+  - Auto-detected if more than one user exists
 
-### 🏆 Social Features
+### 🏆 Social Features (Multi-User only)
 - **Trainer Leaderboard**: ranked by portfolio value, cards, P&L
 - **Trainer Comparison**: side-by-side stats, card overlap, trade suggestions
 - **Achievements**: 20 badges (PokeAPI gym badge sprites) with progress tracking
 
 ### 🎨 Themes
-- 9 Pokémon-type color themes (Fire, Water, Grass, Electric, Psychic, Dragon, Dark, Fairy)
+- 9 Pokémon-type color themes (Default, Fire, Water, Grass, Electric, Psychic, Dragon, Dark, Fairy)
 - Instant switch, stored per device
 
 ### 🖼️ Image Cache
@@ -89,6 +92,7 @@ Be kind. Be clear. Assume good intent. Keep feedback constructive.
 - **Language**: German / English UI
 - **Primary Price**: choose which Cardmarket price drives your portfolio value
 - **Currency**: EUR or USD (live exchange rate via Frankfurter API)
+- **Profile**: change username and avatar
 - **Export**: CSV or PDF of your full collection
 - **Backup / Restore**: full PostgreSQL dump and restore
 - **Sync**: manual trigger or automatic (configurable interval)
@@ -99,34 +103,45 @@ Be kind. Be clear. Assume good intent. Keep feedback constructive.
 
 ### Prerequisites
 - [Docker](https://docs.docker.com/get-docker/) + [Docker Compose](https://docs.docker.com/compose/)
+- Alternatively: download the code as ZIP from the [GitHub repo](https://github.com/Git-Romer/pokecollector) (green "Code" button → "Download ZIP")
 
 ### 1. Clone & Configure
 
 ```bash
 git clone https://github.com/Git-Romer/pokecollector.git
 cd pokecollector
-cp .env.example .env   # create if not present
 ```
 
-Edit `.env`:
+Create a `.env` file in the project root:
+
 ```env
+# Required
 POSTGRES_PASSWORD=your_secure_password
 
-# Optional — for price alert Telegram notifications
+# Recommended — keeps users logged in across container restarts
+JWT_SECRET_KEY=some_long_random_string
+
+# Optional — Telegram notifications for price alerts
 TELEGRAM_BOT_TOKEN=your_bot_token
 TELEGRAM_CHAT_ID=your_chat_id
 
-# Optional — for AI card recognition
+# Optional — AI card recognition (Google Gemini)
 GEMINI_API_KEY=your_gemini_key
+
+# Optional — customise the auto-created admin account
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=your_admin_password
 ```
 
-> No TCGdex API key required — it's a free open API.
+> **Note:** No TCGdex API key required — it's a free, open API.
 
 ### 2. Start
 
 ```bash
 docker compose up -d
 ```
+
+First launch takes 2–5 minutes while Docker downloads images and builds the app.
 
 ### 3. Open
 
@@ -135,9 +150,45 @@ docker compose up -d
 | App | http://localhost:3000 |
 | API docs | http://localhost:8000/docs |
 
+> Running on a different machine (e.g. a Raspberry Pi)? Use its IP address instead: `http://<ip>:3000`
+
 ### 4. First Sync
 
-On first launch the app is empty. Go to **Settings → Run Sync Now** (or click the 🔄 sync button on the home screen) to fetch all sets and cards from TCGdex. This takes 1–3 minutes.
+On first launch the app is empty. Click the 🔄 sync button on the home screen to fetch all sets and cards from TCGdex. This takes 1–3 minutes.
+
+### 5. Login
+
+On first start, an admin account is automatically created:
+- **Username**: `admin` (or whatever you set in `ADMIN_USERNAME`)
+- **Password**: check the backend logs (`docker compose logs backend`) or set it via `ADMIN_PASSWORD` in `.env`
+- In **single-user mode** (default), no login is required
+
+---
+
+## 🔧 Environment Variables
+
+### Required
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `POSTGRES_PASSWORD` | PostgreSQL database password | `changeme` |
+
+### Recommended
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `JWT_SECRET_KEY` | Secret for signing JWT tokens. If not set, a random key is generated on each restart — **all users will be logged out** when the container restarts. | Random per restart |
+
+### Optional
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TELEGRAM_BOT_TOKEN` | Telegram bot token for price alert notifications | *(empty)* |
+| `TELEGRAM_CHAT_ID` | Telegram chat ID for notifications | *(empty)* |
+| `GEMINI_API_KEY` | Google Gemini API key for AI card scanner (can also be set in Settings UI) | *(empty)* |
+| `ADMIN_USERNAME` | Username for the auto-created admin account | `admin` |
+| `ADMIN_PASSWORD` | Password for the admin account. If not set, a random password is generated and printed to the backend logs. | Random (logged) |
+| `ADMIN_BOOTSTRAP_LOG` | Whether to log admin credentials on first start | `true` |
 
 ---
 
@@ -146,19 +197,24 @@ On first launch the app is empty. Go to **Settings → Run Sync Now** (or click 
 ```
 pokecollector/
 ├── backend/         # Python FastAPI + PostgreSQL
-│   ├── api/         # Route handlers (sets, cards, collection, analytics, …)
-│   ├── services/    # TCGdex client, sync logic, scheduler, notifications
+│   ├── api/         # Route handlers (auth, cards, collection, analytics, social, …)
+│   ├── services/    # TCGdex client, sync logic, scheduler, notifications, auth
 │   ├── models.py    # SQLAlchemy ORM
 │   ├── schemas.py   # Pydantic schemas
 │   └── database.py  # DB engine + idempotent migrations
 ├── frontend/        # React 18 + Vite + Tailwind CSS
-│   └── src/
-│       ├── pages/   # Route pages
-│       ├── components/
-│       ├── contexts/ # SettingsContext (i18n, price config, currency)
-│       └── api/     # Axios client
+│   ├── src/
+│   │   ├── pages/       # Route pages (HomeScreen, Collection, Analytics, …)
+│   │   ├── components/  # Reusable components (AppNav, TabNav, PokeBallLoader, …)
+│   │   ├── contexts/    # AuthContext, SettingsContext
+│   │   ├── hooks/       # useTheme, …
+│   │   ├── i18n/        # German + English translations
+│   │   └── api/         # Axios client
+│   └── nginx.conf       # Reverse proxy (serves frontend + proxies /api/ to backend)
 └── docker-compose.yml
 ```
+
+The frontend is served by **Nginx** which also acts as a reverse proxy — all `/api/` requests are forwarded to the FastAPI backend. This means the app only needs **one URL** (port 3000) for both frontend and API.
 
 See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full deep-dive.
 
@@ -173,6 +229,7 @@ See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full deep-dive.
 | Database | PostgreSQL 15 |
 | Card Data | [TCGdex](https://tcgdex.net/) — free, no API key |
 | Prices | Cardmarket EUR + TCGPlayer USD (via TCGdex pricing) |
+| AI Scanner | Google Gemini 2.5 Flash (optional) |
 | Deploy | Docker + Docker Compose |
 
 ---
@@ -196,8 +253,24 @@ All settings are persisted in the database and editable via the Settings page:
 | Language | `de` | `de`, `en` |
 | Primary Price | `trend` | `trend`, `avg1`, `avg7`, `avg30`, `low`, `market` |
 | Currency | `EUR` | `EUR`, `USD` |
+| Multi-User Mode | `off` | Toggle in Settings (admin only) |
+| Theme | Default | Default, Fire, Water, Grass, Electric, Psychic, Dragon, Dark, Fairy |
 | Auto-sync interval | 30 min | Configurable |
 | Full sync interval | 5 days | Configurable |
+
+---
+
+## 🔄 Updating
+
+To update to the latest version:
+
+```bash
+cd pokecollector
+git pull
+docker compose up -d --build
+```
+
+Database migrations run automatically on startup — no manual steps needed.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,6 @@ services:
   frontend:
     build:
       context: ./frontend
-      args:
-        VITE_API_URL: ""
     container_name: pokemon-frontend
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
## README overhaul

### Added
- **Environment Variables section** with Required / Recommended / Optional tables
  - `JWT_SECRET_KEY` — prevents logout on container restart
  - `ADMIN_USERNAME` / `ADMIN_PASSWORD` — customise auto-created admin
  - `ADMIN_BOOTSTRAP_LOG` — control credential logging
  - `GEMINI_API_KEY` — AI card scanner
- **Single-user vs Multi-user mode** documentation
- **Login / First-start instructions** (where to find admin password)
- **Updating section** (`git pull && docker compose up -d --build`)
- Nginx reverse proxy architecture explanation
- Note about accessing from other machines via IP
- Theme list, profile editing, social features context

### Changed
- Restructured Quick Start to be more beginner-friendly
- Configuration Reference now includes Multi-User Mode and Themes
- Architecture tree updated with current directory structure
- Removed grading references (feature was removed in PR #71)

### Removed
- `VITE_API_URL` build arg from `docker-compose.yml` — it was never used (no `ARG` in Dockerfile, no reference in frontend code)

### Files
- `README.md` — +96 / -25 lines
- `docker-compose.yml` — removed 2 dead lines