### PR TITLE
security: .env credentials only apply to admin, not other users

### DIFF
--- a/backend/api/recognize.py
+++ b/backend/api/recognize.py
@@ -16,17 +16,15 @@ router = APIRouter()
 
 
 def get_gemini_key(db: Session, user_id: int = None) -> str:
-    """Read Gemini API key from user settings, fallback to global, fallback to env."""
+    """Read Gemini API key from user settings only. No cross-user fallback."""
     if user_id is not None:
         row = db.query(UserSetting).filter(
             UserSetting.user_id == user_id, UserSetting.key == "gemini_api_key"
         ).first()
         if row and row.value:
             return row.value
-    row = db.query(Setting).filter(Setting.key == "gemini_api_key").first()
-    if row and row.value:
-        return row.value
-    return os.environ.get("GEMINI_API_KEY", "")
+    # No global/env fallback — each user must configure their own key
+    return ""
 
 
 @router.post("/recognize")

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -33,30 +33,38 @@ DEFAULT_SETTINGS = {
 }
 
 
+def _is_admin(db: Session, user_id: int) -> bool:
+    user = db.query(User).filter(User.id == user_id).first()
+    return user is not None and user.role == "admin"
+
+
 def _get_user_settings(db: Session, user_id: int) -> dict:
     """Get all settings for a user: per-user from user_settings, global from settings."""
     result = {}
 
-    # Only load admin-only keys from global settings — per-user keys come from user_settings
+    # Only load admin-only keys from global settings
     for row in db.query(Setting).all():
         if row.key in ADMIN_ONLY_KEYS:
             result[row.key] = row.value
 
+    # Load this user's own settings
     for row in db.query(UserSetting).filter(UserSetting.user_id == user_id).all():
         result[row.key] = row.value
 
-    if "telegram_bot_token" not in result:
-        env_token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
-        if env_token:
-            result["telegram_bot_token"] = env_token
-    if "telegram_chat_id" not in result:
-        env_chat_id = os.environ.get("TELEGRAM_CHAT_ID", "")
-        if env_chat_id:
-            result["telegram_chat_id"] = env_chat_id
-    if "gemini_api_key" not in result:
-        env_gemini = os.environ.get("GEMINI_API_KEY", "")
-        if env_gemini:
-            result["gemini_api_key"] = env_gemini
+    # Env var fallback ONLY for admin — other users get empty defaults
+    if _is_admin(db, user_id):
+        if "telegram_bot_token" not in result:
+            env_token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+            if env_token:
+                result["telegram_bot_token"] = env_token
+        if "telegram_chat_id" not in result:
+            env_chat_id = os.environ.get("TELEGRAM_CHAT_ID", "")
+            if env_chat_id:
+                result["telegram_chat_id"] = env_chat_id
+        if "gemini_api_key" not in result:
+            env_gemini = os.environ.get("GEMINI_API_KEY", "")
+            if env_gemini:
+                result["gemini_api_key"] = env_gemini
 
     for key, value in DEFAULT_SETTINGS.items():
         result.setdefault(key, value)

--- a/backend/services/telegram.py
+++ b/backend/services/telegram.py
@@ -24,22 +24,23 @@ def _get_telegram_credentials(db=None, user_id=None):
                 chat_id = chat_row.value
         except Exception:
             pass
-    if db is not None and not token:
-        try:
-            from models import Setting
-            token_row = db.query(Setting).filter(Setting.key == "telegram_bot_token").first()
-            chat_row = db.query(Setting).filter(Setting.key == "telegram_chat_id").first()
-            if token_row and token_row.value:
-                token = token_row.value
-            if chat_row and chat_row.value:
-                chat_id = chat_row.value
-        except Exception:
-            pass
-    # Fallback to environment variables
-    if not token:
-        token = os.getenv("TELEGRAM_BOT_TOKEN", "")
-    if not chat_id:
-        chat_id = os.getenv("TELEGRAM_CHAT_ID", "")
+    # If no user_id provided (system-level notification), try global settings + env
+    if not token and user_id is None:
+        if db is not None:
+            try:
+                from models import Setting
+                token_row = db.query(Setting).filter(Setting.key == "telegram_bot_token").first()
+                chat_row = db.query(Setting).filter(Setting.key == "telegram_chat_id").first()
+                if token_row and token_row.value:
+                    token = token_row.value
+                if chat_row and chat_row.value:
+                    chat_id = chat_row.value
+            except Exception:
+                pass
+        if not token:
+            token = os.getenv("TELEGRAM_BOT_TOKEN", "")
+        if not chat_id:
+            chat_id = os.getenv("TELEGRAM_CHAT_ID", "")
     return token, chat_id
 
 


### PR DESCRIPTION
## Problem
Env vars (TELEGRAM_BOT_TOKEN, GEMINI_API_KEY, etc.) were falling back to ALL users when they had no own settings configured. A new trainer user would see and use the admin's API keys.

## Fix
- **settings.py**: env var fallback only for admin users. Non-admin users get empty defaults.
- **telegram.py**: per-user credentials only when user_id is set. Global/env fallback only for system-level notifications (new sets detected, no user context).
- **recognize.py**: removed all global/env fallback for Gemini key. Each user must configure their own.

## Result
| Scenario | Before | After |
|----------|--------|-------|
| Admin with .env keys | Sees keys ✅ | Sees keys ✅ |
| New trainer user | Sees admin keys ❌ | Empty, must set own ✅ |
| Trainer sets own keys | Works | Works |
| Price alert for trainer | Used admin Telegram ❌ | Uses trainer's own Telegram ✅ |