### PR TITLE
Document user management workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Be kind. Be clear. Assume good intent. Keep feedback constructive.
 
 - [Features](#-features)
 - [Quick Start](#-quick-start)
+- [Managing Users](#-managing-users)
 - [Environment Variables](#-environment-variables)
 - [Architecture](#-architecture)
 - [Tech Stack](#-tech-stack)
@@ -146,6 +147,28 @@ On first launch, trigger a sync from the app to populate sets and cards from TCG
 - In single-user mode, login is skipped and the app auto-authenticates as admin
 - In multi-user mode, use the admin account created from `ADMIN_USERNAME` / `ADMIN_PASSWORD`
 - If `ADMIN_PASSWORD` is omitted, a random password may be logged during bootstrap
+
+---
+
+## 👥 Managing Users
+
+User management is available from the app UI when multi-user mode is enabled.
+
+1. Log in as an admin user.
+2. Go to **Settings**.
+3. Enable **Multi-User Mode** if it is not enabled yet.
+4. Open the **Users** tab in Settings.
+
+From the **Users** tab, admins can:
+
+- add new users
+- edit existing users
+- change user roles between `admin` and `trainer`
+- activate or deactivate users
+- delete other users
+- force new users to change their password on first login
+
+The **Users** tab is only visible to admin users and only while multi-user mode is enabled. In single-user mode, PokéCollector skips login and uses the bootstrap admin account automatically.
 
 ---
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -52,7 +52,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="Pokemon TCG Collection API",
-    version="1.9",
+    version="1.10",
     description="Complete Pokemon TCG collection management system",
     lifespan=lifespan,
 )

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -145,6 +145,9 @@ Defined in `frontend/src/components/TabNav.jsx`.
 ### `pages/Settings.jsx`
 
 - Mixes per-user preferences and admin-only controls
+- Admin users can enable multi-user mode from Settings
+- When multi-user mode is enabled, admin users see a **Users** tab
+- The **Users** tab supports creating users, editing usernames/roles/passwords, activating/deactivating users, deleting other users, and forcing first-login password changes
 - Includes:
   - profile name editing
   - avatar picker

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokemon-tcg-collection",
-  "version": "1.9",
+  "version": "1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pokemon-tcg-collection",
-      "version": "1.9",
+      "version": "1.10",
       "dependencies": {
         "@tanstack/react-query": "^5.18.0",
         "axios": "^1.15.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pokemon-tcg-collection",
   "private": true,
-  "version": "1.9",
+  "version": "1.10",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- add README instructions for enabling multi-user mode and managing users from Settings → Users
- document the Users tab in the frontend docs
- bump app metadata from `1.9` to `1.10` so the recent user/sync improvements are reflected in the visible version fields

Closes #173

## Validation

- `python -m py_compile backend/main.py`
- `npm run build`
- `git diff --check`
