### PR TITLE
Add website link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Be kind. Be clear. Assume good intent. Keep feedback constructive.
 
 > A self-hosted, full-stack Pokémon TCG collection manager for cards, sealed products, binders, analytics, scanning, and multi-user collections.
 
+🌐 **Website:** [pokecollector.romerg.de](https://pokecollector.romerg.de/)
+
 ![Dark Theme](https://img.shields.io/badge/theme-dark-1a1a2e?style=flat-square) ![TCGdex](https://img.shields.io/badge/card%20data-TCGdex-e3000b?style=flat-square) ![Docker](https://img.shields.io/badge/deploy-Docker-2496ed?style=flat-square) ![FastAPI](https://img.shields.io/badge/backend-FastAPI-009688?style=flat-square) ![React](https://img.shields.io/badge/frontend-React%2018-61dafb?style=flat-square) [![Ko-fi](https://img.shields.io/badge/support-Ko--fi-ff5e5b?style=flat-square&logo=ko-fi&logoColor=white)](https://ko-fi.com/gillesromer)
 
 ![WebApp Preview](preview-homescreen.png)


### PR DESCRIPTION
## Summary
- add the public PokéCollector website link near the top of the README

## Validation
- checked that https://pokecollector.romerg.de/ returns HTTP 200
- ran `git diff --check`

## Note
I also tried to update the GitHub repo About metadata with the website homepage and a refreshed description, but the current token returned HTTP 403 for `gh repo edit`.
