### PR TITLE
feat: PUBLIC_MODE env var — control SEO and robots.txt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
   frontend:
     build:
       context: ./frontend
+      args:
+        PUBLIC_MODE: ${PUBLIC_MODE:-false}
     container_name: pokemon-frontend
     restart: unless-stopped
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,10 +2,23 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
+ARG PUBLIC_MODE=false
+
 COPY package*.json ./
 RUN npm install
 
 COPY . .
+
+# Inject meta tags for public mode
+RUN if [ "$PUBLIC_MODE" = "true" ]; then \
+      sed -i 's|<title>Pokemon TCG Collection</title>|<title>PokéCollector — Pokemon TCG Collection Manager</title>\n    <meta name="description" content="A free, self-hosted Pokemon TCG collection manager. Track cards, monitor prices, manage binders, and analyse your portfolio." />\n    <meta name="keywords" content="Pokemon, TCG, collection, tracker, cards, prices, portfolio" />\n    <meta property="og:title" content="PokéCollector — Pokemon TCG Collection Manager" />\n    <meta property="og:description" content="Track your Pokemon card collection, monitor prices, and manage your portfolio." />\n    <meta property="og:type" content="website" />|' index.html; \
+      cp public/robots-allow.txt public/robots.txt; \
+    else \
+      echo '<meta name="robots" content="noindex, nofollow">' > /tmp/robots-meta.txt; \
+      sed -i 's|<title>Pokemon TCG Collection</title>|<meta name="robots" content="noindex, nofollow" />\n    <title>Pokemon TCG Collection</title>|' index.html; \
+      cp public/robots-block.txt public/robots.txt; \
+    fi
+
 RUN npm run build
 
 FROM nginx:alpine

--- a/frontend/public/robots-allow.txt
+++ b/frontend/public/robots-allow.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Disallow: /api/

--- a/frontend/public/robots-block.txt
+++ b/frontend/public/robots-block.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## New env var: PUBLIC_MODE

Controls whether the app is visible to search engines.

### Default: `PUBLIC_MODE=false` (private)
- `robots.txt`: `Disallow: /`
- HTML meta tag: `noindex, nofollow`
- Search engines cannot index any page

### `PUBLIC_MODE=true` (public)
- `robots.txt`: `Allow: /`, `Disallow: /api/`
- Meta tags: description, keywords, og:title, og:description
- Title becomes: "PokéCollector — Pokemon TCG Collection Manager"
- API endpoints still blocked from indexing

### Usage
```env
# .env
PUBLIC_MODE=true
```

Requires `docker compose up -d --build` after changing.

### Files (4)
- `frontend/Dockerfile` — build arg + conditional meta/robots
- `docker-compose.yml` — passes PUBLIC_MODE arg
- `frontend/public/robots-block.txt` — blocking robots.txt
- `frontend/public/robots-allow.txt` — allowing robots.txt