### PR TITLE
fix: add missing Chinese language keys to DE and EN i18n

### DIFF
--- a/frontend/src/i18n/de.js
+++ b/frontend/src/i18n/de.js
@@ -690,6 +690,8 @@ const de = {
     selectHint: 'In welcher Sprache hast du diese Karte?',
     de_full: 'Deutsch',
     en_full: 'Englisch',
+    zh: 'ZH',
+    zh_full: 'Chinesisch',
     setLangFilter: 'Sets nach Sprache filtern',
     searchLangFilter: 'Suche nach Sprache filtern',
   },

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -690,6 +690,8 @@ const en = {
     selectHint: 'Which language is this card?',
     de_full: 'German',
     en_full: 'English',
+    zh: 'ZH',
+    zh_full: 'Chinese',
     setLangFilter: 'Filter sets by language',
     searchLangFilter: 'Filter search by language',
   },


### PR DESCRIPTION
Follow-up to PR #92 (Chinese language support).

The Chinese translation added `lang.zh` and `lang.zh_full` only to `zh.js`. These keys are also needed in `de.js` and `en.js` for language filter display.

### Added
- `de.js`: `zh: "ZH"`, `zh_full: "Chinesisch"`
- `en.js`: `zh: "ZH"`, `zh_full: "Chinese"`

### Verification
All three i18n files now have 719-720 keys with no missing keys in ZH relative to DE/EN.