### PR TITLE
fix: 413 error on backup restore — increase nginx upload limit

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,6 +1,7 @@
 server {
     listen 80;
     server_name _;
+    client_max_body_size 500M;
     root /usr/share/nginx/html;
     index index.html;
 


### PR DESCRIPTION
SQL backup files can be large (image cache in DB). Added `client_max_body_size 500M` at nginx server level to fix 413 Request Entity Too Large on restore.

One-line change in `frontend/nginx.conf`.