### PR TITLE
Fix issue 158 data fallbacks and variants

### DIFF
--- a/backend/api/analytics.py
+++ b/backend/api/analytics.py
@@ -3,24 +3,16 @@ from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import func
 from api.auth import get_current_user
 from database import get_db
+from services.card_values import effective_market_price
 from models import CollectionItem, Card, PriceHistory, PortfolioSnapshot, Set, ProductPurchase, User
 from typing import Optional
 import datetime
 
 router = APIRouter()
 
-# Variants that use the Cardmarket holo price family
-HOLO_VARIANTS = {"Holo", "Holo Rare", "Holo V", "Holo VMAX", "Holo VSTAR", "Holo ex", "Reverse Holo"}
-
-
 def _get_item_price(item):
     """Return the correct market price for a collection item, respecting holo variant."""
-    card = item.card
-    if not card:
-        return 0
-    if item.variant in HOLO_VARIANTS and card.price_market_holo is not None:
-        return card.price_market_holo
-    return card.price_market or 0
+    return effective_market_price(item.card, item.variant)
 
 
 @router.get("/duplicates")
@@ -47,7 +39,7 @@ def get_duplicates(
                 "images_small": item.card.images_small,
                 "quantity": item.quantity,
                 "price_market": item.card.price_market,
-                "total_value": round((item.card.price_market or 0) * item.quantity, 2),
+                "total_value": round(_get_item_price(item) * item.quantity, 2),
                 "rarity": item.card.rarity,
             })
 
@@ -132,7 +124,7 @@ def get_rarity_stats(
             rarity = item.card.rarity or "Unknown"
             rarity_counts[rarity] = rarity_counts.get(rarity, 0) + item.quantity
             rarity_values[rarity] = rarity_values.get(rarity, 0) + (
-                (item.card.price_market or 0) * item.quantity
+                _get_item_price(item) * item.quantity
             )
 
     total = sum(rarity_counts.values())

--- a/backend/api/cards.py
+++ b/backend/api/cards.py
@@ -8,6 +8,7 @@ from database import get_db
 from models import Card, Set, PriceHistory, CustomCardMatch, CollectionItem, WishlistItem, BinderCard, Setting, User
 from schemas import CardBase, CardWithSet, PriceHistoryResponse, CardCustomCreate, CustomCardUpdate
 from services import pokemon_api
+from services.card_fallbacks import apply_cross_language_fallbacks
 import datetime
 import re
 from uuid import uuid4
@@ -42,6 +43,7 @@ def _card_to_dict(card: Card) -> dict:
         "artist": card.artist,
         "images_small": card.images_small,
         "images_large": card.images_large,
+        "image_source_lang": getattr(card, "image_source_lang", None),
         "is_custom": card.is_custom or False,
         "lang": card.lang or "en",
         "price_market": card.price_market,
@@ -61,6 +63,7 @@ def _card_to_dict(card: Card) -> dict:
         "price_tcg_normal_market": getattr(card, 'price_tcg_normal_market', None),
         "price_tcg_reverse_market": getattr(card, 'price_tcg_reverse_market', None),
         "price_tcg_holo_market": getattr(card, 'price_tcg_holo_market', None),
+        "price_source_lang": getattr(card, "price_source_lang", None),
     }
 
 
@@ -140,8 +143,13 @@ def _search_by_code_number(
                 set_data = pokemon_api.get_set_cards(tcg_set_id, lang=set_lang)
                 for card_data in set_data.get("cards", []):
                     parsed = pokemon_api.parse_card_for_db(card_data, default_set_id=tcg_set_id, lang=set_lang)
+                    parsed = apply_cross_language_fallbacks(db, parsed)
                     existing = db.query(Card).filter(Card.id == parsed["id"]).first()
-                    if not existing:
+                    if existing:
+                        for key, value in parsed.items():
+                            if key != "id":
+                                setattr(existing, key, value)
+                    else:
                         db.add(Card(**parsed))
                 db.commit()
             except Exception:
@@ -474,6 +482,7 @@ def migrate_custom_card(
         if not api_data:
             raise HTTPException(status_code=404, detail="API card not found on TCGdex")
         parsed = pokemon_api.parse_card_for_db(api_data, lang=fetch_lang)
+        parsed = apply_cross_language_fallbacks(db, parsed)
         composite_api_card_id = parsed["id"]  # e.g. "sv1-1_en"
 
         # Ensure set record exists
@@ -491,7 +500,7 @@ def migrate_custom_card(
         existing_api_card = db.query(Card).filter(Card.id == composite_api_card_id).first()
         if existing_api_card:
             for k, v in parsed.items():
-                if k != "id" and v is not None:
+                if k != "id":
                     setattr(existing_api_card, k, v)
             existing_api_card.is_custom = False
         else:
@@ -714,6 +723,7 @@ def get_card(
             raise HTTPException(status_code=404, detail="Card not found")
 
         parsed = pokemon_api.parse_card_for_db(card_data, lang=card_lang)
+        parsed = apply_cross_language_fallbacks(db, parsed)
 
         # Ensure set exists
         if parsed.get("set_id"):

--- a/backend/api/collection.py
+++ b/backend/api/collection.py
@@ -6,22 +6,15 @@ from database import get_db
 from models import CollectionItem, Card, Set, User
 from schemas import CollectionItemCreate, CollectionItemUpdate, CollectionItemResponse, BulkCollectionAddRequest, BulkCollectionAddResponse
 from services import pokemon_api
+from services.card_fallbacks import apply_cross_language_fallbacks
+from services.card_values import effective_market_price
 import datetime
 
 router = APIRouter()
 
-# Variants that use the Cardmarket holo price family
-HOLO_VARIANTS = {"Holo", "Holo Rare", "Holo V", "Holo VMAX", "Holo VSTAR", "Holo ex", "Reverse Holo"}
-
-
 def _get_item_price(item):
     """Return the correct market price for a collection item, respecting holo variant."""
-    card = item.card
-    if not card:
-        return 0
-    if item.variant in HOLO_VARIANTS and card.price_market_holo is not None:
-        return card.price_market_holo
-    return card.price_market or 0
+    return effective_market_price(item.card, item.variant)
 
 
 def ensure_card_exists(db: Session, card_id: str, lang: str = "en") -> Card:
@@ -36,6 +29,7 @@ def ensure_card_exists(db: Session, card_id: str, lang: str = "en") -> Card:
                 detail=f"Card {card_id} not found in local database. Please run a Sync first."
             )
         parsed = pokemon_api.parse_card_for_db(card_data, lang=lang)
+        parsed = apply_cross_language_fallbacks(db, parsed)
         if parsed.get("set_id"):
             set_data = card_data.get("set", {})
             if set_data:

--- a/backend/api/export.py
+++ b/backend/api/export.py
@@ -3,6 +3,7 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session, joinedload
 from api.auth import get_current_user
 from database import get_db
+from services.card_values import effective_market_price
 from models import CollectionItem, Card, User
 import io
 import csv
@@ -38,7 +39,8 @@ def export_csv(
         if not card:
             continue
         set_name = card.set_ref.name if card.set_ref else ""
-        total_value = round((card.price_market or 0) * item.quantity, 2)
+        current_price = effective_market_price(card, item.variant)
+        total_value = round(current_price * item.quantity, 2)
 
         writer.writerow([
             card.id,
@@ -49,7 +51,7 @@ def export_csv(
             item.quantity,
             item.condition,
             item.purchase_price or "",
-            card.price_market or "",
+            current_price or "",
             total_value,
             item.added_at.strftime("%Y-%m-%d") if item.added_at else "",
         ])
@@ -118,7 +120,7 @@ def export_pdf(
             if not card:
                 continue
             set_name = (card.set_ref.name[:20] if card.set_ref else "")
-            val = round((card.price_market or 0) * item.quantity, 2)
+            val = round(effective_market_price(card, item.variant) * item.quantity, 2)
             total_value += val
 
             data.append([

--- a/backend/api/images.py
+++ b/backend/api/images.py
@@ -3,11 +3,44 @@ import httpx
 from sqlalchemy.orm import Session
 
 from database import get_db
-from models import Card, ImageCache, Set
+from models import Card, ImageCache, Set, Setting
 
 router = APIRouter()
 
 _client = httpx.Client(timeout=15, follow_redirects=True)
+
+
+def _setting_enabled(db: Session, key: str, default: bool = True) -> bool:
+    row = db.query(Setting).filter(Setting.key == key).first()
+    if row is None:
+        return default
+    return str(row.value).lower() in {"true", "1", "yes", "on"}
+
+
+def _other_lang(lang: str | None) -> str | None:
+    if lang == "de":
+        return "en"
+    if lang == "en":
+        return "de"
+    return None
+
+
+def _card_back_response():
+    svg = b'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 250 350">
+<defs><linearGradient id="g" x1="0" x2="1" y1="0" y2="1"><stop offset="0" stop-color="#1e3a8a"/><stop offset="1" stop-color="#111827"/></linearGradient></defs>
+<rect width="250" height="350" rx="18" fill="url(#g)"/>
+<rect x="14" y="14" width="222" height="322" rx="14" fill="none" stroke="#f8fafc" stroke-width="8" opacity=".85"/>
+<circle cx="125" cy="175" r="54" fill="#f8fafc" opacity=".95"/>
+<circle cx="125" cy="175" r="22" fill="#111827"/>
+<path d="M35 175h180" stroke="#111827" stroke-width="14"/>
+<text x="125" y="62" text-anchor="middle" font-family="Arial,sans-serif" font-size="24" font-weight="700" fill="#f8fafc">POKEMON</text>
+<text x="125" y="302" text-anchor="middle" font-family="Arial,sans-serif" font-size="18" font-weight="700" fill="#f8fafc">NO IMAGE</text>
+</svg>'''
+    return Response(
+        content=svg,
+        media_type="image/svg+xml",
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
 
 
 def _get_or_fetch(db: Session, key: str, url: str) -> tuple[bytes, str]:
@@ -47,9 +80,12 @@ def get_card_image(card_id: str, size: str, db: Session = Depends(get_db)):
 
     url = card.images_small if size == "small" else card.images_large
     if not url:
-        raise HTTPException(status_code=404, detail="No image URL for this card")
+        return _card_back_response()
 
-    data, content_type = _get_or_fetch(db, f"card:{card_id}:{size}", url)
+    try:
+        data, content_type = _get_or_fetch(db, f"card:{card_id}:{size}", url)
+    except HTTPException:
+        return _card_back_response()
     return Response(
         content=data,
         media_type=content_type,
@@ -67,10 +103,27 @@ def get_set_image(set_id: str, image_type: str, db: Session = Depends(get_db)):
         raise HTTPException(status_code=404, detail="Set not found")
 
     url = card_set.images_logo if image_type == "logo" else card_set.images_symbol
+    cache_key = f"set:{set_id}:{image_type}"
+
+    if not url and _setting_enabled(db, "cross_language_image_fallback", True):
+        fallback_lang = _other_lang(card_set.lang)
+        tcg_set_id = card_set.tcg_set_id or card_set.id.rsplit("_", 1)[0]
+        if fallback_lang:
+            sibling = db.query(Set).filter(
+                Set.tcg_set_id == tcg_set_id,
+                Set.lang == fallback_lang,
+            ).first()
+            if sibling:
+                url = sibling.images_logo if image_type == "logo" else sibling.images_symbol
+                cache_key = f"set:{set_id}:{image_type}:fallback:{fallback_lang}"
+
     if not url:
         raise HTTPException(status_code=404, detail="No image URL for this set")
 
-    data, content_type = _get_or_fetch(db, f"set:{set_id}:{image_type}", url)
+    try:
+        data, content_type = _get_or_fetch(db, cache_key, url)
+    except HTTPException:
+        raise HTTPException(status_code=404, detail="No image URL for this set")
     return Response(
         content=data,
         media_type=content_type,

--- a/backend/api/sets.py
+++ b/backend/api/sets.py
@@ -7,6 +7,7 @@ from database import get_db
 from models import Set, Card, CollectionItem, Setting, User
 from schemas import SetBase
 from services import pokemon_api
+from services.card_fallbacks import apply_cross_language_fallbacks
 
 router = APIRouter()
 
@@ -190,13 +191,14 @@ def get_set_checklist(
             set_data = pokemon_api.get_set_cards(tcg_id, lang=set_lang)
             for card_data in set_data.get("cards", []):
                 parsed = pokemon_api.parse_card_for_db(card_data, default_set_id=tcg_id, lang=set_lang)
+                parsed = apply_cross_language_fallbacks(db, parsed)
                 existing = db.query(Card).filter(Card.id == parsed["id"]).first()
-                if not existing:
-                    db.add(Card(**parsed))
+                if existing:
+                    for key, value in parsed.items():
+                        if key != "id":
+                            setattr(existing, key, value)
                 else:
-                    # Update lang on existing card if it was NULL
-                    if not existing.lang:
-                        existing.lang = set_lang
+                    db.add(Card(**parsed))
             db.commit()
             cards = db.query(Card).filter(
                 Card.set_id == tcg_id,
@@ -237,6 +239,8 @@ def get_set_checklist(
             "rarity": card.rarity,
             "images_small": card.images_small,
             "images_large": card.images_large,
+            "image_source_lang": getattr(card, "image_source_lang", None),
+            "price_source_lang": getattr(card, "price_source_lang", None),
             "owned": owned,
             "quantity": qty,
             "price_market": card.price_market,

--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -21,6 +21,7 @@ PER_USER_KEYS = {
 ADMIN_ONLY_KEYS = {
     "full_sync_interval_days", "price_sync_interval_minutes", "multi_user_mode",
     "tcgdex_sync_languages", "debug_mode",
+    "cross_language_price_fallback", "cross_language_image_fallback",
 }
 
 DEFAULT_SETTINGS = {
@@ -36,6 +37,8 @@ DEFAULT_SETTINGS = {
     "price_primary": "trend",
     "price_display": '["trend", "avg1", "avg7", "avg30", "low"]',
     "tcgdex_sync_languages": "en,de",
+    "cross_language_price_fallback": "true",
+    "cross_language_image_fallback": "true",
     "debug_mode": "false",
 }
 
@@ -55,7 +58,7 @@ def _normalize_tcgdex_sync_languages(value) -> str:
 def _coerce_setting_value(key: str, value) -> str:
     if key == "tcgdex_sync_languages":
         return _normalize_tcgdex_sync_languages(value)
-    if key == "debug_mode":
+    if key in {"debug_mode", "cross_language_price_fallback", "cross_language_image_fallback"}:
         return "true" if str(value).lower() in {"true", "1", "yes", "on"} else "false"
     return str(value)
 

--- a/backend/api/social.py
+++ b/backend/api/social.py
@@ -7,10 +7,9 @@ from sqlalchemy.orm import Session
 from api.auth import get_current_user
 from database import get_db
 from models import Card, CollectionItem, ProductPurchase, Set, User, WishlistItem
+from services.card_values import effective_market_price
 
 router = APIRouter()
-
-HOLO_VARIANTS = {"Holo", "Holo Rare", "Holo V", "Holo VMAX", "Holo VSTAR", "Holo ex", "Reverse Holo"}
 
 
 ACHIEVEMENTS = [
@@ -190,11 +189,7 @@ def _card_payload(card: Card | None):
 
 def _load_user_stats(db: Session, user_ids: list[int] | None = None):
     def _get_price(row):
-        if hasattr(row, "variant") and row.variant in HOLO_VARIANTS:
-            holo = getattr(row, "price_market_holo", None)
-            if holo is not None:
-                return holo
-        return row.price_market or 0
+        return effective_market_price(row, getattr(row, "variant", None))
 
     user_query = db.query(User).filter(User.is_active == True)
     if user_ids is not None:

--- a/backend/database.py
+++ b/backend/database.py
@@ -30,6 +30,8 @@ DEFAULT_SETTINGS = {
     "price_primary": "trend",
     "multi_user_mode": "false",
     "tcgdex_sync_languages": "en,de",
+    "cross_language_price_fallback": "true",
+    "cross_language_image_fallback": "true",
     "debug_mode": "false",
 }
 
@@ -187,6 +189,9 @@ def _run_migrations(conn):
         "ALTER TABLE product_purchases ADD COLUMN IF NOT EXISTS user_id INTEGER REFERENCES users(id)",
         "ALTER TABLE portfolio_snapshots ADD COLUMN IF NOT EXISTS user_id INTEGER REFERENCES users(id)",
         "ALTER TABLE users ADD COLUMN IF NOT EXISTS must_change_password BOOLEAN DEFAULT false",
+        # v43: Track when card prices/images are copied from another language.
+        "ALTER TABLE cards ADD COLUMN IF NOT EXISTS price_source_lang VARCHAR",
+        "ALTER TABLE cards ADD COLUMN IF NOT EXISTS image_source_lang VARCHAR",
     ]
     for stmt in migrations:
         try:

--- a/backend/models.py
+++ b/backend/models.py
@@ -52,6 +52,7 @@ class Card(Base):
     artist = Column(String)
     images_small = Column(String)
     images_large = Column(String)
+    image_source_lang = Column(String, nullable=True)  # Set when images are copied from another TCGdex language
     is_custom = Column(Boolean, default=False)
     lang = Column(String, default="en")      # "en" or "de"
     # Cardmarket EUR prices
@@ -83,6 +84,7 @@ class Card(Base):
     price_tcg_holo_low = Column(Float)
     price_tcg_holo_mid = Column(Float)
     price_tcg_holo_market = Column(Float)
+    price_source_lang = Column(String, nullable=True)  # Set when prices are copied from another TCGdex language
     # Card variants from TCGdex
     variants_normal = Column(Boolean)
     variants_reverse = Column(Boolean)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -36,6 +36,7 @@ class CardBase(BaseModel):
     artist: Optional[str] = None
     images_small: Optional[str] = None
     images_large: Optional[str] = None
+    image_source_lang: Optional[str] = None
     is_custom: bool = False
     price_market: Optional[float] = None
     price_low: Optional[float] = None
@@ -63,6 +64,7 @@ class CardBase(BaseModel):
     price_tcg_holo_low: Optional[float] = None
     price_tcg_holo_mid: Optional[float] = None
     price_tcg_holo_market: Optional[float] = None
+    price_source_lang: Optional[str] = None
     # Variants
     variants_normal: Optional[bool] = None
     variants_reverse: Optional[bool] = None

--- a/backend/services/card_fallbacks.py
+++ b/backend/services/card_fallbacks.py
@@ -1,0 +1,154 @@
+"""Cross-language fallback helpers for TCGdex card rows.
+
+TCGdex can have images or pricing in one language response while the matching
+card in another language has no public API data. These helpers keep the native
+card row but fill missing image/price fields from the sibling language when the
+admin setting allows it, and record the source language for visible UI tags.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from models import Card, Setting
+from services import pokemon_api
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_LANGS = {"en", "de"}
+PRICE_FIELDS = (
+    "price_market",
+    "price_low",
+    "price_mid",
+    "price_high",
+    "price_trend",
+    "price_avg1",
+    "price_avg7",
+    "price_avg30",
+    "price_market_holo",
+    "price_low_holo",
+    "price_trend_holo",
+    "price_avg1_holo",
+    "price_avg7_holo",
+    "price_avg30_holo",
+    "price_tcg_normal_low",
+    "price_tcg_normal_mid",
+    "price_tcg_normal_high",
+    "price_tcg_normal_market",
+    "price_tcg_reverse_low",
+    "price_tcg_reverse_mid",
+    "price_tcg_reverse_market",
+    "price_tcg_holo_low",
+    "price_tcg_holo_mid",
+    "price_tcg_holo_market",
+)
+IMAGE_FIELDS = ("images_small", "images_large")
+
+
+def _setting_enabled(db: Session, key: str, default: bool = True) -> bool:
+    row = db.query(Setting).filter(Setting.key == key).first()
+    if row is None:
+        return default
+    return str(row.value).lower() in {"true", "1", "yes", "on"}
+
+
+def _other_lang(lang: Optional[str]) -> Optional[str]:
+    if lang == "de":
+        return "en"
+    if lang == "en":
+        return "de"
+    return None
+
+
+def _has_price(data: dict) -> bool:
+    return any(data.get(field) is not None for field in PRICE_FIELDS)
+
+
+def _has_image(data: dict) -> bool:
+    return any(data.get(field) for field in IMAGE_FIELDS)
+
+
+def _card_to_data(card: Card) -> dict:
+    data = {field: getattr(card, field, None) for field in (*PRICE_FIELDS, *IMAGE_FIELDS)}
+    # Do not cascade fallback data. A card may only borrow native data from its
+    # sibling language, never data that was itself borrowed from somewhere else.
+    if getattr(card, "price_source_lang", None):
+        for field in PRICE_FIELDS:
+            data[field] = None
+    if getattr(card, "image_source_lang", None):
+        for field in IMAGE_FIELDS:
+            data[field] = None
+    return data
+
+
+def _load_sibling_data(db: Session, tcg_card_id: str, lang: str) -> Optional[dict]:
+    sibling = db.query(Card).filter(
+        Card.tcg_card_id == tcg_card_id,
+        Card.lang == lang,
+        Card.is_custom == False,
+    ).first()
+    if sibling:
+        return _card_to_data(sibling)
+
+    try:
+        card_data = pokemon_api.get_card(tcg_card_id, lang=lang)
+    except Exception as exc:
+        logger.debug("Failed to fetch %s in %s for fallback: %s", tcg_card_id, lang, exc)
+        return None
+
+    if not card_data:
+        return None
+    return pokemon_api.parse_card_for_db(card_data, lang=lang)
+
+
+def apply_cross_language_fallbacks(
+    db: Session,
+    parsed: dict,
+    *,
+    price_enabled: Optional[bool] = None,
+    image_enabled: Optional[bool] = None,
+) -> dict:
+    """Fill missing image/price fields from the DE/EN sibling card when allowed.
+
+    Native data always wins. That means a later sync that receives native prices
+    or images clears the fallback source tag automatically.
+    """
+    lang = parsed.get("lang")
+    tcg_card_id = parsed.get("tcg_card_id") or pokemon_api.strip_lang_suffix(parsed.get("id", ""))[0]
+
+    parsed["price_source_lang"] = None
+    parsed["image_source_lang"] = None
+
+    fallback_lang = _other_lang(lang)
+    if not tcg_card_id or not fallback_lang or lang not in SUPPORTED_LANGS:
+        return parsed
+
+    need_price = not _has_price(parsed)
+    need_image = not _has_image(parsed)
+
+    if price_enabled is None:
+        price_enabled = _setting_enabled(db, "cross_language_price_fallback", True)
+    if image_enabled is None:
+        image_enabled = _setting_enabled(db, "cross_language_image_fallback", True)
+
+    if not ((need_price and price_enabled) or (need_image and image_enabled)):
+        return parsed
+
+    sibling_data = _load_sibling_data(db, tcg_card_id, fallback_lang)
+    if not sibling_data:
+        return parsed
+
+    if need_price and price_enabled and _has_price(sibling_data):
+        for field in PRICE_FIELDS:
+            parsed[field] = sibling_data.get(field)
+        parsed["price_source_lang"] = fallback_lang
+
+    if need_image and image_enabled and _has_image(sibling_data):
+        for field in IMAGE_FIELDS:
+            parsed[field] = sibling_data.get(field)
+        parsed["image_source_lang"] = fallback_lang
+
+    return parsed

--- a/backend/services/card_values.py
+++ b/backend/services/card_values.py
@@ -1,0 +1,9 @@
+HOLO_VARIANTS = {"Holo", "Holo Rare", "Holo V", "Holo VMAX", "Holo VSTAR", "Holo ex", "Reverse Holo"}
+
+
+def effective_market_price(card, variant=None) -> float:
+    if not card:
+        return 0
+    if variant in HOLO_VARIANTS and getattr(card, "price_market_holo", None) is not None:
+        return card.price_market_holo or 0
+    return getattr(card, "price_market", None) or 0

--- a/backend/services/pokemon_api.py
+++ b/backend/services/pokemon_api.py
@@ -359,11 +359,13 @@ def parse_card_for_db(card_data: Dict, default_set_id: Optional[str] = None, lan
         "artist": card_data.get("illustrator"),
         "images_small": f"{image}/low.webp" if image else None,
         "images_large": f"{image}/high.webp" if image else None,
+        "image_source_lang": None,
         "lang": card_lang,
         "variants_normal": variants.get("normal"),
         "variants_reverse": variants.get("reverse"),
         "variants_holo": variants.get("holo"),
         "variants_first_edition": variants.get("firstEdition"),
+        "price_source_lang": None,
         **prices,
     }
 

--- a/backend/services/sync_service.py
+++ b/backend/services/sync_service.py
@@ -4,6 +4,8 @@ from sqlalchemy.orm import Session
 from sqlalchemy import func
 from models import Card, Set, CollectionItem, WishlistItem, PriceHistory, SyncLog, PortfolioSnapshot, CustomCardMatch, Setting, ProductPurchase, User
 from services import pokemon_api, telegram
+from services.card_fallbacks import apply_cross_language_fallbacks
+from services.card_values import effective_market_price
 
 logger = logging.getLogger(__name__)
 
@@ -121,7 +123,7 @@ def take_portfolio_snapshot(db: Session, user_id: int | None = None):
             CollectionItem.user_id == scoped_user_id
         ).all()
         total_value = sum(
-            (item.card.price_market or 0) * item.quantity
+            effective_market_price(item.card, item.variant) * item.quantity
             for item in collection_items
             if item.card
         )
@@ -275,6 +277,7 @@ def perform_full_sync(db: Session) -> dict:
                     set_obj.total = len(cards_data)
                 for card_data in cards_data:
                     parsed = pokemon_api.parse_card_for_db(card_data, default_set_id=tcg_id, lang=set_lang)
+                    parsed = apply_cross_language_fallbacks(db, parsed)
                     upsert_card(db, parsed)
                 db.commit()
             except Exception as e:
@@ -299,6 +302,7 @@ def perform_full_sync(db: Session) -> dict:
                 card_data = pokemon_api.get_card(tcg_id, lang=card_lang)
                 if card_data:
                     parsed = pokemon_api.parse_card_for_db(card_data, lang=card_lang)
+                    parsed = apply_cross_language_fallbacks(db, parsed)
                     # Ensure set exists (check by tcg_set_id since set IDs are now composite)
                     if parsed.get("set_id"):
                         set_exists = db.query(Set).filter(
@@ -372,6 +376,7 @@ def perform_price_sync(db: Session) -> dict:
                 card_data = pokemon_api.get_card(tcg_id, lang=card_lang)
                 if card_data:
                     parsed = pokemon_api.parse_card_for_db(card_data, lang=card_lang)
+                    parsed = apply_cross_language_fallbacks(db, parsed)
                     # Ensure set exists (check by tcg_set_id since set IDs are now composite)
                     if parsed.get("set_id"):
                         set_exists = db.query(Set).filter(

--- a/frontend/src/components/CardItem.jsx
+++ b/frontend/src/components/CardItem.jsx
@@ -9,6 +9,8 @@ import toast from 'react-hot-toast'
 import clsx from 'clsx'
 import { useTilt } from '../hooks/useTilt'
 import { resolveCardImageUrl } from '../utils/imageUrl'
+import { CARD_VARIANTS, getAvailableVariants, getDefaultVariant, getDefaultVariantOrNull } from '../utils/cardVariants'
+import FallbackBadges from './FallbackBadges'
 
 const RARITY_COLORS = {
   'Common': 'text-text-secondary',
@@ -442,6 +444,7 @@ export const CardItem = memo(function CardItem({ card, showActions = true, onAdd
                 {lang.toUpperCase()}
               </span>
             )}
+            <FallbackBadges card={card} compact />
           </div>
           {setName && <p className="text-xs text-text-muted truncate">{setName}</p>}
 
@@ -471,7 +474,7 @@ export const CardItem = memo(function CardItem({ card, showActions = true, onAdd
               className="flex-1 bg-brand-red/20 hover:bg-brand-red/40 text-brand-red text-xs py-1.5 rounded-lg font-medium transition-all flex items-center justify-center gap-1"
               onClick={(e) => {
                 e.stopPropagation()
-                addMutation.mutate({ card_id: card.id, quantity: 1, condition: 'NM', lang: card.lang || 'en' })
+                addMutation.mutate({ card_id: card.id, quantity: 1, condition: 'NM', variant: getDefaultVariantOrNull(card), lang: card.lang || 'en' })
               }}>
               <Plus size={12} /> {t('common.add')}
             </button>
@@ -512,26 +515,12 @@ export const CardItem = memo(function CardItem({ card, showActions = true, onAdd
   )
 })
 
-const CARD_VARIANTS = ['Normal', 'Holo', 'Reverse Holo', 'First Edition']
-
-
 export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
   if (!card || !card.id) return null
 
   const [quantity, setQuantity] = useState(1)
   const [condition, setCondition] = useState('NM')
-  const [variant, setVariant] = useState(() => {
-    const hasNormal = card.variants_normal
-    const hasReverse = card.variants_reverse
-    const hasHolo = card.variants_holo
-    const hasFirst = card.variants_first_edition
-
-    const available = [hasNormal && 'Normal', hasReverse && 'Reverse Holo', hasHolo && 'Holo', hasFirst && 'First Edition'].filter(Boolean)
-
-    if (available.length === 1) return available[0]
-    if (hasHolo && !hasNormal && !hasReverse) return 'Holo'
-    return ''
-  })
+  const [variant, setVariant] = useState(() => getDefaultVariant(card))
   const [purchasePrice, setPurchasePrice] = useState('')
   const [modalPeriod, setModalPeriod] = useState('total')
   const [resolvedCardId, setResolvedCardId] = useState(card.id)
@@ -644,6 +633,7 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
                     {setName && <p className="text-xs text-text-secondary mt-0.5">
                       {setName}{card.number ? ` · #${card.number}` : ''}
                     </p>}
+                    <FallbackBadges card={card} className="mt-1" />
                     {card.rarity && (
                       <p className={`text-xs mt-0.5 ${(RARITY_COLORS[card.rarity] || 'text-text-secondary')}`}>
                         {card.rarity}
@@ -665,6 +655,7 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
                 {setName && <p className="text-sm text-text-secondary">
                   {setName}{card.number ? ` · #${card.number}` : ''}
                 </p>}
+                <FallbackBadges card={card} className="mt-1" />
               </div>
               <button onClick={onClose} className="text-text-muted hover:text-text-primary transition-colors flex-shrink-0">
                 <X size={20} />
@@ -846,12 +837,7 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
                   {CARD_VARIANTS.map(v => <option key={v} value={v}>{v}</option>)}
                 </select>
                 {(() => {
-                  const available = [
-                    card.variants_normal && 'Normal',
-                    card.variants_reverse && 'Reverse Holo',
-                    card.variants_holo && 'Holo',
-                    card.variants_first_edition && 'First Edition',
-                  ].filter(Boolean)
+                  const available = getAvailableVariants(card)
                   return available.length > 0 ? (
                     <p className="text-[10px] text-text-muted mt-1">
                       📋 {t('card.availableVariants')}: {available.join(', ')}

--- a/frontend/src/components/CardScanner.jsx
+++ b/frontend/src/components/CardScanner.jsx
@@ -5,15 +5,14 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useSettings } from '../contexts/SettingsContext'
 import toast from 'react-hot-toast'
 import clsx from 'clsx'
-
-const CARD_VARIANTS = ['Normal', 'Holo', 'Reverse Holo', 'First Edition']
+import { CARD_VARIANTS, getDefaultVariant } from '../utils/cardVariants'
 
 // ─── Add-to-Collection Modal für Scan-Ergebnis ──────────────────────────────
 function ScanAddModal({ match, defaultLang, onClose, onAdded }) {
   const { t } = useSettings()
   const [quantity, setQuantity] = useState(1)
   const [condition, setCondition] = useState('NM')
-  const [variant, setVariant] = useState('')
+  const [variant, setVariant] = useState(() => getDefaultVariant(match))
   const [lang, setLang] = useState(match.lang || defaultLang || 'en')
   const [purchasePrice, setPurchasePrice] = useState('')
   const [adding, setAdding] = useState(false)

--- a/frontend/src/components/FallbackBadges.jsx
+++ b/frontend/src/components/FallbackBadges.jsx
@@ -1,0 +1,37 @@
+import clsx from 'clsx'
+import { useSettings } from '../contexts/SettingsContext'
+
+const sourceLabel = (lang) => (lang ? lang.toUpperCase() : '')
+
+export default function FallbackBadges({ card, className = '', compact = false }) {
+  const { t } = useSettings()
+  if (!card) return null
+  const priceLang = card.price_source_lang
+  const imageLang = card.image_source_lang
+  if (!priceLang && !imageLang) return null
+
+  const baseClass = compact
+    ? 'text-[9px] px-1 py-0.5 rounded leading-none'
+    : 'text-[10px] px-1.5 py-0.5 rounded-full'
+
+  return (
+    <div className={clsx('flex flex-wrap gap-1', className)}>
+      {priceLang && (
+        <span
+          className={clsx(baseClass, 'font-bold bg-amber-500/15 text-amber-300 border border-amber-500/30')}
+          title={t('fallback.priceFrom').replace('{lang}', sourceLabel(priceLang))}
+        >
+          {t('fallback.price')} {sourceLabel(priceLang)}
+        </span>
+      )}
+      {imageLang && (
+        <span
+          className={clsx(baseClass, 'font-bold bg-sky-500/15 text-sky-300 border border-sky-500/30')}
+          title={t('fallback.imageFrom').replace('{lang}', sourceLabel(imageLang))}
+        >
+          🖼 {sourceLabel(imageLang)}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/contexts/SettingsContext.jsx
+++ b/frontend/src/contexts/SettingsContext.jsx
@@ -10,6 +10,8 @@ const DEFAULT_SETTINGS = {
   price_display: '["trend", "avg1", "avg7", "avg30", "low"]',
   price_primary: 'trend',
   tcgdex_sync_languages: 'en,de',
+  cross_language_price_fallback: 'true',
+  cross_language_image_fallback: 'true',
   debug_mode: 'false',
 }
 

--- a/frontend/src/i18n/de.js
+++ b/frontend/src/i18n/de.js
@@ -20,6 +20,12 @@ const de = {
   },
 
   // Common / General
+  fallback: {
+    image: 'Bild',
+    price: 'Preis',
+    imageFrom: 'Bild-Fallback aus {lang}',
+    priceFrom: 'Preis-Fallback aus {lang}',
+  },
   common: {
     back: 'Zurück',
     loading: 'Laden...',
@@ -502,6 +508,10 @@ const de = {
     debugModeDesc: 'Schreibt ein temporäres Backend-Debug-Log, das zur Fehlersuche heruntergeladen werden kann. Nur Admin.',
     debugLogDownload: 'Log herunterladen',
     debugLogDownloadFailed: 'Debug-Log konnte nicht heruntergeladen werden',
+    crossLanguagePriceFallback: 'Sprachübergreifender Preis-Fallback',
+    crossLanguagePriceFallbackDesc: 'Nutzt DE ↔ EN Preise, wenn die gewählte Sprache keine öffentlichen TCGdex-Preisdaten hat. Fallback-Preise werden markiert.',
+    crossLanguageImageFallback: 'Sprachübergreifender Bild-Fallback',
+    crossLanguageImageFallbackDesc: 'Nutzt DE ↔ EN Bilder, wenn die gewählte Sprache kein öffentliches TCGdex-Bild hat. Fallback-Bilder werden markiert.',
     priceTrend: 'Trend',
     priceAvg1: 'Ø 1 Tag',
     priceAvg7: 'Ø 7 Tage',

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -20,6 +20,12 @@ const en = {
   },
 
   // Common / General
+  fallback: {
+    image: 'Image',
+    price: 'Price',
+    imageFrom: 'Image fallback from {lang}',
+    priceFrom: 'Price fallback from {lang}',
+  },
   common: {
     back: 'Back',
     loading: 'Loading...',
@@ -502,6 +508,10 @@ const en = {
     debugModeDesc: 'Write a temporary backend debug log that can be downloaded for troubleshooting. Admin only.',
     debugLogDownload: 'Download Log',
     debugLogDownloadFailed: 'Debug log download failed',
+    crossLanguagePriceFallback: 'Cross-language price fallback',
+    crossLanguagePriceFallbackDesc: 'Use DE ↔ EN prices when the selected language has no public TCGdex price data. Fallback prices are tagged.',
+    crossLanguageImageFallback: 'Cross-language image fallback',
+    crossLanguageImageFallbackDesc: 'Use DE ↔ EN images when the selected language has no public TCGdex image. Fallback images are tagged.',
     priceTrend: 'Trend',
     priceAvg1: 'Avg 1 Day',
     priceAvg7: 'Avg 7 Days',

--- a/frontend/src/i18n/zh.js
+++ b/frontend/src/i18n/zh.js
@@ -20,6 +20,12 @@ const zh = {
   },
 
   // Common / General
+  fallback: {
+    image: '图片',
+    price: '价格',
+    imageFrom: '图片回退来源：{lang}',
+    priceFrom: '价格回退来源：{lang}',
+  },
   common: {
     back: '返回',
     loading: '加载中...',
@@ -503,6 +509,10 @@ const zh = {
     debugModeDesc: '写入可下载的临时后端调试日志，用于排查问题。仅管理员。',
     debugLogDownload: '下载日志',
     debugLogDownloadFailed: '调试日志下载失败',
+    crossLanguagePriceFallback: '跨语言价格回退',
+    crossLanguagePriceFallbackDesc: '当所选语言没有公开 TCGdex 价格数据时使用 DE ↔ EN 价格，并显示回退标签。',
+    crossLanguageImageFallback: '跨语言图片回退',
+    crossLanguageImageFallbackDesc: '当所选语言没有公开 TCGdex 图片时使用 DE ↔ EN 图片，并显示回退标签。',
     priceTrend: '趋势',
     priceAvg1: '平均 1天',
     priceAvg7: '平均 7天',

--- a/frontend/src/pages/CardSearch.jsx
+++ b/frontend/src/pages/CardSearch.jsx
@@ -7,6 +7,7 @@ import { CardItem, CustomCardModal, CardModal } from '../components/CardItem'
 import { useSettings } from '../contexts/SettingsContext'
 import Sheet from '../components/ui/Sheet'
 import CardScanner from '../components/CardScanner'
+import { getDefaultVariantOrNull } from '../utils/cardVariants'
 import { useTilt } from '../hooks/useTilt'
 
 function TiltCardWrapper({ children, className, onClick }) {
@@ -267,7 +268,7 @@ export default function CardSearch() {
     setSelectedItems(prev => {
       const next = new Map(prev)
       if (next.has(card.id)) next.delete(card.id)
-      else next.set(card.id, { card_id: card.id, lang: cardLang(card) })
+      else next.set(card.id, { card_id: card.id, lang: cardLang(card), variant: getDefaultVariantOrNull(card) })
       return next
     })
   }
@@ -276,7 +277,7 @@ export default function CardSearch() {
     setSelectedItems(prev => {
       const next = new Map(prev)
       for (const card of (data?.data || [])) {
-        next.set(card.id, { card_id: card.id, lang: cardLang(card) })
+        next.set(card.id, { card_id: card.id, lang: cardLang(card), variant: getDefaultVariantOrNull(card) })
       }
       return next
     })
@@ -300,7 +301,7 @@ export default function CardSearch() {
       setSelectedItems(prev => {
         const next = new Map(prev)
         for (const card of cards) {
-          next.set(card.id, { card_id: card.id, lang: cardLang(card) })
+          next.set(card.id, { card_id: card.id, lang: cardLang(card), variant: getDefaultVariantOrNull(card) })
         }
         return next
       })
@@ -310,11 +311,11 @@ export default function CardSearch() {
 
   const bulkAddMutation = useMutation({
     mutationFn: () => {
-      const items = Array.from(selectedItems.values()).map(({ card_id, lang }) => ({
+      const items = Array.from(selectedItems.values()).map(({ card_id, lang, variant }) => ({
         card_id,
         quantity: 1,
         condition: 'NM',
-        variant: null,
+        variant,
         purchase_price: null,
         lang,
       }))

--- a/frontend/src/pages/Collection.jsx
+++ b/frontend/src/pages/Collection.jsx
@@ -11,6 +11,7 @@ import toast from 'react-hot-toast'
 import clsx from 'clsx'
 import { useTilt } from '../hooks/useTilt'
 import { resolveCardImageUrl } from '../utils/imageUrl'
+import FallbackBadges from '../components/FallbackBadges'
 
 function TiltBinderCard({ className, onClick, children }) {
   const { ref, onMouseMove, onMouseEnter, onMouseLeave } = useTilt(10)
@@ -687,6 +688,7 @@ export default function Collection() {
                             {item.lang.toUpperCase()}
                           </span>
                         )}
+                        <FallbackBadges card={card} compact />
                       </div>
                     </TiltBinderCard>
                   )
@@ -767,6 +769,7 @@ export default function Collection() {
                                       {item.lang.toUpperCase()}
                                     </span>
                                   )}
+                                  <FallbackBadges card={card} compact />
                                 </div>
                                 {(() => {
                                   const abbr = card?.set_ref?.abbreviation

--- a/frontend/src/pages/SetDetail.jsx
+++ b/frontend/src/pages/SetDetail.jsx
@@ -7,6 +7,8 @@ import { useSettings } from '../contexts/SettingsContext'
 import toast from 'react-hot-toast'
 import clsx from 'clsx'
 import { resolveCardImageUrl, resolveSetImageUrl } from '../utils/imageUrl'
+import { getDefaultVariantOrNull } from '../utils/cardVariants'
+import FallbackBadges from '../components/FallbackBadges'
 
 export default function SetDetail() {
   const { setId } = useParams()
@@ -23,7 +25,13 @@ export default function SetDetail() {
   const setLang = data?.set?.lang || 'en'
 
   const addMutation = useMutation({
-    mutationFn: (cardId) => addToCollection({ card_id: cardId, quantity: 1, condition: 'NM', lang: setLang }),
+    mutationFn: (card) => addToCollection({
+      card_id: card.id,
+      quantity: 1,
+      condition: 'NM',
+      variant: getDefaultVariantOrNull(card),
+      lang: setLang,
+    }),
     onSuccess: () => {
       toast.success(t('card.addedToCollection'))
       queryClient.invalidateQueries({ queryKey: ['set-checklist', setId] })
@@ -141,8 +149,8 @@ export default function SetDetail() {
       <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-2">
         {filteredCards.map((card) => (
           <div key={card.id}
-            onClick={() => { if (!card.owned) addMutation.mutate(card.id) }}
-            onKeyDown={(e) => { if (!card.owned && (e.key === 'Enter' || e.key === ' ')) addMutation.mutate(card.id) }}
+            onClick={() => { if (!card.owned) addMutation.mutate(card) }}
+            onKeyDown={(e) => { if (!card.owned && (e.key === 'Enter' || e.key === ' ')) addMutation.mutate(card) }}
             role={card.owned ? undefined : 'button'}
             tabIndex={card.owned ? undefined : 0}
             className={clsx(
@@ -161,8 +169,9 @@ export default function SetDetail() {
 
             <div className="absolute inset-0 bg-black/0 group-hover:bg-black/40 transition-all flex flex-col items-center justify-center gap-1 opacity-0 group-hover:opacity-100">
               <p className="text-white text-xs font-medium text-center px-1 line-clamp-2">{card.name}</p>
+              <FallbackBadges card={card} className="justify-center" compact />
               {!card.owned && (
-                <button onClick={(e) => { e.stopPropagation(); addMutation.mutate(card.id) }}
+                <button onClick={(e) => { e.stopPropagation(); addMutation.mutate(card) }}
                   className="bg-brand-red text-white rounded-full p-1">
                   <Plus size={12} />
                 </button>

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -481,6 +481,15 @@ export default function Settings() {
     }
   }
 
+  const handleCrossLanguageFallbackToggle = async (key, enabled) => {
+    try {
+      await updateSettings({ [key]: enabled ? 'true' : 'false' })
+      toast.success(t('settings.saved'))
+    } catch {
+      toast.error(t('settings.saveFailed'))
+    }
+  }
+
   const handleDownloadDebugLog = async () => {
     try {
       await downloadDebugLog()
@@ -514,6 +523,8 @@ export default function Settings() {
   const currentCurrency = settings.currency || 'EUR'
   const currentPriceType = settings.price_primary || 'trend'
   const currentTcgdexSyncLanguages = settings.tcgdex_sync_languages || 'en,de'
+  const crossLanguagePriceFallback = settings.cross_language_price_fallback !== 'false'
+  const crossLanguageImageFallback = settings.cross_language_image_fallback !== 'false'
 
   const usernameMutation = useMutation({
     mutationFn: (username) => changeUsername(username),
@@ -828,6 +839,22 @@ export default function Settings() {
                     }}
                   />
                 </SettingsRow>
+              )}
+              {user?.role === 'admin' && (
+                <>
+                  <SettingsRow label={t('settings.crossLanguagePriceFallback')} description={t('settings.crossLanguagePriceFallbackDesc')}>
+                    <Toggle
+                      value={crossLanguagePriceFallback}
+                      onChange={(val) => handleCrossLanguageFallbackToggle('cross_language_price_fallback', val)}
+                    />
+                  </SettingsRow>
+                  <SettingsRow label={t('settings.crossLanguageImageFallback')} description={t('settings.crossLanguageImageFallbackDesc')}>
+                    <Toggle
+                      value={crossLanguageImageFallback}
+                      onChange={(val) => handleCrossLanguageFallbackToggle('cross_language_image_fallback', val)}
+                    />
+                  </SettingsRow>
+                </>
               )}
               {customMatches.length > 0 && (
                 <SettingsRow label={t('migration.title')} description={`${customMatches.length} ${t('migration.pendingMatches')}`}>

--- a/frontend/src/pages/UserCollection.jsx
+++ b/frontend/src/pages/UserCollection.jsx
@@ -6,6 +6,8 @@ import { getUserCollection } from '../api/client'
 import { useSettings } from '../contexts/SettingsContext'
 import { resolveCardImageUrl } from '../utils/imageUrl'
 import { CardModal } from '../components/CardItem'
+import CardImage from '../components/CardImage'
+import FallbackBadges from '../components/FallbackBadges'
 
 const HOLO_VARIANTS = new Set(['Holo', 'Holo Rare', 'Holo V', 'Holo VMAX', 'Holo VSTAR', 'Holo ex', 'Reverse Holo'])
 
@@ -185,7 +187,7 @@ export default function UserCollection() {
           {filtered.map((item) => {
             const card = item.card
             if (!card) return null
-            const imgSrc = card.images_small || resolveCardImageUrl(card) || (card.image ? `${card.image}/low.webp` : null)
+            const imgSrc = resolveCardImageUrl(card)
             const price = getPrice(card, item.variant)
             return (
               <div
@@ -194,16 +196,11 @@ export default function UserCollection() {
                 onClick={() => setSelectedCard(card)}
               >
                 <div className="aspect-[2.5/3.5] rounded-xl overflow-hidden ring-1 ring-white/5 group-hover:ring-brand-red/30 transition-all">
-                  {imgSrc ? (
-                    <img src={imgSrc} alt={card.name} className="w-full h-full object-cover" loading="lazy" />
-                  ) : (
-                    <div className="w-full h-full bg-bg-surface flex items-center justify-center text-[9px] text-text-muted p-1 text-center">
-                      {card.name}
-                    </div>
-                  )}
+                  <CardImage src={imgSrc} alt={card.name} className="w-full h-full object-cover" />
                 </div>
                 <div className="mt-1 px-0.5">
                   <p className="text-[10px] font-semibold text-text-primary truncate">{card.name}</p>
+                  <FallbackBadges card={card} compact />
                   <div className="flex items-center justify-between">
                     <span className="text-[9px] text-text-muted">{item.quantity}x · {item.variant || 'Normal'}</span>
                     {price > 0 && (

--- a/frontend/src/pages/Wishlist.jsx
+++ b/frontend/src/pages/Wishlist.jsx
@@ -7,6 +7,7 @@ import CardListItem from '../components/CardListItem'
 import TabNav from '../components/TabNav'
 import toast from 'react-hot-toast'
 import { resolveCardImageUrl } from '../utils/imageUrl'
+import FallbackBadges from '../components/FallbackBadges'
 
 function AlertEditor({ item, onDone }) {
   const [above, setAbove] = useState(item.price_alert_above || '')
@@ -262,6 +263,7 @@ export default function Wishlist() {
                               </div>
                               <div className="min-w-0">
                                 <p className="text-sm font-medium text-text-primary">{card?.name}</p>
+                                <FallbackBadges card={card} compact />
                                 {card?.rarity && <p className="text-xs text-text-muted">{card.rarity}</p>}
                               </div>
                             </div>
@@ -343,6 +345,8 @@ export default function Wishlist() {
                   if (item.price_alert_above) badges.push({ label: `↑ ${formatPrice(item.price_alert_above)}`, variant: 'yellow' })
                   if (item.price_alert_below) badges.push({ label: `↓ ${formatPrice(item.price_alert_below)}`, variant: 'blue' })
                   if (card?.rarity) badges.push({ label: card.rarity, variant: 'gray' })
+                  if (card?.price_source_lang) badges.push({ label: `${t('fallback.price')} ${card.price_source_lang.toUpperCase()}`, variant: 'yellow' })
+                  if (card?.image_source_lang) badges.push({ label: `${t('fallback.image')} ${card.image_source_lang.toUpperCase()}`, variant: 'blue' })
 
                   return (
                     <CardListItem

--- a/frontend/src/utils/cardVariants.js
+++ b/frontend/src/utils/cardVariants.js
@@ -1,0 +1,20 @@
+export const CARD_VARIANTS = ['Normal', 'Holo', 'Reverse Holo', 'First Edition']
+
+export const getAvailableVariants = (card) => [
+  card?.variants_normal && 'Normal',
+  card?.variants_reverse && 'Reverse Holo',
+  card?.variants_holo && 'Holo',
+  card?.variants_first_edition && 'First Edition',
+].filter(Boolean)
+
+export const getDefaultVariant = (card) => {
+  // Normal availability means the safest default is the plain/non-holo card.
+  // Only auto-select a variant when there is no normal print and exactly one
+  // special variant exists, e.g. holo-only promos.
+  if (card?.variants_normal) return ''
+  const available = getAvailableVariants(card)
+  if (available.length === 1) return available[0]
+  return ''
+}
+
+export const getDefaultVariantOrNull = (card) => getDefaultVariant(card) || null


### PR DESCRIPTION
## Summary
* Fix quick-add default variant selection so cards with a normal print stay plain by default, while holo-only or single-special-variant cards auto-select that required variant.
* Add admin settings for the two requested bidirectional fallbacks:
  * Cross-language price fallback
  * Cross-language image fallback
* Add DE ↔ EN card data fallback during card fetch, set checklist loading, full sync, and price sync.
* Store fallback source language on cards and clear the fallback tag automatically when native data appears on a later sync.
* Add visible fallback badges for prices/images in search, card modal, set checklist, collection, user collection, and wishlist views.
* Make missing card images consistently return a card-back placeholder instead of a broken image, and allow set logo/symbol image fallback to the sibling language when enabled.
* Reuse holo-aware market values in snapshots, analytics, exports, and social stats.

## Notes
* Native TCGdex data always wins. Fallback values are only copied when the selected language has no public image or no public price data.
* Fallback data does not cascade. A DE card will not borrow data from an EN card that is itself already using fallback data.
* Some cards, prices, and images are still absent from the public TCGdex API in both languages. In those cases the app now shows a card-back placeholder, but it cannot invent upstream data.

## Validation
* `python3 -m compileall backend`
* `npm --prefix frontend run build`
* `git diff --check`
