### PR TITLE
security: rate limiting (60/min) + Content Security Policy

### DIFF
--- a/backend/api/auth.py
+++ b/backend/api/auth.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Body, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException, Request
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from jose import JWTError
 from pydantic import BaseModel
@@ -93,7 +93,7 @@ def get_optional_user(token: str = Depends(oauth2_scheme), db: Session = Depends
 
 
 @router.post("/login", response_model=TokenResponse)
-def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
+def login(request: Request, form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
     user = db.query(User).filter(User.username == form_data.username, User.is_active == True).first()
     if not user or not verify_password(form_data.password, user.hashed_password):
         raise HTTPException(status_code=401, detail="Incorrect username or password")

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,11 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from contextlib import asynccontextmanager
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.middleware import SlowAPIMiddleware
+from slowapi.util import get_remote_address
+from slowapi.errors import RateLimitExceeded
 import logging
 import os
 
@@ -9,6 +14,9 @@ logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
+
+# Rate limiter: uses client IP, default 60 requests/minute
+limiter = Limiter(key_func=get_remote_address, default_limits=["60/minute"])
 
 
 @asynccontextmanager
@@ -43,6 +51,10 @@ app = FastAPI(
     description="Complete Pokemon TCG collection management system",
     lifespan=lifespan,
 )
+
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+app.add_middleware(SlowAPIMiddleware)
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,4 @@ pillow==12.1.1
 alembic==1.13.1
 bcrypt
 python-jose[cryptography]
+slowapi==0.1.9

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -13,6 +13,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(self), microphone=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https://assets.tcgdex.net https://raw.githubusercontent.com https://avatars.githubusercontent.com data: blob:; connect-src 'self' https://api.tcgdex.net https://api.frankfurter.app https://api.github.com https://raw.githubusercontent.com https://generativelanguage.googleapis.com" always;
 
     # Gzip
     gzip on;


### PR DESCRIPTION
## Rate Limiting

Added `slowapi` for IP-based rate limiting.

- **Global default**: 60 requests/minute per IP
- Returns `429 Too Many Requests` when exceeded
- Applied via `SlowAPIMiddleware` on all endpoints

## Content Security Policy

Added CSP header to Nginx:

| Directive | Allowed Sources |
|-----------|----------------|
| `default-src` | `self` |
| `script-src` | `self` |
| `style-src` | `self`, `unsafe-inline`, Google Fonts |
| `font-src` | `self`, Google Fonts |
| `img-src` | `self`, TCGdex assets, GitHub avatars, `data:`, `blob:` |
| `connect-src` | `self`, TCGdex API, Frankfurter, GitHub API, Gemini API |

## Files (4)
- `backend/main.py` — slowapi setup + middleware
- `backend/api/auth.py` — Request param on login
- `backend/requirements.txt` — slowapi dependency
- `frontend/nginx.conf` — CSP header