### PR TITLE
fix: scanner returns wrong language — strip EX/GX/V suffixes for broader search

### DIFF
--- a/backend/api/recognize.py
+++ b/backend/api/recognize.py
@@ -114,6 +114,20 @@ Respond ONLY with this exact JSON (no markdown, no explanation):
     if not card_name:
         raise HTTPException(status_code=422, detail="Kartenname konnte nicht erkannt werden.")
 
+    # Strip card suffixes for broader TCGdex search — exact variants differ between
+    # printed text ("EX") and TCGdex naming ("ex", "-ex"). The number ranking and
+    # visual verification will find the exact match from the broader result set.
+    _SUFFIXES = re.compile(
+        r"[\s-]+(?:EX|ex|GX|gx|V|VMAX|VSTAR|VStar|TAG\s*TEAM|BREAK|LV\.?\s*X)\s*$",
+        re.IGNORECASE,
+    )
+
+    def _simplify_name(name: str) -> str:
+        return _SUFFIXES.sub("", name).strip()
+
+    card_name_simple = _simplify_name(card_name)
+    card_name_en_simple = _simplify_name(card_name_en)
+
     # Use detected language for TCGdex search
     detected_lang = card_info.get("language", "en").lower().strip()
     # TCGdex supports: en, fr, es, it, pt, de, nl, pl, ru, ko, zh-hans, zh-hant, ja
@@ -121,10 +135,14 @@ Respond ONLY with this exact JSON (no markdown, no explanation):
     if detected_lang not in supported_langs:
         detected_lang = "en"
 
-    # Build (lang, search_name) pairs — use native name for native lang, English name for English fallback
-    search_pairs = [(detected_lang, card_name)]
+    # Build (lang, search_name) pairs — try simplified name first (broader), then original as fallback
+    search_pairs = [(detected_lang, card_name_simple)]
+    if card_name_simple != card_name:
+        search_pairs.append((detected_lang, card_name))
     if detected_lang != "en":
-        search_pairs.append(("en", card_name_en))
+        search_pairs.append(("en", card_name_en_simple))
+        if card_name_en_simple != card_name_en:
+            search_pairs.append(("en", card_name_en))
 
     # Collect all raw results first, setting _lang on each card
     all_results = []


### PR DESCRIPTION
## Bug
Scanning a German card like "Mega-Glurak Y EX" returned only English results because TCGdex stores the name as "Mega-Glurak Y-ex" (lowercase, with hyphen). The exact search `name=Mega-Glurak Y EX` returned 0 DE results, so only the EN fallback ("Mega Charizard Y EX") produced matches.

## Fix
Strip common TCG suffixes (EX, GX, V, VMAX, VSTAR, BREAK, LV.X) before searching TCGdex. This produces a broader search that finds the card regardless of suffix formatting.

Example: `Mega-Glurak Y EX` → searches for `Mega-Glurak Y` → finds 2 DE results including the exact card.

The number ranking (PR #96) + visual verification then sort the exact match to position #1.

## Search order
1. Simplified name in detected language (e.g. `Mega-Glurak Y` in DE)
2. Original name in detected language (fallback)
3. Simplified name in EN
4. Original name in EN (fallback)

## Tested
- `Mega-Glurak Y EX` → `Mega-Glurak Y` → 2 DE results ✅
- `Glurak-ex` → `Glurak` → all Glurak cards ✅
- `Pikachu` → unchanged (no suffix) ✅