### PR TITLE
Add manual contributors file support

### DIFF
--- a/CONTRIBUTORS.csv
+++ b/CONTRIBUTORS.csv
@@ -1,2 +1,3 @@
 login,note
 f0rr3stfunk,Testing and feedback
+mgzwarrior,Bulk add contribution

--- a/CONTRIBUTORS.csv
+++ b/CONTRIBUTORS.csv
@@ -1,1 +1,2 @@
 login,note
+f0rr3stfunk,Testing and feedback

--- a/CONTRIBUTORS.csv
+++ b/CONTRIBUTORS.csv
@@ -1,0 +1,1 @@
+login,note

--- a/backend/api/github.py
+++ b/backend/api/github.py
@@ -11,32 +11,96 @@ logger = logging.getLogger(__name__)
 REPO = "Git-Romer/pokecollector"
 GITHUB_API = "https://api.github.com"
 SUPPORTERS_CSV_URL = f"https://raw.githubusercontent.com/{REPO}/main/SUPPORTERS.csv"
+CONTRIBUTORS_CSV_URL = f"https://raw.githubusercontent.com/{REPO}/main/CONTRIBUTORS.csv"
+GITHUB_HEADERS = {"Accept": "application/vnd.github+json"}
+
+
+def _github_avatar_url(login: str) -> str:
+    return f"https://github.com/{login}.png"
+
+
+async def _fetch_repo_contributors(client: httpx.AsyncClient) -> list[dict]:
+    resp = await client.get(
+        f"{GITHUB_API}/repos/{REPO}/contributors",
+        headers=GITHUB_HEADERS,
+    )
+    resp.raise_for_status()
+    return [
+        {
+            "login": contributor["login"],
+            "avatar_url": contributor["avatar_url"],
+            "html_url": contributor["html_url"],
+            "contributions": contributor["contributions"],
+            "manual": False,
+            "note": None,
+        }
+        for contributor in resp.json()
+        if contributor.get("type") == "User"
+    ]
+
+
+async def _fetch_manual_contributors(client: httpx.AsyncClient) -> list[dict]:
+    """Fetch additional contributors from CONTRIBUTORS.csv in the repo."""
+    resp = await client.get(CONTRIBUTORS_CSV_URL)
+    if resp.status_code == 404:
+        return []
+    resp.raise_for_status()
+
+    contributors = []
+    reader = csv.DictReader(io.StringIO(resp.text))
+    for row in reader:
+        login = (row.get("login") or row.get("username") or "").strip()
+        if not login:
+            continue
+
+        note = (row.get("note") or row.get("role") or "").strip() or None
+        contributor = {
+            "login": login,
+            "avatar_url": _github_avatar_url(login),
+            "html_url": f"https://github.com/{login}",
+            "contributions": 0,
+            "manual": True,
+            "note": note,
+        }
+
+        try:
+            user_resp = await client.get(f"{GITHUB_API}/users/{login}", headers=GITHUB_HEADERS)
+            user_resp.raise_for_status()
+            user_data = user_resp.json()
+            contributor["login"] = user_data.get("login") or login
+            contributor["avatar_url"] = user_data.get("avatar_url") or contributor["avatar_url"]
+            contributor["html_url"] = user_data.get("html_url") or contributor["html_url"]
+        except Exception as exc:
+            logger.warning("Failed to fetch manual contributor %s: %s", login, exc)
+
+        contributors.append(contributor)
+
+    return contributors
 
 
 @router.get("/contributors")
 async def get_contributors():
-    """Fetch contributors from GitHub API (public, no auth needed)."""
-    try:
-        async with httpx.AsyncClient(timeout=10) as client:
-            resp = await client.get(
-                f"{GITHUB_API}/repos/{REPO}/contributors",
-                headers={"Accept": "application/vnd.github+json"},
-            )
-            resp.raise_for_status()
-            data = resp.json()
-            return [
-                {
-                    "login": contributor["login"],
-                    "avatar_url": contributor["avatar_url"],
-                    "html_url": contributor["html_url"],
-                    "contributions": contributor["contributions"],
-                }
-                for contributor in data
-                if contributor.get("type") == "User"
-            ]
-    except Exception as exc:
-        logger.warning("Failed to fetch contributors: %s", exc)
-        return []
+    """Fetch repo contributors from GitHub and merge additional CONTRIBUTORS.csv users."""
+    contributors = []
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        try:
+            contributors = await _fetch_repo_contributors(client)
+        except Exception as exc:
+            logger.warning("Failed to fetch repo contributors: %s", exc)
+
+        seen_logins = {contributor["login"].lower() for contributor in contributors}
+
+        try:
+            for contributor in await _fetch_manual_contributors(client):
+                login_key = contributor["login"].lower()
+                if login_key not in seen_logins:
+                    contributors.append(contributor)
+                    seen_logins.add(login_key)
+        except Exception as exc:
+            logger.warning("Failed to fetch manual contributors: %s", exc)
+
+    return contributors
 
 
 @router.get("/supporters")

--- a/backend/api/github.py
+++ b/backend/api/github.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 import csv
 import io
 import logging
+import os
 
 import httpx
 
@@ -12,7 +13,14 @@ REPO = "Git-Romer/pokecollector"
 GITHUB_API = "https://api.github.com"
 SUPPORTERS_CSV_URL = f"https://raw.githubusercontent.com/{REPO}/main/SUPPORTERS.csv"
 CONTRIBUTORS_CSV_URL = f"https://raw.githubusercontent.com/{REPO}/main/CONTRIBUTORS.csv"
-GITHUB_HEADERS = {"Accept": "application/vnd.github+json"}
+
+
+def _github_headers() -> dict[str, str]:
+    headers = {"Accept": "application/vnd.github+json"}
+    token = os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
 
 
 def _github_avatar_url(login: str) -> str:
@@ -22,7 +30,7 @@ def _github_avatar_url(login: str) -> str:
 async def _fetch_repo_contributors(client: httpx.AsyncClient) -> list[dict]:
     resp = await client.get(
         f"{GITHUB_API}/repos/{REPO}/contributors",
-        headers=GITHUB_HEADERS,
+        headers=_github_headers(),
     )
     resp.raise_for_status()
     return [
@@ -54,26 +62,16 @@ async def _fetch_manual_contributors(client: httpx.AsyncClient) -> list[dict]:
             continue
 
         note = (row.get("note") or row.get("role") or "").strip() or None
-        contributor = {
-            "login": login,
-            "avatar_url": _github_avatar_url(login),
-            "html_url": f"https://github.com/{login}",
-            "contributions": 0,
-            "manual": True,
-            "note": note,
-        }
-
-        try:
-            user_resp = await client.get(f"{GITHUB_API}/users/{login}", headers=GITHUB_HEADERS)
-            user_resp.raise_for_status()
-            user_data = user_resp.json()
-            contributor["login"] = user_data.get("login") or login
-            contributor["avatar_url"] = user_data.get("avatar_url") or contributor["avatar_url"]
-            contributor["html_url"] = user_data.get("html_url") or contributor["html_url"]
-        except Exception as exc:
-            logger.warning("Failed to fetch manual contributor %s: %s", login, exc)
-
-        contributors.append(contributor)
+        contributors.append(
+            {
+                "login": login,
+                "avatar_url": _github_avatar_url(login),
+                "html_url": f"https://github.com/{login}",
+                "contributions": 0,
+                "manual": True,
+                "note": note,
+            }
+        )
 
     return contributors
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -52,7 +52,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="Pokemon TCG Collection API",
-    version="1.8",
+    version="1.9",
     description="Complete Pokemon TCG collection management system",
     lifespan=lifespan,
 )

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokemon-tcg-collection",
-  "version": "1.7",
+  "version": "1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pokemon-tcg-collection",
-      "version": "1.7",
+      "version": "1.9",
       "dependencies": {
         "@tanstack/react-query": "^5.18.0",
         "axios": "^1.15.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pokemon-tcg-collection",
   "private": true,
-  "version": "1.8",
+  "version": "1.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/i18n/de.js
+++ b/frontend/src/i18n/de.js
@@ -566,6 +566,7 @@ const de = {
     sourceCode: 'Quellcode',
     sourceCodeDesc: 'Open Source auf GitHub',
     contributors: 'Mitwirkende',
+    manualContributor: 'Mitwirkende/r',
     supporters: 'Unterstützer',
     sponsors: 'Unterstützen',
     sponsorMessage: 'Dir gefällt PokéCollector? Alle Einnahmen werden an Tierschutzorganisationen gespendet. 🐾',

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -566,6 +566,7 @@ const en = {
     sourceCode: 'Source Code',
     sourceCodeDesc: 'Open source on GitHub',
     contributors: 'Contributors',
+    manualContributor: 'Contributor',
     supporters: 'Supporters',
     sponsors: 'Support',
     sponsorMessage: 'Enjoying PokéCollector? All earnings are donated to animal rescue organizations. 🐾',

--- a/frontend/src/i18n/zh.js
+++ b/frontend/src/i18n/zh.js
@@ -567,6 +567,7 @@ const zh = {
     sourceCode: '源代码',
     sourceCodeDesc: 'GitHub开源',
     contributors: '贡献者',
+    manualContributor: '贡献者',
     supporters: '支持者',
     sponsors: '支持',
     sponsorMessage: '喜欢PokéCollector吗？所有收益都捐赠给动物保护组织。🐾',

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -778,7 +778,7 @@ export default function Settings() {
               <SettingsRow label={t('settings.app')} description="Pokemon TCG Collection">
                 <span className="text-xs font-bold text-text-muted px-2 py-1 rounded-lg"
                   style={{ background: 'rgba(255,255,255,0.05)' }}>
-                  v1.9
+                  v{__APP_VERSION__}
                 </span>
               </SettingsRow>
               <SettingsRow label={t('settings.dataSource')} description={t('settings.dataSourceDesc')}>

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -189,7 +189,9 @@ function ContributorsSection({ t }) {
             <a key={c.login} href={c.html_url} target="_blank" rel="noreferrer" className="flex flex-col items-center gap-1.5 group">
               <img src={c.avatar_url} alt={c.login} className="w-12 h-12 rounded-full border-2 border-border group-hover:border-brand-red transition-colors" />
               <span className="text-[10px] font-semibold text-text-secondary group-hover:text-text-primary transition-colors">{c.login}</span>
-              <span className="text-[9px] text-text-muted">{c.contributions} {t('settings.commits')}</span>
+              <span className="text-[9px] text-text-muted">
+                {c.manual ? (c.note || t('settings.contributors')) : `${c.contributions} ${t('settings.commits')}`}
+              </span>
             </a>
           ))}
         </div>
@@ -776,7 +778,7 @@ export default function Settings() {
               <SettingsRow label={t('settings.app')} description="Pokemon TCG Collection">
                 <span className="text-xs font-bold text-text-muted px-2 py-1 rounded-lg"
                   style={{ background: 'rgba(255,255,255,0.05)' }}>
-                  v1.8
+                  v1.9
                 </span>
               </SettingsRow>
               <SettingsRow label={t('settings.dataSource')} description={t('settings.dataSourceDesc')}>

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -190,7 +190,7 @@ function ContributorsSection({ t }) {
               <img src={c.avatar_url} alt={c.login} className="w-12 h-12 rounded-full border-2 border-border group-hover:border-brand-red transition-colors" />
               <span className="text-[10px] font-semibold text-text-secondary group-hover:text-text-primary transition-colors">{c.login}</span>
               <span className="text-[9px] text-text-muted">
-                {c.manual ? (c.note || t('settings.contributors')) : `${c.contributions} ${t('settings.commits')}`}
+                {c.manual ? (c.note || t('settings.manualContributor')) : `${c.contributions} ${t('settings.commits')}`}
               </span>
             </a>
           ))}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,8 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const packageJson = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8'))
+
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(packageJson.version),
+  },
   server: {
     proxy: {
       '/api': {


### PR DESCRIPTION
## Summary
* add CONTRIBUTORS.csv as a manual contributor source alongside GitHub repo contributors
* fetch manual contributor GitHub profiles, merge them into the contributors API response, and deduplicate by login
* show manual contributor notes in Settings and bump app version to 1.9

## Validation
* python3 -m compileall backend
* npm --prefix frontend run build
* git diff --check