### PR TITLE
fix: env vars not reaching Docker + force password change feature

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -23,6 +23,7 @@ class CreateUserRequest(BaseModel):
     password: str
     role: str = "trainer"
     avatar_id: int | None = None
+    must_change_password: bool = False
 
 
 class UpdateUserRequest(BaseModel):
@@ -35,6 +36,10 @@ class UpdateUserRequest(BaseModel):
 
 class ChangePasswordRequest(BaseModel):
     current_password: str
+    new_password: str
+
+
+class ForceChangePasswordRequest(BaseModel):
     new_password: str
 
 
@@ -95,13 +100,25 @@ def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depend
     token = create_access_token({"sub": str(user.id), "role": user.role})
     return TokenResponse(
         access_token=token,
-        user={"id": user.id, "username": user.username, "role": user.role, "avatar_id": user.avatar_id},
+        user={
+            "id": user.id,
+            "username": user.username,
+            "role": user.role,
+            "avatar_id": user.avatar_id,
+            "must_change_password": user.must_change_password,
+        },
     )
 
 
 @router.get("/me")
 def get_me(current_user: User = Depends(get_current_user)):
-    return {"id": current_user.id, "username": current_user.username, "role": current_user.role, "avatar_id": current_user.avatar_id}
+    return {
+        "id": current_user.id,
+        "username": current_user.username,
+        "role": current_user.role,
+        "avatar_id": current_user.avatar_id,
+        "must_change_password": current_user.must_change_password,
+    }
 
 
 @router.get("/mode")
@@ -160,6 +177,7 @@ def create_user(
         role=data.role,
         is_active=True,
         avatar_id=data.avatar_id,
+        must_change_password=data.must_change_password,
     )
     db.add(user)
     db.commit()
@@ -222,6 +240,21 @@ def change_password(
     if not verify_password(data.current_password, current_user.hashed_password):
         raise HTTPException(status_code=400, detail="Current password is incorrect")
     current_user.hashed_password = hash_password(data.new_password)
+    current_user.must_change_password = False
+    db.commit()
+    return {"message": "Password changed"}
+
+
+@router.put("/me/force-password")
+def force_change_password(
+    data: ForceChangePasswordRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    if not current_user.must_change_password:
+        raise HTTPException(status_code=400, detail="Password change is not required")
+    current_user.hashed_password = hash_password(data.new_password)
+    current_user.must_change_password = False
     db.commit()
     return {"message": "Password changed"}
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -166,6 +166,7 @@ def _run_migrations(conn):
         "ALTER TABLE binders ADD COLUMN IF NOT EXISTS user_id INTEGER REFERENCES users(id)",
         "ALTER TABLE product_purchases ADD COLUMN IF NOT EXISTS user_id INTEGER REFERENCES users(id)",
         "ALTER TABLE portfolio_snapshots ADD COLUMN IF NOT EXISTS user_id INTEGER REFERENCES users(id)",
+        "ALTER TABLE users ADD COLUMN IF NOT EXISTS must_change_password BOOLEAN DEFAULT false",
     ]
     for stmt in migrations:
         try:

--- a/backend/models.py
+++ b/backend/models.py
@@ -114,6 +114,7 @@ class User(Base):
     role = Column(String, default="trainer")  # "admin" or "trainer"
     is_active = Column(Boolean, default=True)
     avatar_id = Column(Integer, nullable=True)  # Pokemon number (1-151) for avatar sprite
+    must_change_password = Column(Boolean, default=False)
     created_at = Column(DateTime, default=func.now())
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,10 @@ services:
       DATABASE_URL: postgresql://pokemon:${POSTGRES_PASSWORD:-changeme}@postgres:5432/pokemon_tcg
       TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN:-}
       TELEGRAM_CHAT_ID: ${TELEGRAM_CHAT_ID:-}
+      ADMIN_USERNAME: ${ADMIN_USERNAME:-admin}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD:-}
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY:-}
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,10 @@
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
+import { useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
 import PokeBallLoader from './components/PokeBallLoader'
 import { SettingsProvider } from './contexts/SettingsContext'
 import { AuthProvider, useAuth } from './contexts/AuthContext'
+import { forceChangePassword } from './api/client'
 import Layout from './components/Layout'
 import HomeScreen from './pages/HomeScreen'
 import Dashboard from './pages/Dashboard'
@@ -20,6 +23,74 @@ import Login from './pages/Login'
 import Leaderboard from './pages/Leaderboard'
 import Compare from './pages/Compare'
 import Achievements from './pages/Achievements'
+import { useSettings } from './contexts/SettingsContext'
+
+function ForcePasswordChangeScreen() {
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const { updateCurrentUser } = useAuth()
+  const { t } = useSettings()
+
+  const forceChangeMutation = useMutation({
+    mutationFn: forceChangePassword,
+    onSuccess: () => {
+      updateCurrentUser({ must_change_password: false })
+      setNewPassword('')
+      setConfirmPassword('')
+    },
+  })
+
+  const passwordsMatch = newPassword === confirmPassword
+  const canSubmit = newPassword && confirmPassword && passwordsMatch && !forceChangeMutation.isPending
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    if (!canSubmit) return
+    forceChangeMutation.mutate(newPassword)
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-bg-primary px-4">
+      <form onSubmit={handleSubmit} className="w-full max-w-md rounded-2xl border border-border bg-bg-secondary p-6 shadow-xl space-y-4">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-bold text-text-primary">{t('settings.users.changePassword')}</h1>
+          <p className="text-sm text-text-muted">{t('settings.users.forcePasswordChange')}</p>
+        </div>
+        <div>
+          <label className="text-xs text-text-secondary mb-1 block">{t('settings.users.newPassword')}</label>
+          <input
+            type="password"
+            value={newPassword}
+            onChange={(event) => setNewPassword(event.target.value)}
+            className="input w-full"
+            required
+          />
+        </div>
+        <div>
+          <label className="text-xs text-text-secondary mb-1 block">Confirm Password</label>
+          <input
+            type="password"
+            value={confirmPassword}
+            onChange={(event) => setConfirmPassword(event.target.value)}
+            className="input w-full"
+            required
+          />
+        </div>
+        {!passwordsMatch && confirmPassword && (
+          <p className="text-sm text-brand-red">Passwords do not match</p>
+        )}
+        {forceChangeMutation.isError && (
+          <p className="text-sm text-brand-red">
+            {forceChangeMutation.error?.response?.data?.detail || t('common.error')}
+          </p>
+        )}
+        <button type="submit" disabled={!canSubmit} className="btn-primary w-full">
+          {t('settings.users.changePassword')}
+        </button>
+      </form>
+    </div>
+  )
+}
 
 function ProtectedRoutes() {
   const { user, loading, multiUser } = useAuth()
@@ -42,6 +113,10 @@ function ProtectedRoutes() {
         <PokeBallLoader size={48} />
       </div>
     )
+  }
+
+  if (user.must_change_password) {
+    return <ForcePasswordChangeScreen />
   }
 
   return (

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -48,6 +48,7 @@ export const createUser = (data) => api.post('/auth/users', data).then(r => r.da
 export const updateUser = (id, data) => api.put(`/auth/users/${id}`, data).then(r => r.data)
 export const deleteUser = (id) => api.delete(`/auth/users/${id}`).then(r => r.data)
 export const changePassword = (data) => api.put('/auth/me/password', data).then(r => r.data)
+export const forceChangePassword = (newPassword) => api.put('/auth/me/force-password', { new_password: newPassword }).then(r => r.data)
 export const changeAvatar = (avatarId) => api.put('/auth/me/avatar', { avatar_id: avatarId }).then(r => r.data)
 export const changeUsername = (username) => api.put('/auth/me/username', { username }).then(r => r.data)
 

--- a/frontend/src/i18n/de.js
+++ b/frontend/src/i18n/de.js
@@ -567,6 +567,7 @@ const de = {
       userCreated: 'Benutzer erstellt',
       userUpdated: 'Benutzer aktualisiert',
       userDeleted: 'Benutzer gelöscht',
+      forcePasswordChange: 'Passwort muss beim nächsten Login geändert werden',
       cannotDeleteSelf: 'Du kannst dich nicht selbst löschen',
       createdAt: 'Erstellt am',
     },

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -567,6 +567,7 @@ const en = {
       userCreated: 'User created',
       userUpdated: 'User updated',
       userDeleted: 'User deleted',
+      forcePasswordChange: 'User must change password on next login',
       cannotDeleteSelf: 'Cannot delete yourself',
       createdAt: 'Created at',
     },

--- a/frontend/src/i18n/zh.js
+++ b/frontend/src/i18n/zh.js
@@ -568,6 +568,7 @@ const zh = {
       userCreated: '用户已创建',
       userUpdated: '用户已更新',
       userDeleted: '用户已删除',
+      forcePasswordChange: '用户必须在下次登录时更改密码',
       cannotDeleteSelf: '不能删除你自己',
       createdAt: '创建于',
     },

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -990,6 +990,7 @@ function UsersTab({ t, queryClient }) {
   const [formUsername, setFormUsername] = useState('')
   const [formPassword, setFormPassword] = useState('')
   const [formRole, setFormRole] = useState('trainer')
+  const [formForceChange, setFormForceChange] = useState(false)
   const [currentPw, setCurrentPw] = useState('')
   const [newPw, setNewPw] = useState('')
   const { user: currentUser } = useAuth()
@@ -1017,7 +1018,14 @@ function UsersTab({ t, queryClient }) {
     onError: (e) => toast.error(e.response?.data?.detail || t('common.error')),
   })
 
-  const openCreate = () => { setEditingUser(null); setFormUsername(''); setFormPassword(''); setFormRole('trainer'); setShowModal(true) }
+  const openCreate = () => {
+    setEditingUser(null)
+    setFormUsername('')
+    setFormPassword('')
+    setFormRole('trainer')
+    setFormForceChange(false)
+    setShowModal(true)
+  }
   const openEdit = (u) => { setEditingUser(u); setFormUsername(u.username); setFormPassword(''); setFormRole(u.role); setShowModal(true) }
   const handleSubmit = (e) => {
     e.preventDefault()
@@ -1028,7 +1036,12 @@ function UsersTab({ t, queryClient }) {
       if (formRole !== editingUser.role) data.role = formRole
       updateMut.mutate({ id: editingUser.id, data })
     } else {
-      createMut.mutate({ username: formUsername, password: formPassword, role: formRole })
+      createMut.mutate({
+        username: formUsername,
+        password: formPassword,
+        role: formRole,
+        must_change_password: formForceChange,
+      })
     }
   }
 
@@ -1088,6 +1101,16 @@ function UsersTab({ t, queryClient }) {
               <option value="admin">{t('settings.users.admin')}</option>
             </select>
           </div>
+          {!editingUser && (
+            <label className="flex items-center gap-2 text-sm text-text-primary">
+              <input
+                type="checkbox"
+                checked={formForceChange}
+                onChange={(e) => setFormForceChange(e.target.checked)}
+              />
+              <span>{t('settings.users.forcePasswordChange')}</span>
+            </label>
+          )}
           <div className="flex gap-3 pt-2">
             <button type="button" onClick={() => setShowModal(false)} className="btn-ghost flex-1">{t('common.cancel')}</button>
             <button type="submit" disabled={createMut.isPending || updateMut.isPending} className="btn-primary flex-1">


### PR DESCRIPTION
## Bug fix: .env variables not working

`ADMIN_USERNAME`, `ADMIN_PASSWORD`, `JWT_SECRET_KEY`, and `GEMINI_API_KEY` were defined in `.env` but never passed to the backend Docker container. Only `DATABASE_URL`, `TELEGRAM_BOT_TOKEN`, and `TELEGRAM_CHAT_ID` were in the `environment:` section.

Now all documented env vars are properly forwarded.

## New feature: Force password change

When admin creates a new user, there is now a checkbox:
☑️ "User must change password on next login"

If checked, the user sees a full-screen password change form after login — they cannot access the app until they set a new password.

### How it works
- `must_change_password` boolean column on users table
- Login + /me responses include the flag
- App.jsx blocks routing when flag is true, shows password form
- `PUT /auth/me/force-password` — changes password without needing current password (only when flag is true)
- Flag clears on both normal and forced password change

### Files (10)
- `docker-compose.yml` — 4 new env vars
- `backend/models.py` — must_change_password column
- `backend/database.py` — migration
- `backend/api/auth.py` — CreateUserRequest, login, /me, force-password endpoint
- `frontend/src/App.jsx` — ForcePasswordChangeScreen component
- `frontend/src/api/client.js` — forceChangePassword function
- `frontend/src/pages/Settings.jsx` — checkbox in create user modal
- `frontend/src/i18n/de.js` + `en.js` + `zh.js` — new key