### PR TITLE
fix: settings leaking between users on logout/login

### DIFF
--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -67,6 +67,9 @@ export function AuthProvider({ children }) {
     localStorage.removeItem('token')
     localStorage.removeItem('user')
     setUser(null)
+    // Force full page reload to clear all cached data (React Query, etc.)
+    // Prevents settings/data from previous user session leaking
+    window.location.href = '/login'
   }
 
   return (


### PR DESCRIPTION
## Root cause
When logging out as admin and logging in as trainer, React Query cache still contained the admin's settings (Gemini key, Telegram token, etc.). The backend was correctly returning empty values for the trainer, but the cached data from the admin session was displayed.

## Fix
Logout now forces a full page reload (`window.location.href = /login`) instead of just clearing localStorage. This clears the entire React Query cache, ensuring no data from the previous session bleeds into the next.

## One-line change
`frontend/src/contexts/AuthContext.jsx` — logout function