### PR TITLE
Add custom image fallback for API cards

### DIFF
--- a/backend/api/cards.py
+++ b/backend/api/cards.py
@@ -5,10 +5,11 @@ from sqlalchemy.exc import IntegrityError
 from typing import Optional, List
 from api.auth import get_current_user
 from database import get_db
-from models import Card, Set, PriceHistory, CustomCardMatch, CollectionItem, WishlistItem, BinderCard, Setting, User
+from models import Card, Set, PriceHistory, CustomCardMatch, CollectionItem, WishlistItem, BinderCard, Setting, User, ImageCache
 from schemas import CardBase, CardWithSet, PriceHistoryResponse, CardCustomCreate, CustomCardUpdate, CardCustomImageUpdate
 from services import pokemon_api
 from services.card_fallbacks import apply_cross_language_fallbacks
+from services.image_url_security import validate_public_https_image_url
 import datetime
 import re
 from uuid import uuid4
@@ -705,17 +706,28 @@ def update_card_custom_image(
         raise HTTPException(status_code=404, detail="Card not found")
     if card.is_custom:
         raise HTTPException(status_code=400, detail="Use the custom card editor for manually created cards")
+
+    custom_cache_keys = [
+        f"card:{card_id}:small:custom",
+        f"card:{card_id}:large:custom",
+    ]
     if card.images_small or card.images_large:
         if card.custom_image_url:
             card.custom_image_url = None
+            db.query(ImageCache).filter(ImageCache.image_key.in_(custom_cache_keys)).delete(synchronize_session=False)
             db.commit()
             db.refresh(card)
         return _card_to_dict(card)
 
     image_url = (update.custom_image_url or "").strip()
-    if image_url and not re.match(r"^https?://", image_url, re.IGNORECASE):
-        raise HTTPException(status_code=422, detail="Image URL must start with http:// or https://")
+    if image_url:
+        try:
+            image_url = validate_public_https_image_url(image_url)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
 
+    if card.custom_image_url != (image_url or None):
+        db.query(ImageCache).filter(ImageCache.image_key.in_(custom_cache_keys)).delete(synchronize_session=False)
     card.custom_image_url = image_url or None
     db.commit()
     db.refresh(card)

--- a/backend/api/cards.py
+++ b/backend/api/cards.py
@@ -6,7 +6,7 @@ from typing import Optional, List
 from api.auth import get_current_user
 from database import get_db
 from models import Card, Set, PriceHistory, CustomCardMatch, CollectionItem, WishlistItem, BinderCard, Setting, User
-from schemas import CardBase, CardWithSet, PriceHistoryResponse, CardCustomCreate, CustomCardUpdate
+from schemas import CardBase, CardWithSet, PriceHistoryResponse, CardCustomCreate, CustomCardUpdate, CardCustomImageUpdate
 from services import pokemon_api
 from services.card_fallbacks import apply_cross_language_fallbacks
 import datetime
@@ -44,6 +44,7 @@ def _card_to_dict(card: Card) -> dict:
         "images_small": card.images_small,
         "images_large": card.images_large,
         "image_source_lang": getattr(card, "image_source_lang", None),
+        "custom_image_url": getattr(card, "custom_image_url", None),
         "is_custom": card.is_custom or False,
         "lang": card.lang or "en",
         "price_market": card.price_market,
@@ -689,6 +690,36 @@ def get_price_history(
         .all()
     )
     return history
+
+
+@router.put("/{card_id}/custom-image", response_model=CardBase)
+def update_card_custom_image(
+    card_id: str,
+    update: CardCustomImageUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Set or clear a manual image URL for API cards that have no TCGdex image yet."""
+    card = db.query(Card).filter(Card.id == card_id).first()
+    if not card:
+        raise HTTPException(status_code=404, detail="Card not found")
+    if card.is_custom:
+        raise HTTPException(status_code=400, detail="Use the custom card editor for manually created cards")
+    if card.images_small or card.images_large:
+        if card.custom_image_url:
+            card.custom_image_url = None
+            db.commit()
+            db.refresh(card)
+        return _card_to_dict(card)
+
+    image_url = (update.custom_image_url or "").strip()
+    if image_url and not re.match(r"^https?://", image_url, re.IGNORECASE):
+        raise HTTPException(status_code=422, detail="Image URL must start with http:// or https://")
+
+    card.custom_image_url = image_url or None
+    db.commit()
+    db.refresh(card)
+    return _card_to_dict(card)
 
 
 @router.get("/{card_id}", response_model=CardBase)

--- a/backend/api/images.py
+++ b/backend/api/images.py
@@ -3,15 +3,20 @@ from fastapi.responses import FileResponse, RedirectResponse
 import hashlib
 import httpx
 from pathlib import Path
+from urllib.parse import urljoin
 from sqlalchemy.orm import Session
 
 from database import get_db
 from models import Card, ImageCache, Set, Setting
+from services.image_url_security import validate_public_https_image_url
 
 router = APIRouter()
 
 _client = httpx.Client(timeout=15, follow_redirects=True)
+_custom_image_client = httpx.Client(timeout=10, follow_redirects=False)
 _SET_FALLBACK_IMAGE = Path(__file__).resolve().parents[1] / "static" / "pokemon-logo.svg"
+_MAX_CUSTOM_IMAGE_BYTES = 8 * 1024 * 1024
+_MAX_CUSTOM_IMAGE_REDIRECTS = 3
 
 
 def _setting_enabled(db: Session, key: str, default: bool = True) -> bool:
@@ -73,6 +78,59 @@ def _get_or_fetch(db: Session, key: str, url: str) -> tuple[bytes, str]:
     return resp.content, content_type
 
 
+def _get_or_fetch_custom_image(db: Session, key: str, url: str) -> tuple[bytes, str]:
+    cached = db.query(ImageCache).filter(ImageCache.image_key == key).first()
+    if cached:
+        return cached.data, cached.content_type
+
+    current_url = validate_public_https_image_url(url)
+    for _ in range(_MAX_CUSTOM_IMAGE_REDIRECTS + 1):
+        chunks: list[bytes] = []
+        total = 0
+        try:
+            with _custom_image_client.stream("GET", current_url) as resp:
+                if resp.is_redirect:
+                    location = resp.headers.get("location")
+                    if not location:
+                        raise HTTPException(status_code=502, detail="Invalid custom image redirect")
+                    current_url = validate_public_https_image_url(urljoin(current_url, location))
+                    continue
+
+                resp.raise_for_status()
+                content_type = resp.headers.get("content-type", "image/webp").split(";", 1)[0].strip().lower()
+                if not content_type.startswith("image/"):
+                    raise HTTPException(status_code=502, detail="Custom image URL did not return an image")
+
+                content_length = resp.headers.get("content-length")
+                if content_length and int(content_length) > _MAX_CUSTOM_IMAGE_BYTES:
+                    raise HTTPException(status_code=502, detail="Custom image is too large")
+
+                for chunk in resp.iter_bytes():
+                    total += len(chunk)
+                    if total > _MAX_CUSTOM_IMAGE_BYTES:
+                        raise HTTPException(status_code=502, detail="Custom image is too large")
+                    chunks.append(chunk)
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise HTTPException(status_code=502, detail="Failed to fetch custom image") from exc
+
+        data = b"".join(chunks)
+        entry = ImageCache(image_key=key, data=data, content_type=content_type)
+        db.add(entry)
+        try:
+            db.commit()
+        except Exception:
+            db.rollback()
+            cached = db.query(ImageCache).filter(ImageCache.image_key == key).first()
+            if cached:
+                return cached.data, cached.content_type
+            raise
+        return data, content_type
+
+    raise HTTPException(status_code=502, detail="Custom image redirected too many times")
+
+
 @router.get("/card/{card_id}/{size}")
 def get_card_image(card_id: str, size: str, db: Session = Depends(get_db)):
     if size not in ("small", "large"):
@@ -91,9 +149,12 @@ def get_card_image(card_id: str, size: str, db: Session = Depends(get_db)):
         return _card_back_response()
 
     try:
-        url_hash = hashlib.sha1(url.encode("utf-8")).hexdigest()
-        data, content_type = _get_or_fetch(db, f"card:{card_id}:{size}:{url_hash}", url)
-    except HTTPException:
+        if card.custom_image_url and url == card.custom_image_url:
+            data, content_type = _get_or_fetch_custom_image(db, f"card:{card_id}:{size}:custom", url)
+        else:
+            url_hash = hashlib.sha1(url.encode("utf-8")).hexdigest()
+            data, content_type = _get_or_fetch(db, f"card:{card_id}:{size}:{url_hash}", url)
+    except (HTTPException, ValueError):
         return _card_back_response()
     return Response(
         content=data,

--- a/backend/api/images.py
+++ b/backend/api/images.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Response
 from fastapi.responses import FileResponse, RedirectResponse
+import hashlib
 import httpx
 from pathlib import Path
 from sqlalchemy.orm import Session
@@ -81,12 +82,17 @@ def get_card_image(card_id: str, size: str, db: Session = Depends(get_db)):
     if not card:
         raise HTTPException(status_code=404, detail="Card not found")
 
-    url = card.images_small if size == "small" else card.images_large
+    requested_url = card.images_small if size == "small" else card.images_large
+    alternate_api_url = card.images_large if size == "small" else card.images_small
+    # Manual image URLs are temporary fallbacks only. If any API image is
+    # available, prefer that API image over the custom URL.
+    url = requested_url or alternate_api_url or card.custom_image_url
     if not url:
         return _card_back_response()
 
     try:
-        data, content_type = _get_or_fetch(db, f"card:{card_id}:{size}", url)
+        url_hash = hashlib.sha1(url.encode("utf-8")).hexdigest()
+        data, content_type = _get_or_fetch(db, f"card:{card_id}:{size}:{url_hash}", url)
     except HTTPException:
         return _card_back_response()
     return Response(

--- a/backend/database.py
+++ b/backend/database.py
@@ -195,6 +195,8 @@ def _run_migrations(conn):
         # v44: Track price sync attempts independently from general card updates.
         "ALTER TABLE cards ADD COLUMN IF NOT EXISTS last_price_sync_attempt_at TIMESTAMP",
         "ALTER TABLE cards ADD COLUMN IF NOT EXISTS last_price_sync_success_at TIMESTAMP",
+        # v45: Manual temporary card image fallback while TCGdex has no image.
+        "ALTER TABLE cards ADD COLUMN IF NOT EXISTS custom_image_url VARCHAR",
     ]
     for stmt in migrations:
         try:

--- a/backend/models.py
+++ b/backend/models.py
@@ -53,6 +53,7 @@ class Card(Base):
     images_small = Column(String)
     images_large = Column(String)
     image_source_lang = Column(String, nullable=True)  # Set when images are copied from another TCGdex language
+    custom_image_url = Column(String, nullable=True)   # Manual temporary fallback while TCGdex has no image
     is_custom = Column(Boolean, default=False)
     lang = Column(String, default="en")      # "en" or "de"
     # Cardmarket EUR prices

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -37,6 +37,7 @@ class CardBase(BaseModel):
     images_small: Optional[str] = None
     images_large: Optional[str] = None
     image_source_lang: Optional[str] = None
+    custom_image_url: Optional[str] = None
     is_custom: bool = False
     price_market: Optional[float] = None
     price_low: Optional[float] = None
@@ -96,6 +97,10 @@ class CustomCardUpdate(BaseModel):
     image_url: Optional[str] = None
     hp: Optional[str] = None
     lang: Optional[str] = None
+
+
+class CardCustomImageUpdate(BaseModel):
+    custom_image_url: Optional[str] = None
 
 
 class CardWithSet(CardBase):

--- a/backend/services/image_url_security.py
+++ b/backend/services/image_url_security.py
@@ -1,0 +1,78 @@
+"""Validation helpers for user-provided image URLs.
+
+The backend image proxy fetches these URLs server-side, so custom image URLs
+must be restricted to public HTTPS destinations to avoid SSRF against local or
+private network resources.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+
+_BLOCKED_HOSTS = {"localhost", "localhost.localdomain"}
+
+
+def _is_public_ip(value: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(value)
+    except ValueError:
+        return False
+    return ip.is_global
+
+
+def validate_public_https_image_url(raw_url: str) -> str:
+    """Return a normalized custom image URL or raise ValueError.
+
+    Only public HTTPS URLs are accepted. Hostnames are resolved and every
+    resolved address must be globally routable; localhost, loopback,
+    link-local, private, reserved, multicast, and metadata-service addresses are
+    rejected.
+    """
+    url = (raw_url or "").strip()
+    parsed = urlparse(url)
+
+    if parsed.scheme != "https":
+        raise ValueError("Image URL must start with https://")
+    if not parsed.hostname:
+        raise ValueError("Image URL must include a valid host")
+    if parsed.username or parsed.password:
+        raise ValueError("Image URL must not include credentials")
+
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise ValueError("Image URL has an invalid port") from exc
+    if port not in (None, 443):
+        raise ValueError("Image URL must use the default HTTPS port")
+
+    host = parsed.hostname.rstrip(".").lower()
+    if host in _BLOCKED_HOSTS or host.endswith(".localhost"):
+        raise ValueError("Image URL host is not allowed")
+
+    if _is_public_ip(host):
+        return url
+
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        pass
+    else:
+        raise ValueError("Image URL host is not publicly reachable")
+
+    try:
+        resolved = socket.getaddrinfo(host.encode("idna").decode("ascii"), port or 443, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise ValueError("Image URL host could not be resolved") from exc
+
+    if not resolved:
+        raise ValueError("Image URL host could not be resolved")
+
+    for item in resolved:
+        address = item[4][0]
+        if not _is_public_ip(address):
+            raise ValueError("Image URL host resolves to a non-public address")
+
+    return url

--- a/backend/services/sync_service.py
+++ b/backend/services/sync_service.py
@@ -4,7 +4,7 @@ import math
 from typing import Any, Mapping
 from sqlalchemy.orm import Session, load_only
 from sqlalchemy import func
-from models import Card, Set, CollectionItem, WishlistItem, PriceHistory, SyncLog, PortfolioSnapshot, CustomCardMatch, Setting, ProductPurchase, User
+from models import Card, Set, CollectionItem, WishlistItem, PriceHistory, SyncLog, PortfolioSnapshot, CustomCardMatch, Setting, ProductPurchase, User, ImageCache
 from services import pokemon_api, telegram
 from services.card_fallbacks import PRICE_FIELDS, apply_cross_language_fallbacks
 from services.card_values import effective_market_price
@@ -255,6 +255,10 @@ def upsert_card(db: Session, card_data: dict):
                 setattr(existing, key, value)
         if has_api_image:
             existing.custom_image_url = None
+            db.query(ImageCache).filter(ImageCache.image_key.in_([
+                f"card:{existing.id}:small:custom",
+                f"card:{existing.id}:large:custom",
+            ])).delete(synchronize_session=False)
     else:
         existing = Card(**card_data)
         db.add(existing)

--- a/backend/services/sync_service.py
+++ b/backend/services/sync_service.py
@@ -248,10 +248,13 @@ def upsert_card(db: Session, card_data: dict):
     """Insert or update a card in the database."""
     existing = db.query(Card).filter(Card.id == card_data["id"]).first()
     card_data["updated_at"] = datetime.datetime.utcnow()
+    has_api_image = bool(card_data.get("images_small") or card_data.get("images_large"))
     if existing:
         for key, value in card_data.items():
             if key != "id":
                 setattr(existing, key, value)
+        if has_api_image:
+            existing.custom_image_url = None
     else:
         existing = Card(**card_data)
         db.add(existing)

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -59,6 +59,7 @@ export const getCardInLang = (cardId, lang) => api.get(`/cards/${cardId}/lang/${
 export const getPriceHistory = (id) => api.get(`/cards/${id}/price-history`)
 export const createCustomCard = (data) => api.post('/cards/custom', data)
 export const updateCustomCard = (cardId, data) => api.put(`/cards/custom/${cardId}`, data).then(r => r.data)
+export const updateCardCustomImage = (cardId, data) => api.put(`/cards/${cardId}/custom-image`, data).then(r => r.data)
 export const deleteCustomCard = (cardId) => api.delete(`/cards/custom/${cardId}`)
 export const getCustomCards = () => api.get('/cards/custom')
 

--- a/frontend/src/components/CardItem.jsx
+++ b/frontend/src/components/CardItem.jsx
@@ -2,13 +2,13 @@ import { useState, useEffect, memo } from 'react'
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query'
 import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
 import { Plus, Check, Heart, BookOpen, X, PenLine, Pencil,  Trash2 } from 'lucide-react'
-import { addToCollection, addToWishlist, createCustomCard, updateCustomCard, deleteCustomCard, getSets, getPriceHistory } from '../api/client'
+import { addToCollection, addToWishlist, createCustomCard, updateCustomCard, updateCardCustomImage, deleteCustomCard, getSets, getPriceHistory } from '../api/client'
 import { useSettings } from '../contexts/SettingsContext'
 import PeriodSelector, { CARD_PERIODS, PERIOD_PRICE_FIELD } from './PeriodSelector'
 import toast from 'react-hot-toast'
 import clsx from 'clsx'
 import { useTilt } from '../hooks/useTilt'
-import { resolveCardImageUrl } from '../utils/imageUrl'
+import { cardImageUrl, resolveCardImageUrl } from '../utils/imageUrl'
 import { CARD_VARIANTS, getAvailableVariants, getDefaultVariant, getDefaultVariantOrNull } from '../utils/cardVariants'
 import FallbackBadges from './FallbackBadges'
 
@@ -524,6 +524,9 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
   const [purchasePrice, setPurchasePrice] = useState('')
   const [modalPeriod, setModalPeriod] = useState('total')
   const [resolvedCardId, setResolvedCardId] = useState(card.id)
+  const [customImageUrl, setCustomImageUrl] = useState(card.custom_image_url || '')
+  const [savedCustomImageUrl, setSavedCustomImageUrl] = useState(card.custom_image_url || '')
+  const [customImageVersion, setCustomImageVersion] = useState(0)
   const { t, formatPrice } = useSettings()
   const queryClient = useQueryClient()
 
@@ -537,11 +540,26 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
     retry: false,
   })
 
+  useEffect(() => {
+    const nextUrl = card.custom_image_url || ''
+    setCustomImageUrl(nextUrl)
+    setSavedCustomImageUrl(nextUrl)
+  }, [card.id, card.custom_image_url])
+
   const safePriceHistory = Array.isArray(priceHistory) ? priceHistory : []
+  const hasApiImage = Boolean(card?.images?.large || card?.images_large || card?.images?.small || card?.images_small || card?.image)
+  const customImageCardId = card?.card_id || card?.id
+  const canEditCustomImage = !card.is_custom && !hasApiImage && typeof customImageCardId === 'string'
+  const customImageProxyUrl = canEditCustomImage && savedCustomImageUrl
+    ? `${cardImageUrl(customImageCardId, 'large')}?v=${customImageVersion}`
+    : null
   const cardImage = card?.images?.large
-    || resolveCardImageUrl(card, 'large')
+    || card?.images_large
     || (card?.image ? `${card.image}/high.webp` : null)
     || card?.images?.small
+    || card?.images_small
+    || customImageProxyUrl
+    || resolveCardImageUrl(card, 'large')
     || resolveCardImageUrl(card)
   const setName = card.set?.name || card.set_ref?.name
 
@@ -564,6 +582,22 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
       onClose()
     },
     onError: () => toast.error(t('card.wishlistFailed')),
+  })
+
+  const customImageMutation = useMutation({
+    mutationFn: (url) => updateCardCustomImage(card.card_id || card.id, { custom_image_url: url || null }),
+    onSuccess: (updatedCard) => {
+      const nextUrl = updatedCard?.custom_image_url || ''
+      setCustomImageUrl(nextUrl)
+      setSavedCustomImageUrl(nextUrl)
+      setCustomImageVersion((version) => version + 1)
+      toast.success(t('card.customImageSaved'))
+      queryClient.invalidateQueries()
+    },
+    onError: (err) => {
+      const detail = err?.response?.data?.detail || t('common.error')
+      toast.error(detail)
+    },
   })
 
   const ALL_PRICE_KEYS = ['trend', 'avg1', 'avg7', 'avg30', 'low']
@@ -743,6 +777,51 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
                       <span className="font-bold text-blue-400">${val.toFixed(2)}</span>
                     </div>
                   ))}
+                </div>
+              </div>
+            )}
+
+            {canEditCustomImage && (
+              <div className="bg-bg-card rounded-xl p-3 space-y-2 border border-border">
+                <div>
+                  <p className="text-xs text-text-muted font-medium uppercase tracking-wide">
+                    {t('card.customImageUrl')}
+                  </p>
+                  <p className="text-xs text-text-secondary mt-1">
+                    {t('card.customImageUrlDesc')}
+                  </p>
+                </div>
+                <input
+                  type="url"
+                  placeholder="https://..."
+                  value={customImageUrl}
+                  onChange={(e) => setCustomImageUrl(e.target.value)}
+                  className="input w-full"
+                />
+                {customImageProxyUrl && (
+                  <div className="w-20 h-28 rounded overflow-hidden border border-border">
+                    <img src={customImageProxyUrl} alt="preview" className="w-full h-full object-cover" />
+                  </div>
+                )}
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => customImageMutation.mutate(customImageUrl.trim())}
+                    disabled={customImageMutation.isPending || customImageUrl.trim() === savedCustomImageUrl}
+                    className="btn-primary text-sm"
+                  >
+                    {customImageMutation.isPending ? t('common.saving') : t('card.saveCustomImage')}
+                  </button>
+                  {savedCustomImageUrl && (
+                    <button
+                      type="button"
+                      onClick={() => customImageMutation.mutate('')}
+                      disabled={customImageMutation.isPending}
+                      className="btn-ghost text-sm"
+                    >
+                      {t('card.clearCustomImage')}
+                    </button>
+                  )}
                 </div>
               </div>
             )}

--- a/frontend/src/components/CardItem.jsx
+++ b/frontend/src/components/CardItem.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, memo } from 'react'
+import { useState, useEffect, useId, memo } from 'react'
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query'
 import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
 import { Plus, Check, Heart, BookOpen, X, PenLine, Pencil,  Trash2 } from 'lucide-react'
@@ -527,6 +527,7 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
   const [customImageUrl, setCustomImageUrl] = useState(card.custom_image_url || '')
   const [savedCustomImageUrl, setSavedCustomImageUrl] = useState(card.custom_image_url || '')
   const [customImageVersion, setCustomImageVersion] = useState(0)
+  const customImageInputId = useId()
   const { t, formatPrice } = useSettings()
   const queryClient = useQueryClient()
 
@@ -592,7 +593,10 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
       setSavedCustomImageUrl(nextUrl)
       setCustomImageVersion((version) => version + 1)
       toast.success(t('card.customImageSaved'))
-      queryClient.invalidateQueries()
+      queryClient.invalidateQueries({ queryKey: ['card-search'] })
+      queryClient.invalidateQueries({ queryKey: ['collection'] })
+      queryClient.invalidateQueries({ queryKey: ['wishlist'] })
+      queryClient.invalidateQueries({ queryKey: ['set-checklist'] })
     },
     onError: (err) => {
       const detail = err?.response?.data?.detail || t('common.error')
@@ -784,14 +788,15 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
             {canEditCustomImage && (
               <div className="bg-bg-card rounded-xl p-3 space-y-2 border border-border">
                 <div>
-                  <p className="text-xs text-text-muted font-medium uppercase tracking-wide">
+                  <label htmlFor={customImageInputId} className="text-xs text-text-muted font-medium uppercase tracking-wide block">
                     {t('card.customImageUrl')}
-                  </p>
+                  </label>
                   <p className="text-xs text-text-secondary mt-1">
                     {t('card.customImageUrlDesc')}
                   </p>
                 </div>
                 <input
+                  id={customImageInputId}
                   type="url"
                   placeholder="https://..."
                   value={customImageUrl}
@@ -800,7 +805,7 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en' }) {
                 />
                 {customImageProxyUrl && (
                   <div className="w-20 h-28 rounded overflow-hidden border border-border">
-                    <img src={customImageProxyUrl} alt="preview" className="w-full h-full object-cover" />
+                    <img src={customImageProxyUrl} alt="" className="w-full h-full object-cover" />
                   </div>
                 )}
                 <div className="flex gap-2">

--- a/frontend/src/components/FallbackBadges.jsx
+++ b/frontend/src/components/FallbackBadges.jsx
@@ -8,7 +8,8 @@ export default function FallbackBadges({ card, className = '', compact = false }
   if (!card) return null
   const priceLang = card.price_source_lang
   const imageLang = card.image_source_lang
-  if (!priceLang && !imageLang) return null
+  const hasCustomImage = Boolean(card.custom_image_url) && !(card.images_small || card.images_large || card.images?.small || card.images?.large || card.image)
+  if (!priceLang && !imageLang && !hasCustomImage) return null
 
   const baseClass = compact
     ? 'text-[9px] px-1 py-0.5 rounded leading-none'
@@ -30,6 +31,14 @@ export default function FallbackBadges({ card, className = '', compact = false }
           title={t('fallback.imageFrom').replace('{lang}', sourceLabel(imageLang))}
         >
           🖼 {sourceLabel(imageLang)}
+        </span>
+      )}
+      {hasCustomImage && (
+        <span
+          className={clsx(baseClass, 'font-bold bg-violet-500/15 text-violet-300 border border-violet-500/30')}
+          title={t('fallback.customImageDesc')}
+        >
+          🖼 {t('fallback.customImage')}
         </span>
       )}
     </div>

--- a/frontend/src/i18n/de.js
+++ b/frontend/src/i18n/de.js
@@ -25,6 +25,8 @@ const de = {
     price: 'Preis',
     imageFrom: 'Bild-Fallback aus {lang}',
     priceFrom: 'Preis-Fallback aus {lang}',
+    customImage: 'Eigenes Bild',
+    customImageDesc: 'Manueller Bild-Fallback, solange die API kein Bild liefert',
   },
   common: {
     back: 'Zurück',
@@ -690,6 +692,11 @@ const de = {
     addedToWishlist: 'zur Wunschliste hinzugefügt!',
     wishlistFailed: 'Fehler beim Hinzufügen zur Wunschliste',
     editCard: 'Karte bearbeiten',
+    customImageUrl: 'Eigene Bild-URL',
+    customImageUrlDesc: 'Wird nur verwendet, solange TCGDex kein offizielles Kartenbild liefert. Sobald ein API-Bild verfügbar ist, wird es ignoriert.',
+    saveCustomImage: 'Bild-URL speichern',
+    clearCustomImage: 'Bild-URL entfernen',
+    customImageSaved: 'Eigene Bild-URL gespeichert',
   },
 
 

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -25,6 +25,8 @@ const en = {
     price: 'Price',
     imageFrom: 'Image fallback from {lang}',
     priceFrom: 'Price fallback from {lang}',
+    customImage: 'Custom image',
+    customImageDesc: 'Manual image fallback while the API has no image',
   },
   common: {
     back: 'Back',
@@ -690,6 +692,11 @@ const en = {
     addedToWishlist: 'added to wishlist!',
     wishlistFailed: 'Failed to add to wishlist',
     editCard: 'Edit card',
+    customImageUrl: 'Custom image URL',
+    customImageUrlDesc: 'Used only while TCGDex has no official card image. It will be ignored once an API image becomes available.',
+    saveCustomImage: 'Save image URL',
+    clearCustomImage: 'Clear image URL',
+    customImageSaved: 'Custom image URL saved',
   },
 
 

--- a/frontend/src/i18n/zh.js
+++ b/frontend/src/i18n/zh.js
@@ -25,6 +25,8 @@ const zh = {
     price: '价格',
     imageFrom: '图片回退来源：{lang}',
     priceFrom: '价格回退来源：{lang}',
+    customImage: '自定义图片',
+    customImageDesc: 'API 暂无图片时使用的手动图片回退',
   },
   common: {
     back: '返回',
@@ -691,6 +693,11 @@ const zh = {
     addedToWishlist: '已添加到愿望清单！',
     wishlistFailed: '添加到愿望清单失败',
     editCard: '编辑卡牌',
+    customImageUrl: '自定义图片 URL',
+    customImageUrlDesc: '仅在 TCGDex 没有官方卡牌图片时使用。一旦 API 图片可用，将自动忽略它。',
+    saveCustomImage: '保存图片 URL',
+    clearCustomImage: '清除图片 URL',
+    customImageSaved: '自定义图片 URL 已保存',
   },
 
   // Card Scanner

--- a/frontend/src/utils/imageUrl.js
+++ b/frontend/src/utils/imageUrl.js
@@ -16,14 +16,16 @@ export const resolveCardImageUrl = (card, size = 'small') => {
       || (card?.image ? `${card.image}/high.webp` : null)
       || card?.images?.small
       || card?.images_small
+      || card?.custom_image_url
       || card?.image_url
       || null
   }
 
   return card?.images?.small
     || card?.images_small
-    || card?.image_url
     || (card?.image ? `${card.image}/low.webp` : null)
+    || card?.custom_image_url
+    || card?.image_url
     || null
 }
 


### PR DESCRIPTION
## Summary
- add a temporary `custom_image_url` field for API cards that have no TCGDex image yet
- expose an authenticated endpoint and card modal UI to save/clear the manual image URL
- prefer official API images everywhere and clear the custom fallback during sync once an API image appears
- show a small custom-image fallback badge and proxy/cache the manual image through the existing image API

Closes #175

## Validation
- `python -m py_compile backend/models.py backend/database.py backend/schemas.py backend/api/cards.py backend/api/images.py backend/services/sync_service.py`
- `npm run build`
- `git diff --check`