### PR TITLE
Fix authenticated settings saves

### DIFF
--- a/frontend/src/contexts/SettingsContext.jsx
+++ b/frontend/src/contexts/SettingsContext.jsx
@@ -56,15 +56,20 @@ export function SettingsProvider({ children }) {
     const next = { ...settings, ...updates }
     setSettings(next)
     try {
+      const token = localStorage.getItem('token')
+      const headers = { 'Content-Type': 'application/json' }
+      if (token) headers.Authorization = `Bearer ${token}`
+
       const resp = await fetch('/api/settings/', {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        headers,
         body: JSON.stringify(updates),
       })
       if (!resp.ok) throw new Error('Save failed')
       const saved = await resp.json()
       setSettings(prev => ({ ...prev, ...saved }))
     } catch (err) {
+      setSettings(settings)
       console.error('Failed to save settings:', err)
       throw err
     }


### PR DESCRIPTION
## Summary
* Send the Bearer token when saving settings through `SettingsContext.updateSettings()`.
* Restore the previous settings state if the save fails, instead of leaving an optimistic local value after a 401 or other error.

## Validation
* `python3 -m compileall backend`
* `npm --prefix frontend run build`
* `git diff --check`
