### PR TITLE
Fix manual contributor avatar loading

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -13,7 +13,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(self), microphone=()" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https://assets.tcgdex.net https://raw.githubusercontent.com https://avatars.githubusercontent.com data: blob:; connect-src 'self' https://api.tcgdex.net https://api.frankfurter.app https://api.github.com https://raw.githubusercontent.com https://generativelanguage.googleapis.com" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https://assets.tcgdex.net https://raw.githubusercontent.com https://avatars.githubusercontent.com https://github.com data: blob:; connect-src 'self' https://api.tcgdex.net https://api.frankfurter.app https://api.github.com https://raw.githubusercontent.com https://generativelanguage.googleapis.com" always;
 
     # Gzip
     gzip on;


### PR DESCRIPTION
## Summary
* allow github.com image URLs in the frontend CSP
* fixes manually-added contributor avatars that use https://github.com/{login}.png

## Validation
* npm --prefix frontend run build
* git diff --check

Note: nginx -t could not be run locally because nginx is not installed on this host.