### PR TITLE
fix: bigger dashboard card slides (v1.2)

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -51,7 +51,7 @@ export default function Dashboard() {
           <div className="h-9 bg-brand-red/70" />
           <div className="p-4 space-y-3">
             <div className="flex gap-4">
-              <div className="skeleton w-36 h-[10rem] rounded-xl" />
+              <div className="skeleton w-44 h-[12rem] rounded-xl" />
               <div className="flex-1 space-y-2">
                 <div className="skeleton h-6 w-32 rounded" />
                 <div className="skeleton h-3 w-16 rounded" />
@@ -128,7 +128,7 @@ export default function Dashboard() {
           </div>
           <div className="flex gap-2.5 overflow-x-auto pb-2 no-scrollbar -mx-4 px-4">
             {data.recent_additions.slice(0, 12).map(card => (
-              <div key={card.id} className="flex-shrink-0 w-36 group cursor-pointer">
+              <div key={card.id} className="flex-shrink-0 w-44 group cursor-pointer">
                 <div className="aspect-[2.5/3.5] rounded-lg overflow-hidden shadow-lg ring-1 ring-white/5 group-hover:ring-brand-red/50 group-hover:scale-[1.03] transition-all duration-150 transform-gpu origin-center">
                   {card.images_small
                     ? <img src={card.images_small} alt={card.name} className="w-full h-full object-cover" loading="lazy" />
@@ -179,7 +179,7 @@ export default function Dashboard() {
           </div>
           <div className="flex gap-2.5 overflow-x-auto pb-2 no-scrollbar -mx-4 px-4">
             {data.top_cards.slice(0, 10).map((card, i) => (
-              <div key={card.id} className="flex-shrink-0 w-40 group cursor-pointer">
+              <div key={card.id} className="flex-shrink-0 w-48 group cursor-pointer">
                 <div className="relative">
                   <div className="aspect-[2.5/3.5] rounded-lg overflow-hidden shadow-lg ring-1 ring-white/5 group-hover:scale-[1.03] transition-all duration-150 group-hover:ring-gold/40 transform-gpu origin-center">
                     {card.images_small

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -676,7 +676,7 @@ export default function Settings() {
               <SettingsRow label={t('settings.app')} description="Pokemon TCG Collection">
                 <span className="text-xs font-bold text-text-muted px-2 py-1 rounded-lg"
                   style={{ background: 'rgba(255,255,255,0.05)' }}>
-                  v1.1
+                  v1.2
                 </span>
               </SettingsRow>
               <SettingsRow label={t('settings.dataSource')} description={t('settings.dataSourceDesc')}>


### PR DESCRIPTION
## Changes

- **Version:** v1.1 → v1.2
- Recently Added carousel: `w-36` → `w-44`
- Most Valuable carousel: `w-40` → `w-48`
- Skeleton updated to match (`h-[12rem]`)