### PR TITLE
fix: Collection page shows different value than HomeScreen

### DIFF
--- a/frontend/src/pages/Collection.jsx
+++ b/frontend/src/pages/Collection.jsx
@@ -44,7 +44,7 @@ const VARIANT_COLORS = {
 }
 
 
-const HOLO_VARIANTS = new Set(['Holo', 'Holo Rare', 'Holo V', 'Holo VMAX', 'Holo VSTAR', 'Holo ex'])
+const HOLO_VARIANTS = new Set(['Holo', 'Holo Rare', 'Holo V', 'Holo VMAX', 'Holo VSTAR', 'Holo ex', 'Reverse Holo'])
 const HOLO_FIELD_MAP = {
   price_market: 'price_market_holo',
   price_trend: 'price_trend_holo',


### PR DESCRIPTION
### Bug
Collection page showed €87.77 while HomeScreen showed €90.14 for the same cards.

### Cause
`HOLO_VARIANTS` in `Collection.jsx` was missing `"Reverse Holo"`, so Reverse Holo cards used non-holo (lower) prices for the collection total. The backend Dashboard endpoint already had the correct set since PR #78.

### Fix
One-line change: add `"Reverse Holo"` to the frontend `HOLO_VARIANTS` set in `Collection.jsx`.

Now both pages use the same price logic for Reverse Holo cards.