### PR TITLE
fix: show name overlay when image fails to load

### DIFF
--- a/frontend/src/components/CardImage.jsx
+++ b/frontend/src/components/CardImage.jsx
@@ -4,14 +4,21 @@
  *
  * Usage: <CardImage src={url} alt={card.name} className="w-full h-full object-cover" />
  */
+import { useState } from 'react'
+
 const CARD_BACK = '/cardback.jpg'
 
 export default function CardImage({ src, alt, className, showName = false, style, loading = 'lazy' }) {
+  const [failed, setFailed] = useState(false)
+  
   const handleError = (e) => {
     e.currentTarget.onerror = null // prevent infinite loop
     e.currentTarget.src = CARD_BACK
     e.currentTarget.style.opacity = '0.8'
+    setFailed(true)
   }
+
+  const showOverlay = !src || failed || showName
 
   return (
     <div className="relative w-full h-full">
@@ -19,11 +26,11 @@ export default function CardImage({ src, alt, className, showName = false, style
         src={src || CARD_BACK}
         alt={alt}
         className={className || 'w-full h-full object-cover'}
-        style={{ ...(src ? {} : { opacity: 0.8 }), ...style }}
+        style={{ ...(src && !failed ? {} : { opacity: 0.8 }), ...style }}
         loading={loading}
         onError={handleError}
       />
-      {(!src || showName) && alt && (
+      {showOverlay && alt && (
         <div
           className="absolute bottom-0 left-0 right-0 px-1 pb-1 pt-3"
           style={{ background: 'linear-gradient(to top, rgba(0,0,0,0.85) 0%, transparent 100%)' }}


### PR DESCRIPTION
The name overlay only showed when `src` was null. But for cards like MEP 010, `src` has a value — it just fails to load (API returns JSON error). 

## Fix
Added `useState` to track when `onError` fires, then show the overlay when:
- `src` is null/undefined, OR
- the image failed to load (`onError` triggered)