### PR TITLE
fix: Collection.jsx broken JSX syntax causing build failure

### DIFF
--- a/frontend/src/pages/Collection.jsx
+++ b/frontend/src/pages/Collection.jsx
@@ -645,9 +645,7 @@ export default function Collection() {
                       <div
                         className="aspect-[2.5/3.5] relative rounded-xl overflow-hidden flex-shrink-0"
                       >
-                        {resolveCardImageUrl(card)
-                          <CardImage src={resolveCardImageUrl(card)} alt={card?.name} className="w-full h-full object-cover" />
-                        }
+                        <CardImage src={resolveCardImageUrl(card)} alt={card?.name} className="w-full h-full object-cover" />
                         <HoloOverlay variant={item.variant} />
                       </div>
                       {(() => {


### PR DESCRIPTION
Fixes broken JSX left in `Collection.jsx` by PR #131 — the ternary condition `{resolveCardImageUrl(card)` was left without `? ... : ...`, causing a build error.

Replaces with a clean `<CardImage>` call that handles null src internally.