### PR TITLE
Add fallback for missing set images

### DIFF
--- a/backend/api/images.py
+++ b/backend/api/images.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Response
-from fastapi.responses import RedirectResponse
+from fastapi.responses import FileResponse, RedirectResponse
 import httpx
+from pathlib import Path
 from sqlalchemy.orm import Session
 
 from database import get_db
@@ -9,6 +10,7 @@ from models import Card, ImageCache, Set, Setting
 router = APIRouter()
 
 _client = httpx.Client(timeout=15, follow_redirects=True)
+_SET_FALLBACK_IMAGE = Path(__file__).resolve().parents[1] / "static" / "pokemon-logo.svg"
 
 
 def _setting_enabled(db: Session, key: str, default: bool = True) -> bool:
@@ -31,6 +33,17 @@ def _card_back_response():
     # changes the missing-image response behavior; it must not replace the
     # placeholder image data/design.
     return RedirectResponse(url="/cardback.jpg", status_code=307)
+
+
+def _set_fallback_response():
+    # Serve a bundled Pokémon-style wordmark when TCGdex has no set logo/symbol
+    # or the upstream image cannot be fetched. Serving it from the API keeps the
+    # fallback independent from frontend static-asset routing.
+    return FileResponse(
+        _SET_FALLBACK_IMAGE,
+        media_type="image/svg+xml",
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
 
 
 def _get_or_fetch(db: Session, key: str, url: str) -> tuple[bytes, str]:
@@ -108,12 +121,14 @@ def get_set_image(set_id: str, image_type: str, db: Session = Depends(get_db)):
                 cache_key = f"set:{set_id}:{image_type}:fallback:{fallback_lang}"
 
     if not url:
-        raise HTTPException(status_code=404, detail="No image URL for this set")
+        return _set_fallback_response()
 
     try:
         data, content_type = _get_or_fetch(db, cache_key, url)
-    except HTTPException:
-        raise HTTPException(status_code=404, detail="No image URL for this set")
+    except HTTPException as exc:
+        if exc.status_code == 502:
+            return _set_fallback_response()
+        raise
     return Response(
         content=data,
         media_type=content_type,

--- a/backend/static/pokemon-logo.svg
+++ b/backend/static/pokemon-logo.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 240" role="img" aria-labelledby="title desc">
+  <title id="title">Pokémon logo fallback</title>
+  <desc id="desc">A local Pokémon-style wordmark used when a set logo or symbol is unavailable.</desc>
+  <defs>
+    <filter id="shadow" x="-20%" y="-30%" width="140%" height="160%">
+      <feDropShadow dx="0" dy="7" stdDeviation="5" flood-color="#000" flood-opacity="0.28"/>
+    </filter>
+  </defs>
+  <rect width="640" height="240" rx="36" fill="none"/>
+  <text x="320" y="136"
+        text-anchor="middle"
+        dominant-baseline="middle"
+        font-family="Arial Rounded MT Bold, Arial, Helvetica, sans-serif"
+        font-size="90"
+        font-weight="900"
+        letter-spacing="-3"
+        fill="#ffcb05"
+        stroke="#2a75bb"
+        stroke-width="12"
+        paint-order="stroke fill"
+        filter="url(#shadow)">Pokémon</text>
+</svg>

--- a/frontend/public/pokemon-logo.svg
+++ b/frontend/public/pokemon-logo.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 240" role="img" aria-labelledby="title desc">
+  <title id="title">Pokémon logo fallback</title>
+  <desc id="desc">A local Pokémon-style wordmark used when a set logo or symbol is unavailable.</desc>
+  <defs>
+    <filter id="shadow" x="-20%" y="-30%" width="140%" height="160%">
+      <feDropShadow dx="0" dy="7" stdDeviation="5" flood-color="#000" flood-opacity="0.28"/>
+    </filter>
+  </defs>
+  <rect width="640" height="240" rx="36" fill="none"/>
+  <text x="320" y="136"
+        text-anchor="middle"
+        dominant-baseline="middle"
+        font-family="Arial Rounded MT Bold, Arial, Helvetica, sans-serif"
+        font-size="90"
+        font-weight="900"
+        letter-spacing="-3"
+        fill="#ffcb05"
+        stroke="#2a75bb"
+        stroke-width="12"
+        paint-order="stroke fill"
+        filter="url(#shadow)">Pokémon</text>
+</svg>

--- a/frontend/src/pages/Sets.jsx
+++ b/frontend/src/pages/Sets.jsx
@@ -292,7 +292,7 @@ export default function Sets() {
                       loading="lazy"
                     />
                   ) : (
-                    <img src="/pokeball.svg" className="w-12 h-12 opacity-20 relative z-10" alt="" />
+                    <img src="/pokemon-logo.svg" className="w-28 h-12 object-contain opacity-40 relative z-10" alt="" />
                   )}
 
                   {pct === 100 && (


### PR DESCRIPTION
## Summary
- add a local Pokémon-style wordmark fallback asset for both frontend and backend use
- serve the backend set-image fallback directly from the API, so it does not depend on frontend static routing
- return the wordmark fallback when a set logo/symbol URL is missing
- also use the wordmark fallback when fetching a set image from upstream fails with the expected upstream-fetch error
- update the set-grid direct visual fallback to use the wordmark instead of the Pokéball
- keep invalid image types and unknown set IDs as real errors

## Why
Some TCGdex sets do not expose logo/symbol image URLs, or the upstream image fetch can fail. The `/sets` page should not show broken browser image icons or noisy 404s for those expected missing assets.

## Validation
- ran `python3 -m py_compile backend/api/images.py`
- ran `npm ci && npm run build`
- checked that frontend and backend wordmark assets exist and match
- rendered the local SVG in Chromium for a visual sanity check
- ran `git diff --check`
