### PR TITLE
feat: CardImage component with onError fallback (v1.5)

### DIFF
--- a/frontend/src/components/CardImage.jsx
+++ b/frontend/src/components/CardImage.jsx
@@ -1,0 +1,38 @@
+/**
+ * CardImage — renders a card image with automatic fallback to the Pokemon card back
+ * when the image is missing or fails to load (e.g. API returns 404/JSON error).
+ *
+ * Usage: <CardImage src={url} alt={card.name} className="w-full h-full object-cover" />
+ */
+const CARD_BACK = 'https://upload.wikimedia.org/wikipedia/en/3/3b/Pokemon_Trading_Card_Game_cardback.jpg'
+
+export default function CardImage({ src, alt, className, showName = false, style, loading = 'lazy' }) {
+  const handleError = (e) => {
+    e.currentTarget.onerror = null // prevent infinite loop
+    e.currentTarget.src = CARD_BACK
+    e.currentTarget.style.opacity = '0.8'
+  }
+
+  return (
+    <div className="relative w-full h-full">
+      <img
+        src={src || CARD_BACK}
+        alt={alt}
+        className={className || 'w-full h-full object-cover'}
+        style={{ ...(src ? {} : { opacity: 0.8 }), ...style }}
+        loading={loading}
+        onError={handleError}
+      />
+      {(!src || showName) && alt && (
+        <div
+          className="absolute bottom-0 left-0 right-0 px-1 pb-1 pt-3"
+          style={{ background: 'linear-gradient(to top, rgba(0,0,0,0.85) 0%, transparent 100%)' }}
+        >
+          <span className="text-[8px] text-white font-semibold leading-tight block text-center truncate">
+            {alt}
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/CardListItem.jsx
+++ b/frontend/src/components/CardListItem.jsx
@@ -1,3 +1,4 @@
+import CardImage from './CardImage'
 import clsx from 'clsx'
 
 /**
@@ -44,18 +45,7 @@ export default function CardListItem({
     >
       {/* Card thumbnail */}
       <div className="flex-shrink-0 w-12 h-[68px] rounded-lg overflow-hidden bg-bg-elevated shadow-lg ring-1 ring-white/5">
-        {image ? (
-          <img
-            src={image}
-            alt={name}
-            className="w-full h-full object-cover"
-            loading="lazy"
-          />
-        ) : (
-          <div className="w-full h-full relative">
-            <img src="https://upload.wikimedia.org/wikipedia/en/3/3b/Pokemon_Trading_Card_Game_cardback.jpg" alt="card back" className="w-full h-full object-cover opacity-80" />
-          </div>
-        )}
+        <CardImage src={image} alt={name} className="w-full h-full object-cover" />
       </div>
 
       {/* Content — flex-1 min-w-0 so it shrinks and wraps instead of overflowing */}

--- a/frontend/src/pages/Collection.jsx
+++ b/frontend/src/pages/Collection.jsx
@@ -4,6 +4,7 @@ import { Trash2, Check, X, Filter, SortAsc, Download, ChevronUp, ChevronDown, Se
 import { getCollection, updateCollectionItem, removeFromCollection, exportCSV, exportPDF, getSets } from '../api/client'
 import { CustomCardModal } from '../components/CardItem'
 import { useSettings } from '../contexts/SettingsContext'
+import CardImage from '../components/CardImage'
 import CardListItem from '../components/CardListItem'
 import TabNav from '../components/TabNav'
 import toast from 'react-hot-toast'
@@ -645,18 +646,7 @@ export default function Collection() {
                         className="aspect-[2.5/3.5] relative rounded-xl overflow-hidden flex-shrink-0"
                       >
                         {resolveCardImageUrl(card)
-                          ? <img
-                              src={resolveCardImageUrl(card)}
-                              alt={card?.name}
-                              className="w-full h-full object-cover"
-                              loading="lazy"
-                            />
-                          : <div className="w-full h-full relative">
-                              <img src="https://upload.wikimedia.org/wikipedia/en/3/3b/Pokemon_Trading_Card_Game_cardback.jpg" alt="card back" className="w-full h-full object-cover opacity-80" />
-                              <div className="absolute bottom-0 left-0 right-0 px-1 pb-1 pt-3" style={{ background: 'linear-gradient(to top, rgba(0,0,0,0.85) 0%, transparent 100%)' }}>
-                                <span className="text-[8px] text-white font-semibold leading-tight block text-center truncate">{card?.name}</span>
-                              </div>
-                            </div>
+                          <CardImage src={resolveCardImageUrl(card)} alt={card?.name} className="w-full h-full object-cover" />
                         }
                         <HoloOverlay variant={item.variant} />
                       </div>
@@ -760,11 +750,7 @@ export default function Collection() {
                           <td className="px-4 py-3">
                             <div className="flex items-center gap-3">
                               <div className="w-8 h-10 flex-shrink-0 rounded overflow-hidden">
-                                {resolveCardImageUrl(card) ? (
-                                  <img src={resolveCardImageUrl(card)} alt={card?.name} className="w-full h-full object-cover" />
-                                ) : (
-                                  <div className="w-full h-full bg-border" />
-                                )}
+                                <CardImage src={resolveCardImageUrl(card)} alt={card?.name} className="w-full h-full object-cover" />
                               </div>
                               <div className="min-w-0">
                                 <div className="flex items-center gap-1 flex-wrap">

--- a/frontend/src/pages/HomeScreen.jsx
+++ b/frontend/src/pages/HomeScreen.jsx
@@ -15,6 +15,7 @@ import toast from 'react-hot-toast'
 import { format, parseISO } from 'date-fns'
 import { useTilt } from '../hooks/useTilt'
 import { resolveCardImageUrl } from '../utils/imageUrl'
+import CardImage from '../components/CardImage'
 
 // Compact number formatter for mobile (1.2k, 3.4M, etc.)
 function compactNum(n) {
@@ -56,15 +57,7 @@ function CardThumb({ card, onClick }) {
       <div className="aspect-[2.5/3.5] rounded-xl overflow-hidden shadow-lg transition-all duration-150
         group-hover:shadow-brand-red/20"
         style={{ border: '1px solid rgba(255,255,255,0.07)', boxShadow: '0 4px 16px rgba(0,0,0,0.5)' }}>
-        {img
-          ? <img src={img} alt={card.name} className="w-full h-full object-cover" loading="lazy" />
-          : <div className="w-full h-full relative">
-              <img src="https://upload.wikimedia.org/wikipedia/en/3/3b/Pokemon_Trading_Card_Game_cardback.jpg" alt="card back" className="w-full h-full object-cover opacity-80" />
-              <div className="absolute bottom-0 left-0 right-0 px-1 pb-1 pt-3" style={{ background: 'linear-gradient(to top, rgba(0,0,0,0.85) 0%, transparent 100%)' }}>
-                <span className="text-[8px] text-white font-semibold leading-tight block text-center truncate">{card.name}</span>
-              </div>
-            </div>
-        }
+        <CardImage src={img} alt={card.name} className="w-full h-full object-cover" />
       </div>
     </div>
   )
@@ -454,15 +447,7 @@ export default function HomeScreen() {
                     <div className="aspect-[2.5/3.5] rounded-xl overflow-hidden shadow-lg transition-all duration-150
                       group-hover:scale-[1.03]"
                       style={{ border:'1px solid rgba(245,200,66,0.2)', boxShadow:'0 4px 16px rgba(0,0,0,0.5)' }}>
-                      {resolveCardImageUrl(card)
-                        ? <img src={resolveCardImageUrl(card)} alt={card.name} className="w-full h-full object-cover" loading="lazy" />
-                        : <div className="w-full h-full relative">
-                            <img src="https://upload.wikimedia.org/wikipedia/en/3/3b/Pokemon_Trading_Card_Game_cardback.jpg" alt="card back" className="w-full h-full object-cover opacity-80" />
-                            <div className="absolute bottom-0 left-0 right-0 px-1 pb-1 pt-3" style={{ background: 'linear-gradient(to top, rgba(0,0,0,0.85) 0%, transparent 100%)' }}>
-                              <span className="text-[8px] text-white font-semibold leading-tight block text-center truncate">{card.name}</span>
-                            </div>
-                          </div>
-                      }
+                      <CardImage src={resolveCardImageUrl(card)} alt={card.name} className="w-full h-full object-cover" />
                     </div>
                     <span className="absolute top-1 left-1 text-[9px] font-black px-1 rounded leading-4"
                       style={{ background:'rgba(0,0,0,0.85)', color:'#f5c842' }}>#{i+1}</span>


### PR DESCRIPTION
## Problem
Cards like `MEP 010` have an image URL but the API returns `{"detail":"No image URL for this card"}` instead of an actual image. The browser shows a broken image icon.

## Solution
Created a reusable `CardImage` component with an `onError` handler that automatically falls back to the Pokemon card back image when:
- The image URL is missing/null
- The image fails to load (404, JSON error, etc.)

## Changes
- **New:** `frontend/src/components/CardImage.jsx`
- **Updated:** `HomeScreen.jsx`, `Collection.jsx`, `CardListItem.jsx` to use `CardImage`
- **Version:** v1.5

## How it works
```jsx
<CardImage src={url} alt={cardName} className="..." />
```
If `src` is null or the image fails to load, it shows the card back with the card name in a gradient overlay.