### PR TITLE
Prevent collection spacing from affecting modals

### DIFF
--- a/frontend/src/pages/Collection.jsx
+++ b/frontend/src/pages/Collection.jsx
@@ -538,8 +538,9 @@ export default function Collection() {
   }
 
   return (
-    <div className="space-y-4 pb-2">
-      <TabNav tabs={COLLECTION_TABS} />
+    <>
+      <div className="space-y-4 pb-2">
+        <TabNav tabs={COLLECTION_TABS} />
 
       {/* ─── Header ───────────────────────────────────────────────── */}
       <div className="flex items-center justify-between gap-2 mb-4 flex-wrap">
@@ -942,6 +943,8 @@ export default function Collection() {
         </>
       )}
 
+      </div>
+
       {/* ─── CollectionEditModal ──────────────────────────────────── */}
       {editingCollectionItem && (
         <CollectionEditModal
@@ -976,6 +979,6 @@ export default function Collection() {
           autoAddCollection={true}
         />
       )}
-    </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- move the collection modals outside the `space-y-4` content wrapper
- prevent Tailwind sibling spacing from adding margin to fixed modal overlays
- preserve the restored blurred/transparent modal backdrop and centered desktop dialog

## Validation
- `npm run build`
- `git diff --check`

## Context
The collection page wrapper uses `space-y-4`, whose generated sibling selector can apply margin to fixed modal overlays when they are rendered as children. Keeping modals as siblings outside that wrapper fixes the top offset generally for collection modals without overriding spacing globally.