### PR TITLE
fix: address issues from #79 (Safari styling, performance, collection search)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full deep-dive.
 | Frontend | React 18, Vite, Tailwind CSS, TanStack Query, Recharts, Lucide Icons |
 | Backend | Python 3.11, FastAPI, SQLAlchemy, APScheduler, Pydantic |
 | Database | PostgreSQL 15 |
-| Card Data | [TCGdex](https://tcgdex.net/) — free, no API key |
+| Card Data | [TCGdex](https://tcgdex.dev/) — free, no API key |
 | Prices | Cardmarket EUR + TCGPlayer USD (via TCGdex pricing) |
 | AI Scanner | Google Gemini 2.5 Flash (optional) |
 | Deploy | Docker + Docker Compose |

--- a/frontend/src/components/CardItem.jsx
+++ b/frontend/src/components/CardItem.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, memo } from 'react'
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query'
 import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
 import { Plus, Check, Heart, BookOpen, X, PenLine, Pencil,  Trash2 } from 'lucide-react'
@@ -103,7 +103,6 @@ export function CustomCardModal({ onClose, onCreated, sets: setsProp = [], autoA
     onSuccess: (res) => {
       toast.success(t('settings.cardUpdated'))
       queryClient.invalidateQueries({ queryKey: ['collection'] })
-      queryClient.invalidateQueries({ queryKey: ['card-search'] })
       onCreated && onCreated(res)
       onClose()
     },
@@ -118,7 +117,6 @@ export function CustomCardModal({ onClose, onCreated, sets: setsProp = [], autoA
     onSuccess: (res) => {
       toast.success(res?.data?.message || t('common.success'))
       queryClient.invalidateQueries({ queryKey: ['collection'] })
-      queryClient.invalidateQueries({ queryKey: ['card-search'] })
       queryClient.invalidateQueries({ queryKey: ['custom-cards'] })
       onClose()
     },
@@ -362,7 +360,7 @@ export function CustomCardModal({ onClose, onCreated, sets: setsProp = [], autoA
   )
 }
 
-export function CardItem({ card, showActions = true, onAddToBinder = null, compact = false, lang = null }) {
+export const CardItem = memo(function CardItem({ card, showActions = true, onAddToBinder = null, compact = false, lang = null }) {
   const [showModal, setShowModal] = useState(false)
   const [showEditModal, setShowEditModal] = useState(false)
   const { t, pricePrimary, formatPrice } = useSettings()
@@ -512,7 +510,7 @@ export function CardItem({ card, showActions = true, onAddToBinder = null, compa
       )}
     </>
   )
-}
+})
 
 const CARD_VARIANTS = [
   'Normal', 'Holo', 'Reverse Holo', 'First Edition', 'Double Rare',

--- a/frontend/src/hooks/useTilt.js
+++ b/frontend/src/hooks/useTilt.js
@@ -16,7 +16,16 @@ import { useRef, useCallback, useEffect } from 'react'
  * Callers must wire up all four handlers (onMouseEnter is new).
  */
 export function useTilt(maxTilt = 10, lerpFactor = 0.1) {
-  const ref       = useRef(null)
+  const ref = useRef(null)
+
+  // Disable tilt on touch devices; no visual benefit and worse scroll performance.
+  const isTouchDevice =
+    typeof window !== 'undefined' && ('ontouchstart' in window || navigator.maxTouchPoints > 0)
+
+  if (isTouchDevice) {
+    return { ref, onMouseMove: () => {}, onMouseEnter: () => {}, onMouseLeave: () => {} }
+  }
+
   const rafRef    = useRef(null)
   const hovered   = useRef(false)
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -32,6 +32,15 @@
   --bottom-nav-height: 4rem; /* 64px */
 }
 
+/* Safari autofill override */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus {
+  -webkit-text-fill-color: var(--color-text-primary);
+  -webkit-box-shadow: 0 0 0px 1000px var(--color-bg) inset;
+  transition: background-color 5000s ease-in-out 0s;
+}
+
 /* ─── Scrollbar — premium dark ───────────────────────────────────────────── */
 * {
   scrollbar-width: thin;

--- a/frontend/src/pages/Collection.jsx
+++ b/frontend/src/pages/Collection.jsx
@@ -411,7 +411,23 @@ export default function Collection() {
       if (filterMinPrice && marketPrice < parseFloat(filterMinPrice)) return false
       if (filterMaxPrice && marketPrice > parseFloat(filterMaxPrice)) return false
       if (filterDuplicates && item.quantity < 2) return false
-      if (searchText && !card?.name.toLowerCase().includes(searchText.toLowerCase())) return false
+      if (searchText) {
+        const q = searchText.toLowerCase().trim()
+        const nameMatch = card?.name?.toLowerCase().includes(q)
+        const setMatch = card?.set_name?.toLowerCase().includes(q) || card?.set?.name?.toLowerCase().includes(q)
+        const numberMatch = card?.number?.toString() === q || card?.localId?.toString() === q
+        // Support "SET NUMBER" shortcode (e.g. "SV1 001")
+        const codeMatch = /^([A-Za-z]+\d*)\s+(\d+)$/.exec(q)
+        let shortcodeMatch = false
+        if (codeMatch) {
+          const [, setCode, num] = codeMatch
+          const normalizedNum = String(parseInt(num, 10))
+          const cardSetId = (card?.set_id || card?.set?.id || "").toLowerCase()
+          const cardNum = (card?.number || card?.localId || "").toString().replace(/^0+/, "") || "0"
+          shortcodeMatch = cardSetId.includes(setCode) && cardNum === normalizedNum
+        }
+        if (!nameMatch && !setMatch && !numberMatch && !shortcodeMatch) return false
+      }
       return true
     })
 

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -424,6 +424,7 @@ export default function Settings() {
                       value={usernameInput}
                       onChange={(e) => setUsernameInput(e.target.value)}
                       className="w-32 rounded-lg border border-border bg-bg-primary px-2 py-1.5 text-xs text-text-primary outline-none focus:border-brand-red"
+                      style={{ WebkitTextFillColor: "var(--color-text-primary)", WebkitBoxShadow: "0 0 0px 1000px var(--color-bg) inset" }}
                       autoFocus
                       maxLength={32}
                     />


### PR DESCRIPTION
Addresses several issues reported in #79.

### Fixes included

| # | Issue | Fix |
|---|-------|-----|
| 1 | White text on white background (Safari input) | Global `-webkit-autofill` CSS override + inline style on username input |
| 2 | Page becomes unresponsive after searching/adding cards | Removed unnecessary `invalidateQueries(["card-search"])` on add-to-collection (search results dont change) |
| 2 | (cont.) | Wrapped `CardItem` in `React.memo` — unchanged cards skip re-render |
| 2 | (cont.) | Disabled `useTilt` on touch devices — CSS transforms on mouse events cause layout thrashing on Safari iOS |
| 4 | Collection search doesnt find by set + number | Search now matches: card name, set name, card number, and `SET NUMBER` shortcode (e.g. `SV1 001`) |
| 6 | TCGdex link broken | `tcgdex.net` → `tcgdex.dev` in README |

### Files changed (6)
- `frontend/src/index.css` — Safari autofill override
- `frontend/src/pages/Settings.jsx` — inline webkit style on username input
- `frontend/src/components/CardItem.jsx` — `React.memo` wrapper + removed card-search invalidation
- `frontend/src/hooks/useTilt.js` — touch device detection, early return with no-ops
- `frontend/src/pages/Collection.jsx` — expanded search filter (name + set + number + shortcode)
- `README.md` — TCGdex link fix

### Not addressed here (needs manual response)
- **#3** (SVP 208 Victini) — TCGdex data limitation, not a code issue
- **#5** (Set dropdown on mobile) — native `<select>` limitation, would need combobox component