### PR TITLE
fix: scanner shows local set names instead of API set IDs

### DIFF
--- a/backend/api/recognize.py
+++ b/backend/api/recognize.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, UploadFile, File, HTTPException, Depends
 from sqlalchemy.orm import Session
 from api.auth import get_current_user
 from database import get_db
-from models import Setting, User
+from models import Setting, User, Set
 
 logger = logging.getLogger(__name__)
 
@@ -177,6 +177,24 @@ Respond ONLY with this exact JSON (no markdown, no explanation):
                         })
         except Exception:
             continue
+
+    # Enrich results with set name from local DB
+    for card in all_results:
+        tcg_card_id = card.get("tcg_card_id", "")
+        card_lang = card.get("_lang", "en")
+        # Extract set_id from card_id: "me02.5-022" -> "me02.5"
+        if "-" in tcg_card_id:
+            set_id = tcg_card_id.rsplit("-", 1)[0]
+            local_set = db.query(Set).filter(
+                Set.tcg_set_id == set_id, Set.lang == card_lang
+            ).first()
+            if not local_set:
+                # Fallback: try without language filter
+                local_set = db.query(Set).filter(Set.tcg_set_id == set_id).first()
+            if local_set:
+                card["set"] = local_set.name
+                if local_set.abbreviation:
+                    card["set_abbreviation"] = local_set.abbreviation
 
     # Dedup by (card_id, _lang) composite key — same card in different languages counts once per lang
     seen = set()

--- a/frontend/src/components/CardScanner.jsx
+++ b/frontend/src/components/CardScanner.jsx
@@ -64,7 +64,7 @@ function ScanAddModal({ match, defaultLang, onClose, onAdded }) {
             )}
             <div className="flex-1 min-w-0">
               <p className="font-bold text-white text-base truncate">{match.name}</p>
-              <p className="text-xs text-text-muted truncate">{match.set}</p>
+              <p className="text-xs text-text-muted truncate">{match.set_abbreviation ? `${match.set_abbreviation} · ${match.set}` : match.set}</p>
               {match.number && <p className="text-[11px] text-text-muted">#{match.number}</p>}
               {match.rarity && <p className="text-[11px] text-text-muted">{match.rarity}</p>}
             </div>
@@ -336,7 +336,7 @@ export default function CardScanner({ isOpen, onClose, onCardSelected }) {
                           {cardIdLabel && (
                             <p className="text-[9px] font-mono text-brand-red/80 font-semibold">{cardIdLabel}</p>
                           )}
-                          <p className="text-[9px] text-text-muted truncate">{match.set}</p>
+                          <p className="text-[9px] text-text-muted truncate">{match.set_abbreviation ? `${match.set_abbreviation} · ${match.set}` : match.set}</p>
                           {match.rarity && (
                             <p className="text-[9px] text-text-muted truncate">{match.rarity}</p>
                           )}


### PR DESCRIPTION
## Bug
Scanner results showed no set name or the raw API set ID instead of the actual set name as printed on the card.

## Cause
The TCGdex card search endpoint (`/v2/de/cards?name=...`) returns no set information in the response. The `set` field was always `null`.

## Fix
After collecting TCGdex results, extract the set ID from the card ID (e.g. `me02.5` from `me02.5-022`) and look up the set name + abbreviation from the local database in the correct language.

Frontend updated to display abbreviation when available:
`ASC · Erhabene Helden` instead of just the set name.

## Files
- `backend/api/recognize.py` — set name enrichment from local DB
- `frontend/src/components/CardScanner.jsx` — display abbreviation + set name