### PR TITLE
feat: per-user settings — Telegram, Gemini, language per user

### DIFF
--- a/backend/api/recognize.py
+++ b/backend/api/recognize.py
@@ -8,15 +8,21 @@ from fastapi import APIRouter, UploadFile, File, HTTPException, Depends
 from sqlalchemy.orm import Session
 from api.auth import get_current_user
 from database import get_db
-from models import Setting, User, Set
+from models import Setting, UserSetting, User, Set
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
 
-def get_gemini_key(db: Session) -> str:
-    """Read Gemini API key from DB settings, fallback to env var."""
+def get_gemini_key(db: Session, user_id: int = None) -> str:
+    """Read Gemini API key from user settings, fallback to global, fallback to env."""
+    if user_id is not None:
+        row = db.query(UserSetting).filter(
+            UserSetting.user_id == user_id, UserSetting.key == "gemini_api_key"
+        ).first()
+        if row and row.value:
+            return row.value
     row = db.query(Setting).filter(Setting.key == "gemini_api_key").first()
     if row and row.value:
         return row.value
@@ -34,7 +40,7 @@ async def recognize_card(
     including the card's language, then searches TCGdex in that language.
     Supports both German and English (and other) cards automatically.
     """
-    api_key = get_gemini_key(db)
+    api_key = get_gemini_key(db, user_id=current_user.id)
     if not api_key:
         raise HTTPException(
             status_code=400,

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -3,9 +3,20 @@ from fastapi import APIRouter, Depends, HTTPException
 from api.auth import get_current_user
 from sqlalchemy.orm import Session
 from database import get_db
-from models import Setting, User
+from models import Setting, UserSetting, User
 
 router = APIRouter()
+
+PER_USER_KEYS = {
+    "language", "currency", "price_primary", "price_display",
+    "telegram_bot_token", "telegram_chat_id", "telegram_enabled",
+    "price_alerts_enabled", "price_alert_threshold",
+    "gemini_api_key", "trainer_name",
+}
+
+ADMIN_ONLY_KEYS = {
+    "full_sync_interval_days", "price_sync_interval_minutes", "multi_user_mode",
+}
 
 DEFAULT_SETTINGS = {
     "trainer_name": "TRAINER",
@@ -18,89 +29,106 @@ DEFAULT_SETTINGS = {
     "language": "de",
     "currency": "EUR",
     "price_primary": "trend",
+    "price_display": '["trend", "avg1", "avg7", "avg30", "low"]',
 }
 
 
-@router.get("/")
-def get_settings(
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-):
-    """Return all settings as a JSON object."""
-    rows = db.query(Setting).all()
-    result = dict(DEFAULT_SETTINGS)
-    result.update({row.key: row.value for row in rows})
+def _get_user_settings(db: Session, user_id: int) -> dict:
+    """Get all settings for a user: per-user from user_settings, global from settings."""
+    result = {}
+
+    for row in db.query(Setting).all():
+        if row.key in ADMIN_ONLY_KEYS or row.key in PER_USER_KEYS:
+            result[row.key] = row.value
+
+    for row in db.query(UserSetting).filter(UserSetting.user_id == user_id).all():
+        result[row.key] = row.value
+
+    if "telegram_bot_token" not in result:
+        env_token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+        if env_token:
+            result["telegram_bot_token"] = env_token
+    if "telegram_chat_id" not in result:
+        env_chat_id = os.environ.get("TELEGRAM_CHAT_ID", "")
+        if env_chat_id:
+            result["telegram_chat_id"] = env_chat_id
+    if "gemini_api_key" not in result:
+        env_gemini = os.environ.get("GEMINI_API_KEY", "")
+        if env_gemini:
+            result["gemini_api_key"] = env_gemini
+
+    for key, value in DEFAULT_SETTINGS.items():
+        result.setdefault(key, value)
+
     return result
+
+
+@router.get("/")
+def get_settings(db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
+    return _get_user_settings(db, current_user.id)
 
 
 @router.put("/")
-def update_settings(
-    data: dict,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-):
-    """Update one or more settings. Accepts a JSON object with key-value pairs."""
+def update_settings(data: dict, db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
     for key, value in data.items():
-        row = db.query(Setting).filter(Setting.key == key).first()
-        if row:
-            row.value = str(value)
+        if key in ADMIN_ONLY_KEYS:
+            if current_user.role != "admin":
+                continue
+            row = db.query(Setting).filter(Setting.key == key).first()
+            if row:
+                row.value = str(value)
+            else:
+                db.add(Setting(key=key, value=str(value)))
         else:
-            db.add(Setting(key=key, value=str(value)))
+            row = db.query(UserSetting).filter(
+                UserSetting.user_id == current_user.id, UserSetting.key == key
+            ).first()
+            if row:
+                row.value = str(value)
+            else:
+                db.add(UserSetting(user_id=current_user.id, key=key, value=str(value)))
     db.commit()
-    rows = db.query(Setting).all()
-    result = dict(DEFAULT_SETTINGS)
-    result.update({row.key: row.value for row in rows})
-    return result
+    return _get_user_settings(db, current_user.id)
 
 
 @router.get("/telegram_status")
-def get_telegram_status(
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-):
-    """Check if Telegram bot token is configured (DB first, then env)."""
-    # Check DB first
-    token_row = db.query(Setting).filter(Setting.key == "telegram_bot_token").first()
-    token = token_row.value if (token_row and token_row.value) else os.environ.get("TELEGRAM_BOT_TOKEN", "")
-    chat_row = db.query(Setting).filter(Setting.key == "telegram_chat_id").first()
-    chat_id = chat_row.value if (chat_row and chat_row.value) else os.environ.get("TELEGRAM_CHAT_ID", "")
+def get_telegram_status(db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
+    settings = _get_user_settings(db, current_user.id)
+    token = settings.get("telegram_bot_token", "")
+    chat_id = settings.get("telegram_chat_id", "")
     return {"configured": bool(token and chat_id)}
 
 
 @router.get("/{key}")
-def get_setting(
-    key: str,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-):
-    """Return a single setting value."""
-    # Legacy alias: sync_interval_hours → full_sync_interval_days
+def get_setting(key: str, db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
     if key == "sync_interval_hours":
-        row = db.query(Setting).filter(Setting.key == "full_sync_interval_days").first()
-        days = int(row.value) if row else 5
+        settings = _get_user_settings(db, current_user.id)
+        days = int(settings.get("full_sync_interval_days", "5"))
         return {"key": key, "value": str(days * 24)}
-    row = db.query(Setting).filter(Setting.key == key).first()
-    if row:
-        return {"key": key, "value": row.value}
-    # Return default if exists
-    if key in DEFAULT_SETTINGS:
-        return {"key": key, "value": DEFAULT_SETTINGS[key]}
-    raise HTTPException(status_code=404, detail=f"Setting '{key}' not found")
+    settings = _get_user_settings(db, current_user.id)
+    if key in settings:
+        return {"key": key, "value": settings[key]}
+    raise HTTPException(status_code=404, detail=f"Setting {key} not found")
 
 
 @router.post("/{key}")
-def set_setting(
-    key: str,
-    body: dict,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-):
-    """Set a single setting value. Body: {value: '...'}"""
+def set_setting(key: str, body: dict, db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
     value = str(body.get("value", ""))
-    row = db.query(Setting).filter(Setting.key == key).first()
-    if row:
-        row.value = value
+    if key in ADMIN_ONLY_KEYS:
+        if current_user.role != "admin":
+            raise HTTPException(status_code=403, detail="Admin only")
+        row = db.query(Setting).filter(Setting.key == key).first()
+        if row:
+            row.value = value
+        else:
+            db.add(Setting(key=key, value=value))
     else:
-        db.add(Setting(key=key, value=value))
+        row = db.query(UserSetting).filter(
+            UserSetting.user_id == current_user.id, UserSetting.key == key
+        ).first()
+        if row:
+            row.value = value
+        else:
+            db.add(UserSetting(user_id=current_user.id, key=key, value=value))
     db.commit()
     return {"key": key, "value": value}

--- a/backend/database.py
+++ b/backend/database.py
@@ -342,7 +342,7 @@ def migrate_card_ids():
 
 def init_db():
     """Initialize the database: create tables, run migrations, seed settings."""
-    from models import Base as ModelBase, Setting
+    from models import Base as ModelBase, Setting, User
     ModelBase.metadata.create_all(bind=engine)
 
     # Run lightweight schema migrations (idempotent, PostgreSQL only)
@@ -374,6 +374,42 @@ def init_db():
         db.commit()
     except Exception:
         db.rollback()
+    # v42: Migrate per-user settings from global to admin user
+    try:
+        from models import UserSetting
+        admin = db.query(User).filter(User.role == "admin").first()
+        if admin:
+            per_user_keys = {
+                "language", "currency", "price_primary", "price_display",
+                "telegram_bot_token", "telegram_chat_id", "telegram_enabled",
+                "price_alerts_enabled", "price_alert_threshold",
+                "gemini_api_key", "trainer_name",
+            }
+            for key in per_user_keys:
+                existing_user_setting = db.query(UserSetting).filter(
+                    UserSetting.user_id == admin.id, UserSetting.key == key
+                ).first()
+                if existing_user_setting:
+                    continue
+                global_row = db.query(Setting).filter(Setting.key == key).first()
+                if global_row:
+                    db.add(UserSetting(user_id=admin.id, key=key, value=global_row.value))
+                elif key == "telegram_bot_token":
+                    val = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+                    if val:
+                        db.add(UserSetting(user_id=admin.id, key=key, value=val))
+                elif key == "telegram_chat_id":
+                    val = os.environ.get("TELEGRAM_CHAT_ID", "")
+                    if val:
+                        db.add(UserSetting(user_id=admin.id, key=key, value=val))
+                elif key == "gemini_api_key":
+                    val = os.environ.get("GEMINI_API_KEY", "")
+                    if val:
+                        db.add(UserSetting(user_id=admin.id, key=key, value=val))
+            db.commit()
+    except Exception as e:
+        db.rollback()
+        logger.warning("User settings migration: %s", e)
     finally:
         db.close()
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -241,6 +241,17 @@ class Setting(Base):
     value = Column(Text, nullable=False)
 
 
+class UserSetting(Base):
+    __tablename__ = "user_settings"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    key = Column(String, nullable=False)
+    value = Column(Text, nullable=False)
+
+    __table_args__ = (UniqueConstraint("user_id", "key", name="uq_user_setting"),)
+
+
 class CustomCardMatch(Base):
     """Tracks custom cards that now have an equivalent API card on TCGdex."""
     __tablename__ = "custom_card_matches"

--- a/backend/services/sync_service.py
+++ b/backend/services/sync_service.py
@@ -97,7 +97,9 @@ def check_wishlist_alerts(db: Session, updated_card_ids: list):
 
         if triggered:
             threshold = item.price_alert_above if alert_type == "above" else item.price_alert_below
-            telegram.send_price_alert(card.name, card.price_market, threshold, alert_type, db=db)
+            telegram.send_price_alert(
+                card.name, card.price_market, threshold, alert_type, db=db, user_id=item.user_id
+            )
             item.notified_at = now
 
     db.commit()

--- a/backend/services/telegram.py
+++ b/backend/services/telegram.py
@@ -5,11 +5,26 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def _get_telegram_credentials(db=None):
-    """Read Telegram credentials from DB settings first, fallback to env vars."""
+def _get_telegram_credentials(db=None, user_id=None):
+    """Read Telegram credentials from user settings first, fallback to env vars."""
     token = ""
     chat_id = ""
-    if db is not None:
+    if db is not None and user_id is not None:
+        try:
+            from models import UserSetting
+            token_row = db.query(UserSetting).filter(
+                UserSetting.user_id == user_id, UserSetting.key == "telegram_bot_token"
+            ).first()
+            chat_row = db.query(UserSetting).filter(
+                UserSetting.user_id == user_id, UserSetting.key == "telegram_chat_id"
+            ).first()
+            if token_row and token_row.value:
+                token = token_row.value
+            if chat_row and chat_row.value:
+                chat_id = chat_row.value
+        except Exception:
+            pass
+    if db is not None and not token:
         try:
             from models import Setting
             token_row = db.query(Setting).filter(Setting.key == "telegram_bot_token").first()
@@ -28,15 +43,15 @@ def _get_telegram_credentials(db=None):
     return token, chat_id
 
 
-def is_configured(db=None) -> bool:
+def is_configured(db=None, user_id=None) -> bool:
     """Check if Telegram is configured (from DB or env)."""
-    token, chat_id = _get_telegram_credentials(db)
+    token, chat_id = _get_telegram_credentials(db, user_id=user_id)
     return bool(token and chat_id)
 
 
-def send_message(text: str, db=None) -> bool:
+def send_message(text: str, db=None, user_id=None) -> bool:
     """Send a message via Telegram Bot API."""
-    token, chat_id = _get_telegram_credentials(db)
+    token, chat_id = _get_telegram_credentials(db, user_id=user_id)
     if not token or not chat_id:
         logger.warning("Telegram not configured, skipping notification")
         return False
@@ -58,7 +73,7 @@ def send_message(text: str, db=None) -> bool:
         return False
 
 
-def send_price_alert(card_name: str, current_price: float, threshold: float, alert_type: str, db=None):
+def send_price_alert(card_name: str, current_price: float, threshold: float, alert_type: str, db=None, user_id=None):
     """Send a price alert notification."""
     emoji = "📈" if alert_type == "above" else "📉"
     direction = "above" if alert_type == "above" else "below"
@@ -70,10 +85,10 @@ def send_price_alert(card_name: str, current_price: float, threshold: float, ale
         f"Alert threshold ({direction}): <b>€{threshold:.2f}</b>\n\n"
         f"Check your collection! 🎯"
     )
-    return send_message(text, db=db)
+    return send_message(text, db=db, user_id=user_id)
 
 
-def send_new_sets_notification(new_sets: list, db=None):
+def send_new_sets_notification(new_sets: list, db=None, user_id=None):
     """Notify about newly detected sets."""
     if not new_sets:
         return False
@@ -84,4 +99,4 @@ def send_new_sets_notification(new_sets: list, db=None):
         f"{sets_list}\n\n"
         f"Check your collection app to explore! 🎮"
     )
-    return send_message(text, db=db)
+    return send_message(text, db=db, user_id=user_id)

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -724,21 +724,23 @@ export default function Settings() {
                   {isRunning ? t('settings.running') : t('settings.syncButton')}
                 </button>
               </SettingsRow>
-              <SettingsRow label={t('settings.interval')} description={t('settings.syncSetsCardsDesc')} last>
-                <SelectControl
-                  value={fullSyncIntervalDays}
-                  options={[
-                    { value: '1',  label: t('settings.day1') },
-                    { value: '2',  label: t('settings.days2') },
-                    { value: '3',  label: t('settings.days3') },
-                    { value: '5',  label: t('settings.days5') },
-                    { value: '7',  label: t('settings.days7') },
-                    { value: '14', label: t('settings.days14') },
-                    { value: '30', label: t('settings.days30') },
-                  ]}
-                  onChange={handleFullSyncIntervalChange}
-                />
-              </SettingsRow>
+              {user?.role === 'admin' && (
+                <SettingsRow label={t('settings.interval')} description={t('settings.syncSetsCardsDesc')} last>
+                  <SelectControl
+                    value={fullSyncIntervalDays}
+                    options={[
+                      { value: '1',  label: t('settings.day1') },
+                      { value: '2',  label: t('settings.days2') },
+                      { value: '3',  label: t('settings.days3') },
+                      { value: '5',  label: t('settings.days5') },
+                      { value: '7',  label: t('settings.days7') },
+                      { value: '14', label: t('settings.days14') },
+                      { value: '30', label: t('settings.days30') },
+                    ]}
+                    onChange={handleFullSyncIntervalChange}
+                  />
+                </SettingsRow>
+              )}
             </SettingsCard>
 
             {/* Card 2: Price Sync */}
@@ -754,20 +756,22 @@ export default function Settings() {
                   {isPriceSyncRunning ? t('settings.running') : t('settings.syncButton')}
                 </button>
               </SettingsRow>
-              <SettingsRow label={t('settings.priceInterval')} description={t('settings.syncPricesOnlyDesc')} last>
-                <SelectControl
-                  value={priceSyncIntervalMinutes}
-                  options={[
-                    { value: '60',   label: t('settings.min60') },
-                    { value: '120',  label: t('settings.min120') },
-                    { value: '180',  label: t('settings.min180') },
-                    { value: '360',  label: t('settings.min360') },
-                    { value: '720',  label: t('settings.min720') },
-                    { value: '1440', label: t('settings.min1440') },
-                  ]}
-                  onChange={handlePriceSyncIntervalChange}
-                />
-              </SettingsRow>
+              {user?.role === 'admin' && (
+                <SettingsRow label={t('settings.priceInterval')} description={t('settings.syncPricesOnlyDesc')} last>
+                  <SelectControl
+                    value={priceSyncIntervalMinutes}
+                    options={[
+                      { value: '60',   label: t('settings.min60') },
+                      { value: '120',  label: t('settings.min120') },
+                      { value: '180',  label: t('settings.min180') },
+                      { value: '360',  label: t('settings.min360') },
+                      { value: '720',  label: t('settings.min720') },
+                      { value: '1440', label: t('settings.min1440') },
+                    ]}
+                    onChange={handlePriceSyncIntervalChange}
+                  />
+                </SettingsRow>
+              )}
             </SettingsCard>
           </section>
 


### PR DESCRIPTION
## What changed

Settings are now per-user instead of global. Each user has their own language, currency, Telegram bot, Gemini API key, etc.

### Per-user settings
- language, currency, price_primary, price_display
- telegram_bot_token, telegram_chat_id, telegram_enabled
- price_alerts_enabled, price_alert_threshold
- gemini_api_key, trainer_name

### Admin-only global settings
- full_sync_interval_days, price_sync_interval_minutes, multi_user_mode

## Database safety
- New `user_settings` table (user_id, key, value)
- Old `settings` table untouched — no rows deleted, no schema changes
- Idempotent migration: copies existing global settings to admin user on startup
- Env vars (TELEGRAM_BOT_TOKEN, etc.) are copied to admin user settings
- Fallback chain: UserSetting → Setting (global) → env var → default

## Changes
- `backend/models.py` — new UserSetting model
- `backend/database.py` — migration in init_db()
- `backend/api/settings.py` — full rewrite, routes per-user or global based on key
- `backend/services/telegram.py` — per-user credential lookup
- `backend/services/sync_service.py` — passes user_id for price alerts
- `backend/api/recognize.py` — per-user Gemini key
- `frontend/src/pages/Settings.jsx` — sync intervals admin-only

## For existing users
After update, existing settings are automatically migrated to the admin account. New users start with defaults and configure their own keys in Settings.