### PR TITLE
feat: split variant/rarity — auto-preselect variants from TCGdex

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,7 +1,9 @@
-from sqlalchemy import create_engine
+import logging
+import os
+
+from sqlalchemy import create_engine, text
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-import os
 
 DATABASE_URL = os.getenv(
     "DATABASE_URL",
@@ -11,6 +13,7 @@ DATABASE_URL = os.getenv(
 engine = create_engine(DATABASE_URL, pool_pre_ping=True, pool_size=10, max_overflow=20)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
+logger = logging.getLogger(__name__)
 
 
 def get_db():
@@ -31,7 +34,6 @@ DEFAULT_SETTINGS = {
 
 def _run_migrations(conn):
     """Apply any schema migrations that cannot be handled by create_all."""
-    from sqlalchemy import text
     migrations = [
         # Add abbreviation column to sets table (safe — PostgreSQL IF NOT EXISTS)
         "ALTER TABLE sets ADD COLUMN IF NOT EXISTS abbreviation VARCHAR",
@@ -173,6 +175,83 @@ def _run_migrations(conn):
             conn.rollback()
 
 
+def migrate_collection_variants():
+    """Move rarity-like values out of collection.variant without creating key collisions."""
+    rarity_values = (
+        "Double Rare", "Full Art", "Alt Art", "Gold", "Rainbow",
+        "Illustration Rare", "Special Illustration Rare", "Crown Rare",
+        "Promo", "Art Rare", "Ultra Rare", "Secret Rare", "Shiny",
+    )
+    placeholders = ",".join([f":v{i}" for i in range(len(rarity_values))])
+    params = {f"v{i}": value for i, value in enumerate(rarity_values)}
+
+    db = SessionLocal()
+    try:
+        rows = db.execute(text(f"""
+            SELECT
+                c.id,
+                c.card_id,
+                c.lang,
+                c.variant,
+                cards.variants_holo,
+                cards.variants_normal,
+                cards.variants_reverse
+            FROM collection c
+            LEFT JOIN cards ON cards.id = c.card_id
+            WHERE c.variant IN ({placeholders})
+            ORDER BY c.id
+        """), params).fetchall()
+
+        if not rows:
+            return
+
+        existing_targets = {
+            (row.card_id, row.lang, row.variant)
+            for row in db.execute(text(f"""
+                SELECT card_id, lang, variant
+                FROM collection
+                WHERE variant IS NOT NULL
+                  AND variant NOT IN ({placeholders})
+            """), params).fetchall()
+        }
+
+        migrated = 0
+        skipped = 0
+        reserved_targets = set()
+
+        for row in rows:
+            target_variant = None
+            if row.variants_normal:
+                target_variant = "Normal"
+            elif row.variants_holo and not row.variants_normal:
+                target_variant = "Holo"
+
+            if target_variant is not None:
+                target_key = (row.card_id, row.lang, target_variant)
+                if target_key in existing_targets or target_key in reserved_targets:
+                    skipped += 1
+                    continue
+                reserved_targets.add(target_key)
+
+            db.execute(
+                text("UPDATE collection SET variant = :variant WHERE id = :id"),
+                {"id": row.id, "variant": target_variant},
+            )
+            migrated += 1
+
+        db.commit()
+        logger.info(
+            "migrate_collection_variants: migrated %s row(s), skipped %s duplicate-conflicting row(s)",
+            migrated,
+            skipped,
+        )
+    except Exception as e:
+        db.rollback()
+        logger.warning("migrate_collection_variants: migration aborted: %s", e)
+    finally:
+        db.close()
+
+
 def migrate_card_ids():
     """Migrate card IDs from plain TCGdex format (e.g. 'sv1-1') to composite format (e.g. 'sv1-1_de').
 
@@ -276,6 +355,12 @@ def init_db():
     # Migrate card IDs to composite format (idempotent)
     try:
         migrate_card_ids()
+    except Exception:
+        pass  # Non-blocking
+
+    # Migrate old rarity-like variant values to physical variants (idempotent)
+    try:
+        migrate_collection_variants()
     except Exception:
         pass  # Non-blocking
 

--- a/frontend/src/components/CardItem.jsx
+++ b/frontend/src/components/CardItem.jsx
@@ -512,18 +512,24 @@ export const CardItem = memo(function CardItem({ card, showActions = true, onAdd
   )
 })
 
-const CARD_VARIANTS = [
-  'Normal', 'Holo', 'Reverse Holo', 'First Edition', 'Double Rare',
-  'Full Art', 'Alt Art', 'Gold', 'Rainbow',
-  'Illustration Rare', 'Special Illustration Rare', 'Crown Rare', 'Promo',
-  'Art Rare', 'Ultra Rare', 'Secret Rare', 'Shiny',
-]
+const CARD_VARIANTS = ['Normal', 'Holo', 'Reverse Holo', 'First Edition']
 
 
 export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
   const [quantity, setQuantity] = useState(1)
   const [condition, setCondition] = useState('NM')
-  const [variant, setVariant] = useState('')
+  const [variant, setVariant] = useState(() => {
+    const hasNormal = card.variants_normal
+    const hasReverse = card.variants_reverse
+    const hasHolo = card.variants_holo
+    const hasFirst = card.variants_first_edition
+
+    const available = [hasNormal && 'Normal', hasReverse && 'Reverse Holo', hasHolo && 'Holo', hasFirst && 'First Edition'].filter(Boolean)
+
+    if (available.length === 1) return available[0]
+    if (hasHolo && !hasNormal && !hasReverse) return 'Holo'
+    return ''
+  })
   const [purchasePrice, setPurchasePrice] = useState('')
   const [modalPeriod, setModalPeriod] = useState('total')
   const [resolvedCardId, setResolvedCardId] = useState(card.id)
@@ -832,7 +838,28 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
                   <option value="">{t('variants.none')}</option>
                   {CARD_VARIANTS.map(v => <option key={v} value={v}>{v}</option>)}
                 </select>
+                {(() => {
+                  const available = [
+                    card.variants_normal && 'Normal',
+                    card.variants_reverse && 'Reverse Holo',
+                    card.variants_holo && 'Holo',
+                    card.variants_first_edition && 'First Edition',
+                  ].filter(Boolean)
+                  return available.length > 0 ? (
+                    <p className="text-[10px] text-text-muted mt-1">
+                      📋 {t('card.availableVariants')}: {available.join(', ')}
+                    </p>
+                  ) : null
+                })()}
               </div>
+              {card.rarity && (
+                <div>
+                  <label className="text-xs text-text-muted mb-1 block font-medium">💎 {t('card.rarity')}</label>
+                  <p className="text-sm text-text-primary font-medium px-3 py-1.5 rounded-lg bg-bg-card border border-border">
+                    {card.rarity}
+                  </p>
+                </div>
+              )}
               <div>
                 <label className="text-xs text-text-muted mb-1 block">{t('card.purchasePrice')}</label>
                 <input type="number" step="0.01" min="0" placeholder={t('card.purchasePricePlaceholder')}

--- a/frontend/src/components/CardScanner.jsx
+++ b/frontend/src/components/CardScanner.jsx
@@ -6,11 +6,7 @@ import { useSettings } from '../contexts/SettingsContext'
 import toast from 'react-hot-toast'
 import clsx from 'clsx'
 
-const CARD_VARIANTS = [
-  'Normal', 'Holo', 'Reverse Holo', 'Full Art', 'Alt Art', 'Gold', 'Rainbow',
-  'Illustration Rare', 'Special Illustration Rare', 'Crown Rare', 'Promo',
-  'Art Rare', 'Ultra Rare', 'Secret Rare', 'Shiny',
-]
+const CARD_VARIANTS = ['Normal', 'Holo', 'Reverse Holo', 'First Edition']
 
 // ─── Add-to-Collection Modal für Scan-Ergebnis ──────────────────────────────
 function ScanAddModal({ match, defaultLang, onClose, onAdded }) {
@@ -124,7 +120,7 @@ function ScanAddModal({ match, defaultLang, onClose, onAdded }) {
             <div>
               <label className="text-xs text-text-muted mb-1 block">✨ {t('card.variant')}</label>
               <select value={variant} onChange={e => setVariant(e.target.value)} className="select">
-                <option value="">{t('common.none')}</option>
+                <option value="">{t('variants.none')}</option>
                 {CARD_VARIANTS.map(v => <option key={v} value={v}>{v}</option>)}
               </select>
             </div>

--- a/frontend/src/i18n/de.js
+++ b/frontend/src/i18n/de.js
@@ -624,6 +624,7 @@ const de = {
   // Card modal
   card: {
     rarity: 'Seltenheit',
+    availableVariants: 'Verfügbar',
     type: 'Typ',
     hp: 'HP',
     artist: 'Illustrator',
@@ -688,6 +689,7 @@ const de = {
     Normal: 'Normal',
     Holo: 'Holo',
     'Reverse Holo': 'Reverse Holo',
+    'First Edition': 'First Edition',
     'Full Art': 'Full Art',
     'Alt Art': 'Alt Art',
     Gold: 'Gold',

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -624,6 +624,7 @@ const en = {
   // Card modal
   card: {
     rarity: 'Rarity',
+    availableVariants: 'Available',
     type: 'Type',
     hp: 'HP',
     artist: 'Artist',
@@ -688,6 +689,7 @@ const en = {
     Normal: 'Normal',
     Holo: 'Holo',
     'Reverse Holo': 'Reverse Holo',
+    'First Edition': 'First Edition',
     'Full Art': 'Full Art',
     'Alt Art': 'Alt Art',
     Gold: 'Gold',

--- a/frontend/src/pages/Collection.jsx
+++ b/frontend/src/pages/Collection.jsx
@@ -35,26 +35,11 @@ const CONDITION_COLORS = {
   MP: 'badge-red',
   HP: 'badge-red',
 }
-const CARD_VARIANTS = [
-  'Normal', 'Holo', 'Reverse Holo', 'Full Art', 'Alt Art', 'Gold', 'Rainbow',
-  'Illustration Rare', 'Special Illustration Rare', 'Crown Rare', 'Promo',
-  'Art Rare', 'Ultra Rare', 'Secret Rare', 'Shiny',
-]
+const CARD_VARIANTS = ['Normal', 'Holo', 'Reverse Holo', 'First Edition']
 const VARIANT_COLORS = {
   'Holo': 'badge-purple',
   'Reverse Holo': 'badge-blue',
-  'Full Art': 'badge-yellow',
-  'Alt Art': 'badge-pink',
-  'Gold': 'badge-yellow',
-  'Rainbow': 'badge-purple',
-  'Illustration Rare': 'badge-blue',
-  'Special Illustration Rare': 'badge-purple',
-  'Crown Rare': 'badge-yellow',
-  'Promo': 'badge-green',
-  'Art Rare': 'badge-red',
-  'Ultra Rare': 'badge-yellow',
-  'Secret Rare': 'badge-red',
-  'Shiny': 'badge-blue',
+  'First Edition': 'badge-green',
   'Normal': 'badge-gray',
 }
 


### PR DESCRIPTION
## What changed

The `variant` field in collections was mixing two concepts:
- **Physical variant** (Normal, Holo, Reverse Holo, First Edition)
- **Rarity** (Illustration Rare, Full Art, Alt Art, Gold, etc.)

This PR separates them. Variant now only stores physical variants. Rarity is displayed read-only from the card data.

## How it works

### Card Modal (Add to Collection)
```
✨ Variant:     [Holo        ▾]     ← auto-preselected from TCGdex
📋 Available: Normal, Reverse Holo   ← info hint
💎 Rarity:      Illustration Rare    ← read-only display
```

### Auto-preselect logic
| TCGdex says | Pre-selected variant |
|-------------|---------------------|
| Only `holo=true` | Holo |
| Only `normal=true` | Normal |
| Exactly 1 variant available | That variant |
| Multiple variants | No pre-selection (user picks) |
| No data | No pre-selection |

All 4 options (Normal, Holo, Reverse Holo, First Edition) always remain selectable.

### Database migration
On startup, old rarity values in `collection.variant` are automatically migrated:
- Cards with `variants_holo=true` → variant set to "Holo"
- Cards with `variants_normal=true` → variant set to "Normal"
- Unresolvable → variant cleared to NULL
- Skips rows that would create unique key conflicts
- Idempotent (safe to run multiple times)

### Files changed (6)
- `backend/database.py` — migration function + init_db call
- `frontend/src/components/CardItem.jsx` — reduced CARD_VARIANTS, auto-preselect, hint text, rarity display
- `frontend/src/components/CardScanner.jsx` — reduced CARD_VARIANTS
- `frontend/src/pages/Collection.jsx` — reduced CARD_VARIANTS + VARIANT_COLORS
- `frontend/src/i18n/de.js` + `en.js` — new keys

Addresses feature request from #79