### PR TITLE
Bump app version to 1.12

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -52,7 +52,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="Pokemon TCG Collection API",
-    version="1.11",
+    version="1.12",
     description="Complete Pokemon TCG collection management system",
     lifespan=lifespan,
 )

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokemon-tcg-collection",
-  "version": "1.11",
+  "version": "1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pokemon-tcg-collection",
-      "version": "1.11",
+      "version": "1.12",
       "dependencies": {
         "@tanstack/react-query": "^5.18.0",
         "axios": "^1.15.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pokemon-tcg-collection",
   "private": true,
-  "version": "1.11",
+  "version": "1.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/i18n/de.js
+++ b/frontend/src/i18n/de.js
@@ -504,7 +504,7 @@ const de = {
     telegramInfo: 'Telegram-Benachrichtigungen über Umgebungsvariablen konfigurieren:',
     telegramNote: 'Benachrichtigungen werden gesendet wenn Wunschlisten-Preise Alarmschwellen überschreiten. Maximal eine Benachrichtigung pro Karte alle 23 Stunden.',
     about: 'Über',
-    aboutDesc1: 'Pokémon TCG Sammlungs-Manager v1.0',
+    aboutDesc1: 'Pokémon TCG Sammlungs-Manager v1.12',
     aboutDesc2: 'Erstellt mit FastAPI + React + PostgreSQL',
     aboutDesc3: 'Daten von',
     aboutDesc4: 'Preise von Cardmarket (EUR)',

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -504,7 +504,7 @@ const en = {
     telegramInfo: 'Configure Telegram notifications via environment variables in your .env file:',
     telegramNote: 'Notifications are sent when wishlist card prices cross your alert thresholds during sync. Maximum one notification per card per 23 hours.',
     about: 'About',
-    aboutDesc1: 'Pokemon TCG Collection Manager v1.0',
+    aboutDesc1: 'Pokemon TCG Collection Manager v1.12',
     aboutDesc2: 'Built with FastAPI + React + PostgreSQL',
     aboutDesc3: 'Data from',
     aboutDesc4: 'Prices from Cardmarket (EUR)',

--- a/frontend/src/i18n/zh.js
+++ b/frontend/src/i18n/zh.js
@@ -505,7 +505,7 @@ const zh = {
     telegramInfo: '通过环境变量配置Telegram通知在你的 .env 文件中:',
     telegramNote: '同步时当愿望清单价格越过你的提醒阈值会发送通知。每张卡牌每23小时最多发送一次通知。',
     about: '关于',
-    aboutDesc1: '宝可梦TCG收藏管理器 v1.0',
+    aboutDesc1: '宝可梦TCG收藏管理器 v1.12',
     aboutDesc2: '使用 FastAPI + React + PostgreSQL 构建',
     aboutDesc3: '数据来自',
     aboutDesc4: '价格来自 Cardmarket (EUR)',


### PR DESCRIPTION
## Summary
* Bump backend API and frontend package versions to `1.12`
* Update visible About text version strings to `v1.12`

Follow-up to PR #191 after the checklist sort fix was merged.

## Validation
* `python -m py_compile backend/main.py backend/api/sets.py`
* `git diff --check`
