### PR TITLE
Restore collection modal dialog presentation

### DIFF
--- a/frontend/src/pages/Collection.jsx
+++ b/frontend/src/pages/Collection.jsx
@@ -213,14 +213,22 @@ function CollectionEditModal({ item, onClose }) {
 
   return (
     <div
-      className="fixed inset-0 z-50 bg-bg-surface"
+      className="fixed inset-0 z-50 bg-black/75 backdrop-blur-sm md:flex md:items-center md:justify-center md:bg-black/80"
       onClick={onClose}
     >
       <div
-        className="fixed inset-0 h-[100dvh] overflow-y-auto bg-bg-surface"
+        className={[
+          'fixed bottom-0 left-0 right-0 rounded-t-2xl max-h-[90dvh] overflow-y-auto',
+          'bg-bg-surface border-t border-border more-sheet-enter',
+          'md:static md:rounded-2xl md:border md:max-w-lg md:w-full md:max-h-[85vh] md:animate-none',
+        ].join(' ')}
         onClick={e => e.stopPropagation()}
       >
-        <div className="p-5 md:max-w-lg md:mx-auto md:w-full">
+        <div className="flex justify-center pt-3 pb-1 md:hidden">
+          <div className="w-10 h-1 bg-border rounded-full" />
+        </div>
+
+        <div className="p-5">
           {/* Header */}
           <div className="flex items-start gap-4 mb-5">
             {cardImage && (


### PR DESCRIPTION
## Summary
- restore the collection edit modal as a dialog/bottom sheet instead of a full-page surface
- bring back the centered desktop modal and mobile sheet presentation
- keep the backdrop darker and blurred at all breakpoints so the background is less visually distracting

## Validation
- `npm run build`
- `git diff --check`

## Note
This corrects the over-aggressive fullscreen change from PR #179.