### PR TITLE
fix: correct card back image URL + Collection.jsx (v1.4)

### DIFF
--- a/frontend/src/components/CardListItem.jsx
+++ b/frontend/src/components/CardListItem.jsx
@@ -53,7 +53,7 @@ export default function CardListItem({
           />
         ) : (
           <div className="w-full h-full relative">
-            <img src="https://upload.wikimedia.org/wikipedia/en/a/a7/Pokemon_card_back.jpg" alt="card back" className="w-full h-full object-cover opacity-80" />
+            <img src="https://upload.wikimedia.org/wikipedia/en/3/3b/Pokemon_Trading_Card_Game_cardback.jpg" alt="card back" className="w-full h-full object-cover opacity-80" />
           </div>
         )}
       </div>

--- a/frontend/src/pages/Collection.jsx
+++ b/frontend/src/pages/Collection.jsx
@@ -651,10 +651,11 @@ export default function Collection() {
                               className="w-full h-full object-cover"
                               loading="lazy"
                             />
-                          : <div className="w-full h-full bg-bg-elevated flex items-center justify-center">
-                              <span className="text-[9px] text-text-muted text-center p-1 leading-tight">
-                                {card?.name}
-                              </span>
+                          : <div className="w-full h-full relative">
+                              <img src="https://upload.wikimedia.org/wikipedia/en/3/3b/Pokemon_Trading_Card_Game_cardback.jpg" alt="card back" className="w-full h-full object-cover opacity-80" />
+                              <div className="absolute bottom-0 left-0 right-0 px-1 pb-1 pt-3" style={{ background: 'linear-gradient(to top, rgba(0,0,0,0.85) 0%, transparent 100%)' }}>
+                                <span className="text-[8px] text-white font-semibold leading-tight block text-center truncate">{card?.name}</span>
+                              </div>
                             </div>
                         }
                         <HoloOverlay variant={item.variant} />

--- a/frontend/src/pages/HomeScreen.jsx
+++ b/frontend/src/pages/HomeScreen.jsx
@@ -59,7 +59,7 @@ function CardThumb({ card, onClick }) {
         {img
           ? <img src={img} alt={card.name} className="w-full h-full object-cover" loading="lazy" />
           : <div className="w-full h-full relative">
-              <img src="https://upload.wikimedia.org/wikipedia/en/a/a7/Pokemon_card_back.jpg" alt="card back" className="w-full h-full object-cover opacity-80" />
+              <img src="https://upload.wikimedia.org/wikipedia/en/3/3b/Pokemon_Trading_Card_Game_cardback.jpg" alt="card back" className="w-full h-full object-cover opacity-80" />
               <div className="absolute bottom-0 left-0 right-0 px-1 pb-1 pt-3" style={{ background: 'linear-gradient(to top, rgba(0,0,0,0.85) 0%, transparent 100%)' }}>
                 <span className="text-[8px] text-white font-semibold leading-tight block text-center truncate">{card.name}</span>
               </div>
@@ -457,7 +457,7 @@ export default function HomeScreen() {
                       {resolveCardImageUrl(card)
                         ? <img src={resolveCardImageUrl(card)} alt={card.name} className="w-full h-full object-cover" loading="lazy" />
                         : <div className="w-full h-full relative">
-                            <img src="https://upload.wikimedia.org/wikipedia/en/a/a7/Pokemon_card_back.jpg" alt="card back" className="w-full h-full object-cover opacity-80" />
+                            <img src="https://upload.wikimedia.org/wikipedia/en/3/3b/Pokemon_Trading_Card_Game_cardback.jpg" alt="card back" className="w-full h-full object-cover opacity-80" />
                             <div className="absolute bottom-0 left-0 right-0 px-1 pb-1 pt-3" style={{ background: 'linear-gradient(to top, rgba(0,0,0,0.85) 0%, transparent 100%)' }}>
                               <span className="text-[8px] text-white font-semibold leading-tight block text-center truncate">{card.name}</span>
                             </div>

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -676,7 +676,7 @@ export default function Settings() {
               <SettingsRow label={t('settings.app')} description="Pokemon TCG Collection">
                 <span className="text-xs font-bold text-text-muted px-2 py-1 rounded-lg"
                   style={{ background: 'rgba(255,255,255,0.05)' }}>
-                  v1.2
+                  v1.4
                 </span>
               </SettingsRow>
               <SettingsRow label={t('settings.dataSource')} description={t('settings.dataSourceDesc')}>


### PR DESCRIPTION
## Problem
PR #128 used a broken Wikimedia URL that returns 404.

## Fix
- Replaced with working URL: `https://upload.wikimedia.org/wikipedia/en/3/3b/Pokemon_Trading_Card_Game_cardback.jpg`
- Also added card back fallback to `Collection.jsx` (was missing)
- Bumped version to v1.4 (was still at v1.2 in main)

## Files
- `HomeScreen.jsx` — fixed URL
- `CardListItem.jsx` — fixed URL  
- `Collection.jsx` — added card back + name overlay
- `Settings.jsx` — v1.4