### PR TITLE
Bust cached card image fallbacks

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -52,7 +52,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="Pokemon TCG Collection API",
-    version="1.8",
+    version="1.9",
     description="Complete Pokemon TCG collection management system",
     lifespan=lifespan,
 )

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pokemon-tcg-collection",
   "private": true,
-  "version": "1.8",
+  "version": "1.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -776,7 +776,7 @@ export default function Settings() {
               <SettingsRow label={t('settings.app')} description="Pokemon TCG Collection">
                 <span className="text-xs font-bold text-text-muted px-2 py-1 rounded-lg"
                   style={{ background: 'rgba(255,255,255,0.05)' }}>
-                  v1.8
+                  v1.9
                 </span>
               </SettingsRow>
               <SettingsRow label={t('settings.dataSource')} description={t('settings.dataSourceDesc')}>

--- a/frontend/src/utils/imageUrl.js
+++ b/frontend/src/utils/imageUrl.js
@@ -1,5 +1,7 @@
+const IMAGE_PROXY_VERSION = 'cardback-fallback-v2'
+
 export const cardImageUrl = (cardId, size = 'small') =>
-  cardId ? `/api/images/card/${encodeURIComponent(cardId)}/${size}` : null
+  cardId ? `/api/images/card/${encodeURIComponent(cardId)}/${size}?v=${IMAGE_PROXY_VERSION}` : null
 
 export const setImageUrl = (setId, imageType) =>
   setId ? `/api/images/set/${encodeURIComponent(setId)}/${imageType}` : null


### PR DESCRIPTION
## Summary
* Add a version query to proxied card image URLs so browsers stop reusing the old generated SVG fallback response cached from the previous deployment.
* Bump app version from 1.8 to 1.9.

## Why
The backend now redirects missing card images to the existing `/cardback.jpg`, but the previous generated SVG fallback was served with browser cache headers. Existing clients can keep showing that SVG for the same `/api/images/card/...` URL until the cache expires. Changing the frontend image URL forces a refetch.

## Validation
* `python3 -m compileall backend`
* `npm --prefix frontend run build`
* `git diff --check`
