### PR TITLE
fix: remove ZH from API filters, add collection lang filter, fix CardModal crash

### DIFF
--- a/frontend/src/components/CardItem.jsx
+++ b/frontend/src/components/CardItem.jsx
@@ -516,6 +516,8 @@ const CARD_VARIANTS = ['Normal', 'Holo', 'Reverse Holo', 'First Edition']
 
 
 export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
+  if (!card || !card.id) return null
+
   const [quantity, setQuantity] = useState(1)
   const [condition, setCondition] = useState('NM')
   const [variant, setVariant] = useState(() => {
@@ -541,12 +543,17 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
   const { data: priceHistory = [] } = useQuery({
     queryKey: ['price-history', cardIdForHistory],
     queryFn: () => getPriceHistory(cardIdForHistory).then(r => r.data),
-    enabled: !!cardIdForHistory,
+    enabled: typeof cardIdForHistory === 'string' && cardIdForHistory.length > 0,
     staleTime: 5 * 60 * 1000,
+    retry: false,
   })
 
-
-  const cardImage = card.images?.large || resolveCardImageUrl(card, 'large') || (card.image ? `${card.image}/high.webp` : null) || card.images?.small || resolveCardImageUrl(card)
+  const safePriceHistory = Array.isArray(priceHistory) ? priceHistory : []
+  const cardImage = card?.images?.large
+    || resolveCardImageUrl(card, 'large')
+    || (card?.image ? `${card.image}/high.webp` : null)
+    || card?.images?.small
+    || resolveCardImageUrl(card)
   const setName = card.set?.name || card.set_ref?.name
 
   const addMutation = useMutation({
@@ -751,14 +758,14 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
 
 
             {/* Price History Chart */}
-            {priceHistory.length > 1 && (
+            {safePriceHistory && safePriceHistory.length > 0 && (
               <div className="bg-bg-card rounded-xl p-3 space-y-2">
                 <p className="text-xs text-text-muted font-medium uppercase tracking-wide">
                   {t('prices.history')}
                 </p>
                 <div className="h-[140px]">
                   <ResponsiveContainer width="100%" height="100%">
-                    <AreaChart data={priceHistory} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
+                    <AreaChart data={safePriceHistory} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
                       <defs>
                         <linearGradient id="priceGrad" x1="0" y1="0" x2="0" y2="1">
                           <stop offset="0%" stopColor="#22c55e" stopOpacity={0.3} />
@@ -804,8 +811,8 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
                   </ResponsiveContainer>
                 </div>
                 {(() => {
-                  const first = priceHistory[0]?.price_trend
-                  const last = priceHistory[priceHistory.length - 1]?.price_trend
+                  const first = safePriceHistory[0]?.price_trend
+                  const last = safePriceHistory[safePriceHistory.length - 1]?.price_trend
                   if (first && last && first > 0) {
                     const change = ((last - first) / first) * 100
                     return (

--- a/frontend/src/components/CardScanner.jsx
+++ b/frontend/src/components/CardScanner.jsx
@@ -77,7 +77,7 @@ function ScanAddModal({ match, defaultLang, onClose, onAdded }) {
             <div>
               <label className="text-xs text-text-muted mb-1.5 block font-medium">🌐 {t('lang.filter')}</label>
               <div className="flex gap-2">
-                {['de', 'en', 'zh'].map(l => (
+                {['de', 'en'].map(l => (
                   <button
                     key={l}
                     type="button"
@@ -88,12 +88,12 @@ function ScanAddModal({ match, defaultLang, onClose, onAdded }) {
                         ? l === 'de'
                           ? 'bg-yellow-500/20 text-yellow-400 border-yellow-500/50'
                           : l === 'en'
-                          ? 'bg-blue-500/20 text-blue-400 border-blue-500/50'
-                          : 'bg-red-500/20 text-red-400 border-red-500/50'
+                            ? 'bg-blue-500/20 text-blue-400 border-blue-500/50'
+                            : 'bg-white/5 text-text-muted border-white/10'
                         : 'bg-white/5 text-text-muted border-white/10'
                     )}
                   >
-                    {l === 'de' ? `🇩🇪 ${t('lang.de_full')}` : l === 'en' ? `🇬🇧 ${t('lang.en_full')}` : `🇨🇳 ${t('lang.zh_full')}`}
+                    {l === 'de' ? `🇩🇪 ${t('lang.de_full')}` : `🇬🇧 ${t('lang.en_full')}`}
                   </button>
                 ))}
               </div>

--- a/frontend/src/pages/CardSearch.jsx
+++ b/frontend/src/pages/CardSearch.jsx
@@ -293,7 +293,6 @@ export default function CardSearch() {
           { value: 'all', label: t('lang.all') },
           { value: 'de', label: `🇩🇪 ${t('lang.de')}` },
           { value: 'en', label: `🇬🇧 ${t('lang.en')}` },
-          { value: 'zh', label: `🇨🇳 ${t('lang.zh')}` },
         ].map(opt => (
           <button
             key={opt.value}
@@ -304,9 +303,7 @@ export default function CardSearch() {
                   ? 'bg-yellow/20 text-yellow border border-yellow/50'
                   : opt.value === 'en'
                     ? 'bg-blue/20 text-blue-400 border border-blue-400/50'
-                    : opt.value === 'zh'
-                      ? 'bg-red/20 text-red-400 border border-red-400/50'
-                      : 'bg-brand-red text-white'
+                    : 'bg-brand-red text-white'
                 : 'bg-bg-card text-text-secondary hover:text-text-primary border border-border'
             }`}
           >

--- a/frontend/src/pages/Collection.jsx
+++ b/frontend/src/pages/Collection.jsx
@@ -257,7 +257,7 @@ function CollectionEditModal({ item, onClose }) {
             <div>
               <label className="text-xs text-text-muted mb-1.5 block">🌐 {t('lang.selectLabel')}</label>
               <div className="flex gap-2">
-                {['de', 'en', 'zh'].map(l => (
+                {['de', 'en'].map(l => (
                   <button
                     key={l}
                     type="button"
@@ -268,12 +268,12 @@ function CollectionEditModal({ item, onClose }) {
                         ? l === 'de'
                           ? 'bg-yellow/20 text-yellow border-yellow/50'
                           : l === 'en'
-                          ? 'bg-blue/20 text-blue-400 border-blue-400/50'
-                          : 'bg-red/20 text-red-400 border-red-400/50'
+                            ? 'bg-blue/20 text-blue-400 border-blue-400/50'
+                            : 'bg-bg-surface text-text-muted border-border hover:border-text-muted'
                         : 'bg-bg-surface text-text-muted border-border hover:border-text-muted'
                     )}
                   >
-                    {l === 'de' ? `🇩🇪 ${t('lang.de_full')}` : l === 'en' ? `🇬🇧 ${t('lang.en_full')}` : `🇨🇳 ${t('lang.zh_full')}`}
+                    {l === 'de' ? `🇩🇪 ${t('lang.de_full')}` : `🇬🇧 ${t('lang.en_full')}`}
                   </button>
                 ))}
               </div>
@@ -336,6 +336,7 @@ export default function Collection() {
   const [filterVariant, setFilterVariant] = useState('')
   const [filterSet, setFilterSet] = useState('')
   const [filterType, setFilterType] = useState('')
+  const [filterLang, setFilterLang] = useState('')
   const [filterMinPrice, setFilterMinPrice] = useState('')
   const [filterMaxPrice, setFilterMaxPrice] = useState('')
   const [filterDuplicates, setFilterDuplicates] = useState(false)
@@ -382,7 +383,7 @@ export default function Collection() {
     return [...all].sort()
   }, [items])
 
-  const hasActiveFilters = filterRarity || filterCondition || filterVariant || filterSet || filterType || filterMinPrice || filterMaxPrice || filterDuplicates || searchText
+  const hasActiveFilters = filterRarity || filterCondition || filterVariant || filterSet || filterType || filterLang || filterMinPrice || filterMaxPrice || filterDuplicates || searchText
 
   const filtered = useMemo(() => {
     let result = items.filter(item => {
@@ -395,6 +396,7 @@ export default function Collection() {
         if (item.card?.set_ref?.id !== filterSet) return false
       }
       if (filterType && !(card?.types || []).includes(filterType)) return false
+      if (filterLang && item.lang !== filterLang) return false
       if (filterMinPrice && marketPrice < parseFloat(filterMinPrice)) return false
       if (filterMaxPrice && marketPrice > parseFloat(filterMaxPrice)) return false
       if (filterDuplicates && item.quantity < 2) return false
@@ -438,14 +440,14 @@ export default function Collection() {
     })
 
     return result
-  }, [items, filterRarity, filterCondition, filterVariant, filterSet, filterType, filterMinPrice, filterMaxPrice, filterDuplicates, searchText, sortBy, sortOrder])
+  }, [items, filterRarity, filterCondition, filterVariant, filterSet, filterType, filterLang, filterMinPrice, filterMaxPrice, filterDuplicates, searchText, sortBy, sortOrder])
 
   const totalValue = filtered.reduce((sum, item) => sum + (getEffectivePrice(item.card, item.variant) * item.quantity), 0)
   const totalCards = filtered.reduce((sum, item) => sum + item.quantity, 0)
 
   const resetFilters = () => {
     setFilterRarity(''); setFilterCondition(''); setFilterVariant('')
-    setFilterSet(''); setFilterType(''); setFilterMinPrice('')
+    setFilterSet(''); setFilterType(''); setFilterLang(''); setFilterMinPrice('')
     setFilterMaxPrice(''); setFilterDuplicates(false); setSearchText('')
   }
 
@@ -539,7 +541,7 @@ export default function Collection() {
         </div>
 
         {showFilters && (
-          <div className="pt-3 border-t border-border grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-7 gap-3">
+          <div className="pt-3 border-t border-border grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-8 gap-3">
             <div>
               <label className="text-xs text-text-muted mb-1 block">{t('common.rarity')}</label>
               <select className="select py-1.5 text-sm" value={filterRarity} onChange={(e) => setFilterRarity(e.target.value)}>
@@ -573,6 +575,14 @@ export default function Collection() {
               <select className="select py-1.5 text-sm" value={filterType} onChange={(e) => setFilterType(e.target.value)}>
                 <option value="">{t('collection.allTypes')}</option>
                 {types.map(tp => <option key={tp} value={tp}>{tp}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="text-xs text-text-muted mb-1 block">{t('lang.filter')}</label>
+              <select className="select py-1.5 text-sm" value={filterLang} onChange={e => setFilterLang(e.target.value)}>
+                <option value="">{t('lang.all')}</option>
+                <option value="de">DE</option>
+                <option value="en">EN</option>
               </select>
             </div>
             <div>

--- a/frontend/src/pages/Sets.jsx
+++ b/frontend/src/pages/Sets.jsx
@@ -117,7 +117,6 @@ export default function Sets() {
             { value: 'all', label: t('lang.all') },
             { value: 'de', label: `🇩🇪 ${t('lang.de')}` },
             { value: 'en', label: `🇬🇧 ${t('lang.en')}` },
-            { value: 'zh', label: `🇨🇳 ${t('lang.zh')}` },
           ].map(opt => (
             <button
               key={opt.value}
@@ -128,9 +127,7 @@ export default function Sets() {
                     ? 'bg-yellow/20 text-yellow border border-yellow/50'
                     : opt.value === 'en'
                       ? 'bg-blue/20 text-blue-400 border border-blue-400/50'
-                      : opt.value === 'zh'
-                        ? 'bg-red/20 text-red-400 border border-red-400/50'
-                        : 'bg-brand-red text-white'
+                      : 'bg-brand-red text-white'
                   : 'bg-bg-card text-text-secondary hover:text-text-primary border border-border'
               }`}
             >


### PR DESCRIPTION
## 3 fixes

### 1. Remove ZH from API language filters
ZH is only a UI language, not available from TCGdex. Removed from:
- Card Search language buttons
- Sets page language buttons
- CardScanner add-modal language selector
- Collection edit-modal language selector

ZH stays in Settings language selector (UI only).

### 2. Collection language filter
New DE/EN filter dropdown in the Collection filter bar.

### 3. CardModal crash fix (PAR 077 black screen)
The modal flashed up then went black. Added defensive checks:
- Early return if card is null
- Price history query: stricter validation, retry disabled
- Safe array wrapper for chart data
- Null-safe image resolution

The PAR 077 crash was likely caused by the price history response (244 bytes vs 2 bytes for PAR 136) triggering a render error in the chart component.