### PR TITLE
Fix missing language card fallbacks

### DIFF
--- a/backend/api/cards.py
+++ b/backend/api/cards.py
@@ -51,6 +51,7 @@ def _card_to_dict(card: Card) -> dict:
         "images_small": card.images_small,
         "images_large": card.images_large,
         "image_source_lang": getattr(card, "image_source_lang", None),
+        "data_source_lang": getattr(card, "data_source_lang", None),
         "custom_image_url": getattr(card, "custom_image_url", None),
         "is_custom": card.is_custom or False,
         "lang": card.lang or "en",

--- a/backend/api/cards.py
+++ b/backend/api/cards.py
@@ -8,7 +8,12 @@ from database import get_db
 from models import Card, Set, PriceHistory, CustomCardMatch, CollectionItem, WishlistItem, BinderCard, Setting, User, ImageCache
 from schemas import CardBase, CardWithSet, PriceHistoryResponse, CardCustomCreate, CustomCardUpdate, CardCustomImageUpdate
 from services import pokemon_api
-from services.card_fallbacks import apply_cross_language_fallbacks
+from services.card_fallbacks import (
+    apply_cross_language_fallbacks,
+    build_missing_language_card,
+    clone_card_for_missing_language,
+    other_supported_lang,
+)
 from services.image_url_security import validate_public_https_image_url
 import datetime
 import re
@@ -168,7 +173,9 @@ def _search_by_code_number(
                 stripped_filters.append(Card.lang == lang)
             cards = db.query(Card).filter(*stripped_filters).all()
 
-    # 3. Card not in DB — fetch from TCGdex and cache
+    # 3. Card not in DB — fetch from TCGdex and cache. If the requested
+    # language has only set metadata but no cards yet, create target-language
+    # fallback rows from the sibling language so exact add/search still works.
     if not cards:
         for set_obj in set_objs:
             tcg_set_id = set_obj.tcg_set_id or set_obj.id
@@ -187,7 +194,33 @@ def _search_by_code_number(
                         db.add(Card(**parsed))
                 db.commit()
             except Exception:
-                pass
+                db.rollback()
+
+            if db.query(Card).filter(Card.set_id == tcg_set_id, Card.lang == set_lang).count() == 0:
+                fallback_lang = other_supported_lang(set_lang)
+                if fallback_lang:
+                    try:
+                        fallback_data = pokemon_api.get_set_cards(tcg_set_id, lang=fallback_lang)
+                        for card_data in fallback_data.get("cards", []):
+                            parsed = clone_card_for_missing_language(
+                                db,
+                                card_data,
+                                target_lang=set_lang,
+                                source_lang=fallback_lang,
+                                default_set_id=tcg_set_id,
+                            )
+                            if not parsed:
+                                continue
+                            existing = db.query(Card).filter(Card.id == parsed["id"]).first()
+                            if existing:
+                                for key, value in parsed.items():
+                                    if key != "id":
+                                        setattr(existing, key, value)
+                            else:
+                                db.add(Card(**parsed))
+                        db.commit()
+                    except Exception:
+                        db.rollback()
 
         lang_filters = [Card.set_id.in_(tcg_set_ids), Card.number == card_number]
         if lang != "all":
@@ -787,27 +820,26 @@ def get_card(
     # Fetch full card detail from TCGdex (includes pricing)
     # strip_lang_suffix handles both composite IDs (sv1-1_de) and legacy IDs (sv1-1)
     tcg_card_id, detected_lang = pokemon_api.strip_lang_suffix(card_id)
-    card_lang = lang or detected_lang
+    # An explicit suffix in the DB id wins over the query default. Requesting
+    # me04-001_de should create/return a German row, even if it temporarily uses
+    # English fallback data.
+    card_lang = detected_lang if card_id.endswith(("_de", "_en")) else (lang or detected_lang)
     try:
         card_data = pokemon_api.get_card(tcg_card_id, lang=card_lang)
-        if not card_data:
-            # Try the other language as fallback
-            fallback = "de" if card_lang == "en" else "en"
-            card_data = pokemon_api.get_card(tcg_card_id, lang=fallback)
-            if card_data:
-                card_lang = fallback
-        if not card_data:
-            raise HTTPException(status_code=404, detail="Card not found")
-
-        parsed = pokemon_api.parse_card_for_db(card_data, lang=card_lang)
-        parsed = apply_cross_language_fallbacks(db, parsed)
+        if card_data:
+            parsed = pokemon_api.parse_card_for_db(card_data, lang=card_lang)
+            parsed = apply_cross_language_fallbacks(db, parsed)
+        else:
+            parsed = build_missing_language_card(db, tcg_card_id, card_lang)
+            if not parsed:
+                raise HTTPException(status_code=404, detail="Card not found")
 
         # Ensure set exists
         if parsed.get("set_id"):
             set_obj = db.query(Set).filter(Set.id == parsed["set_id"]).first()
             if not set_obj:
                 # Create minimal set record
-                set_data = card_data.get("set") or {}
+                set_data = card_data.get("set") if card_data else None
                 if set_data:
                     set_parsed = pokemon_api.parse_set_for_db(set_data)
                     db.add(Set(**set_parsed))

--- a/backend/api/cards.py
+++ b/backend/api/cards.py
@@ -14,6 +14,7 @@ from services.card_fallbacks import (
     clone_card_for_missing_language,
     other_supported_lang,
 )
+from services.card_upsert import upsert_card
 from services.image_url_security import validate_public_https_image_url
 import datetime
 import re
@@ -185,13 +186,7 @@ def _search_by_code_number(
                 for card_data in set_data.get("cards", []):
                     parsed = pokemon_api.parse_card_for_db(card_data, default_set_id=tcg_set_id, lang=set_lang)
                     parsed = apply_cross_language_fallbacks(db, parsed)
-                    existing = db.query(Card).filter(Card.id == parsed["id"]).first()
-                    if existing:
-                        for key, value in parsed.items():
-                            if key != "id":
-                                setattr(existing, key, value)
-                    else:
-                        db.add(Card(**parsed))
+                    upsert_card(db, parsed)
                 db.commit()
             except Exception:
                 db.rollback()
@@ -211,13 +206,7 @@ def _search_by_code_number(
                             )
                             if not parsed:
                                 continue
-                            existing = db.query(Card).filter(Card.id == parsed["id"]).first()
-                            if existing:
-                                for key, value in parsed.items():
-                                    if key != "id":
-                                        setattr(existing, key, value)
-                            else:
-                                db.add(Card(**parsed))
+                            upsert_card(db, parsed)
                         db.commit()
                     except Exception:
                         db.rollback()
@@ -846,8 +835,7 @@ def get_card(
                 else:
                     db.add(Set(id=parsed["set_id"], name=parsed["set_id"], total=0))
 
-        card = Card(**parsed)
-        db.add(card)
+        card = upsert_card(db, parsed)
         db.commit()
         db.refresh(card)
         return card

--- a/backend/api/collection.py
+++ b/backend/api/collection.py
@@ -7,7 +7,7 @@ from database import get_db
 from models import CollectionItem, Card, Set, User
 from schemas import CollectionItemCreate, CollectionItemUpdate, CollectionItemResponse, BulkCollectionAddRequest, BulkCollectionAddResponse
 from services import pokemon_api
-from services.card_fallbacks import apply_cross_language_fallbacks
+from services.card_fallbacks import apply_cross_language_fallbacks, build_missing_language_card
 from services.card_values import effective_market_price
 import datetime
 import csv
@@ -36,14 +36,17 @@ def ensure_card_exists(db: Session, card_id: str, lang: str = "en") -> Card:
     if not card:
         tcg_card_id, _ = pokemon_api.strip_lang_suffix(card_id)
         card_data = pokemon_api.get_card(tcg_card_id, lang=lang)
-        if not card_data:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Card {card_id} not found in local database. Please run a Sync first."
-            )
-        parsed = pokemon_api.parse_card_for_db(card_data, lang=lang)
-        parsed = apply_cross_language_fallbacks(db, parsed)
-        if parsed.get("set_id"):
+        if card_data:
+            parsed = pokemon_api.parse_card_for_db(card_data, lang=lang)
+            parsed = apply_cross_language_fallbacks(db, parsed)
+        else:
+            parsed = build_missing_language_card(db, tcg_card_id, lang)
+            if not parsed:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Card {card_id} not found in local database. Please run a Sync first."
+                )
+        if parsed.get("set_id") and card_data:
             set_data = card_data.get("set", {})
             if set_data:
                 set_parsed = pokemon_api.parse_set_for_db(set_data)
@@ -69,7 +72,8 @@ def ensure_card_exists(db: Session, card_id: str, lang: str = "en") -> Card:
 
 def _add_collection_item(db: Session, current_user: User, item: CollectionItemCreate, commit: bool = True) -> str:
     """Add one item and return "added" or "updated"."""
-    item_lang = item.lang or "en"
+    _, detected_lang = pokemon_api.strip_lang_suffix(item.card_id)
+    item_lang = item.lang or detected_lang or "en"
 
     if item.card_id.startswith("custom-"):
         effective_card_id = item.card_id
@@ -306,7 +310,8 @@ def add_to_collection(
     db: Session = Depends(get_db),
 ):
     """Add a card to the collection. Cards with identical card_id+variant+lang+condition+purchase_price are grouped."""
-    item_lang = item.lang or "en"
+    _, detected_lang = pokemon_api.strip_lang_suffix(item.card_id)
+    item_lang = item.lang or detected_lang or "en"
 
     # Resolve the correct language-variant card_id
     if item.card_id.startswith("custom-"):
@@ -373,7 +378,8 @@ def bulk_add_to_collection(
 
     for item in request.items:
         try:
-            item_lang = item.lang or "en"
+            _, detected_lang = pokemon_api.strip_lang_suffix(item.card_id)
+            item_lang = item.lang or detected_lang or "en"
 
             if item.card_id.startswith("custom-"):
                 effective_card_id = item.card_id

--- a/backend/api/collection.py
+++ b/backend/api/collection.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
-from sqlalchemy import func
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session, joinedload
 from typing import List, Optional
 from api.auth import get_current_user
@@ -30,6 +30,30 @@ def _get_item_price(item):
     return effective_market_price(item.card, item.variant)
 
 
+def _ensure_set_exists_for_card(db: Session, parsed: dict, lang: str, card_data: Optional[dict] = None) -> None:
+    set_id = parsed.get("set_id")
+    if not set_id:
+        return
+
+    existing_set = db.query(Set).filter(
+        or_(Set.id == set_id, Set.id == f"{set_id}_{lang}", Set.tcg_set_id == set_id),
+        Set.lang == lang,
+    ).first()
+    if existing_set:
+        return
+
+    set_data = card_data.get("set") if card_data else None
+    if set_data:
+        set_parsed = pokemon_api.parse_set_for_db(set_data)
+        set_parsed["lang"] = set_data.get("_lang", lang)
+        if not set_parsed["id"].endswith(("_de", "_en")):
+            set_parsed["id"] = f"{set_id}_{lang}"
+        set_parsed["tcg_set_id"] = set_id
+        db.add(Set(**set_parsed))
+    else:
+        db.add(Set(id=f"{set_id}_{lang}", tcg_set_id=set_id, name=set_id, total=0, lang=lang))
+
+
 def ensure_card_exists(db: Session, card_id: str, lang: str = "en") -> Card:
     """Ensure card exists in DB. If not found locally, try to fetch from TCGdex."""
     card = db.query(Card).filter(Card.id == card_id).first()
@@ -44,16 +68,9 @@ def ensure_card_exists(db: Session, card_id: str, lang: str = "en") -> Card:
             if not parsed:
                 raise HTTPException(
                     status_code=404,
-                    detail=f"Card {card_id} not found in local database. Please run a Sync first."
+                    detail=f"Card {card_id} is not available locally, from TCGdex, or from a sibling-language fallback yet. Please try again after the source data is available or run Sync later."
                 )
-        if parsed.get("set_id") and card_data:
-            set_data = card_data.get("set", {})
-            if set_data:
-                set_parsed = pokemon_api.parse_set_for_db(set_data)
-                set_parsed["lang"] = set_data.get("_lang", lang)
-                existing_set = db.query(Set).filter(Set.id == set_parsed["id"]).first()
-                if not existing_set:
-                    db.add(Set(**set_parsed))
+        _ensure_set_exists_for_card(db, parsed, lang, card_data)
         card = Card(**parsed)
         db.add(card)
         try:
@@ -65,7 +82,7 @@ def ensure_card_exists(db: Session, card_id: str, lang: str = "en") -> Card:
             if not card:
                 raise HTTPException(
                     status_code=404,
-                    detail=f"Card {card_id} not found in local database. Please run a Sync first."
+                    detail=f"Card {card_id} is not available locally, from TCGdex, or from a sibling-language fallback yet. Please try again after the source data is available or run Sync later."
                 )
     return card
 

--- a/backend/api/sets.py
+++ b/backend/api/sets.py
@@ -9,7 +9,11 @@ from database import get_db
 from models import Set, Card, CollectionItem, Setting, User
 from schemas import SetBase
 from services import pokemon_api
-from services.card_fallbacks import apply_cross_language_fallbacks
+from services.card_fallbacks import (
+    apply_cross_language_fallbacks,
+    clone_card_for_missing_language,
+    other_supported_lang,
+)
 
 router = APIRouter()
 
@@ -40,6 +44,18 @@ def _get_language(db: Session) -> str:
     """Get display language from settings."""
     row = db.query(Setting).filter(Setting.key == "language").first()
     return row.value if row else "de"
+
+
+def _upsert_card(db: Session, parsed: dict) -> Card:
+    existing = db.query(Card).filter(Card.id == parsed["id"]).first()
+    if existing:
+        for key, value in parsed.items():
+            if key != "id":
+                setattr(existing, key, value)
+        return existing
+    card = Card(**parsed)
+    db.add(card)
+    return card
 
 
 def _refresh_sets(db: Session, display_lang: str):
@@ -180,7 +196,8 @@ def get_set_checklist(
     """Get set checklist - cards with ownership status.
 
     set_id is the composite DB key (e.g. 'sv1_de').
-    Cards are served exclusively from the local DB — no live API call.
+    Missing local cards are fetched from TCGdex and may use sibling-language
+    fallback rows until native language data exists.
     """
     set_obj = db.query(Set).filter(Set.id == set_id).first()
     if not set_obj:
@@ -196,42 +213,79 @@ def get_set_checklist(
         Card.lang == set_lang,
     ).all()
 
-    # If no lang-filtered cards found, check if there are cards with NULL/wrong lang
-    # (pre-migration cards) and fix them
+    # If no lang-filtered cards are found, only repair legacy cards that do not
+    # already have an explicit language in their DB id. Do not relabel sibling
+    # rows like me04-001_en as German cards.
     if not cards:
-        existing_cards = db.query(Card).filter(
-            Card.set_id == tcg_id,
-        ).all()
-        if existing_cards:
-            # Update their lang to match this set
-            for c in existing_cards:
-                c.lang = set_lang
+        legacy_cards = db.query(Card).filter(Card.set_id == tcg_id).all()
+        repairable_cards = [
+            card for card in legacy_cards
+            if not (card.id or "").endswith(("_de", "_en"))
+        ]
+        if repairable_cards:
+            for card in repairable_cards:
+                card.lang = set_lang
             db.commit()
-            cards = existing_cards  # Use them directly
+            cards = repairable_cards
 
-    # If still no cards, fetch from TCGdex and cache them
+    # If still no cards, fetch native cards from TCGdex and cache them.
     if not cards:
         try:
             set_data = pokemon_api.get_set_cards(tcg_id, lang=set_lang)
             for card_data in set_data.get("cards", []):
                 parsed = pokemon_api.parse_card_for_db(card_data, default_set_id=tcg_id, lang=set_lang)
                 parsed = apply_cross_language_fallbacks(db, parsed)
-                existing = db.query(Card).filter(Card.id == parsed["id"]).first()
-                if existing:
-                    for key, value in parsed.items():
-                        if key != "id":
-                            setattr(existing, key, value)
-                else:
-                    db.add(Card(**parsed))
+                _upsert_card(db, parsed)
             db.commit()
             cards = db.query(Card).filter(
                 Card.set_id == tcg_id,
                 Card.lang == set_lang,
             ).all()
         except Exception:
-            # Last resort: return any cards for this set regardless of lang
+            db.rollback()
+
+    # Some new sets exist as localized set metadata before localized card data
+    # exists. In that temporary state, create target-language card rows from the
+    # sibling language so users can add e.g. me04-001_de now and let a later sync
+    # replace the fallback data when TCGdex publishes the German card.
+    if not cards:
+        fallback_lang = other_supported_lang(set_lang)
+        if fallback_lang:
+            source_cards = db.query(Card).filter(
+                Card.set_id == tcg_id,
+                Card.lang == fallback_lang,
+                Card.is_custom == False,
+            ).all()
+            try:
+                if source_cards:
+                    for source_card in source_cards:
+                        parsed = clone_card_for_missing_language(
+                            db,
+                            source_card,
+                            target_lang=set_lang,
+                            source_lang=fallback_lang,
+                            default_set_id=tcg_id,
+                        )
+                        if parsed:
+                            _upsert_card(db, parsed)
+                else:
+                    set_data = pokemon_api.get_set_cards(tcg_id, lang=fallback_lang)
+                    for card_data in set_data.get("cards", []):
+                        parsed = clone_card_for_missing_language(
+                            db,
+                            card_data,
+                            target_lang=set_lang,
+                            source_lang=fallback_lang,
+                            default_set_id=tcg_id,
+                        )
+                        if parsed:
+                            _upsert_card(db, parsed)
+                db.commit()
+            except Exception:
+                db.rollback()
             cards = db.query(Card).filter(
                 Card.set_id == tcg_id,
+                Card.lang == set_lang,
             ).all()
 
     cards.sort(key=lambda card: _natural_card_number_key(card.number))

--- a/backend/api/sets.py
+++ b/backend/api/sets.py
@@ -307,6 +307,7 @@ def get_set_checklist(
             "images_small": card.images_small,
             "images_large": card.images_large,
             "image_source_lang": getattr(card, "image_source_lang", None),
+            "data_source_lang": getattr(card, "data_source_lang", None),
             "price_source_lang": getattr(card, "price_source_lang", None),
             "owned": owned,
             "quantity": qty,

--- a/backend/api/sets.py
+++ b/backend/api/sets.py
@@ -14,6 +14,7 @@ from services.card_fallbacks import (
     clone_card_for_missing_language,
     other_supported_lang,
 )
+from services.card_upsert import upsert_card
 
 router = APIRouter()
 
@@ -44,18 +45,6 @@ def _get_language(db: Session) -> str:
     """Get display language from settings."""
     row = db.query(Setting).filter(Setting.key == "language").first()
     return row.value if row else "de"
-
-
-def _upsert_card(db: Session, parsed: dict) -> Card:
-    existing = db.query(Card).filter(Card.id == parsed["id"]).first()
-    if existing:
-        for key, value in parsed.items():
-            if key != "id":
-                setattr(existing, key, value)
-        return existing
-    card = Card(**parsed)
-    db.add(card)
-    return card
 
 
 def _refresh_sets(db: Session, display_lang: str):
@@ -235,7 +224,7 @@ def get_set_checklist(
             for card_data in set_data.get("cards", []):
                 parsed = pokemon_api.parse_card_for_db(card_data, default_set_id=tcg_id, lang=set_lang)
                 parsed = apply_cross_language_fallbacks(db, parsed)
-                _upsert_card(db, parsed)
+                upsert_card(db, parsed)
             db.commit()
             cards = db.query(Card).filter(
                 Card.set_id == tcg_id,
@@ -267,7 +256,7 @@ def get_set_checklist(
                             default_set_id=tcg_id,
                         )
                         if parsed:
-                            _upsert_card(db, parsed)
+                            upsert_card(db, parsed)
                 else:
                     set_data = pokemon_api.get_set_cards(tcg_id, lang=fallback_lang)
                     for card_data in set_data.get("cards", []):
@@ -279,7 +268,7 @@ def get_set_checklist(
                             default_set_id=tcg_id,
                         )
                         if parsed:
-                            _upsert_card(db, parsed)
+                            upsert_card(db, parsed)
                 db.commit()
             except Exception:
                 db.rollback()

--- a/backend/api/sets.py
+++ b/backend/api/sets.py
@@ -11,8 +11,8 @@ from schemas import SetBase
 from services import pokemon_api
 from services.card_fallbacks import (
     apply_cross_language_fallbacks,
-    clone_card_for_missing_language,
-    other_supported_lang,
+    build_missing_language_cards_for_set,
+    missing_language_fallback_enabled,
 )
 from services.card_upsert import upsert_card
 
@@ -195,12 +195,19 @@ def get_set_checklist(
     # Use the original TCGdex set ID for card lookups
     tcg_id = set_obj.tcg_set_id or set_obj.id
     set_lang = set_obj.lang or "en"
+    fallback_enabled = missing_language_fallback_enabled(db)
+
+    def query_set_cards():
+        query = db.query(Card).filter(
+            Card.set_id == tcg_id,
+            Card.lang == set_lang,
+        )
+        if not fallback_enabled:
+            query = query.filter(Card.data_source_lang.is_(None))
+        return query.all()
 
     # Query DB for cards matching both set_id and lang
-    cards = db.query(Card).filter(
-        Card.set_id == tcg_id,
-        Card.lang == set_lang,
-    ).all()
+    cards = query_set_cards()
 
     # If no lang-filtered cards are found, only repair legacy cards that do not
     # already have an explicit language in their DB id. Do not relabel sibling
@@ -226,56 +233,24 @@ def get_set_checklist(
                 parsed = apply_cross_language_fallbacks(db, parsed)
                 upsert_card(db, parsed)
             db.commit()
-            cards = db.query(Card).filter(
-                Card.set_id == tcg_id,
-                Card.lang == set_lang,
-            ).all()
+            cards = query_set_cards()
         except Exception:
             db.rollback()
 
     # Some new sets exist as localized set metadata before localized card data
-    # exists. In that temporary state, create target-language card rows from the
-    # sibling language so users can add e.g. me04-001_de now and let a later sync
-    # replace the fallback data when TCGdex publishes the German card.
-    if not cards:
-        fallback_lang = other_supported_lang(set_lang)
-        if fallback_lang:
-            source_cards = db.query(Card).filter(
-                Card.set_id == tcg_id,
-                Card.lang == fallback_lang,
-                Card.is_custom == False,
-            ).all()
-            try:
-                if source_cards:
-                    for source_card in source_cards:
-                        parsed = clone_card_for_missing_language(
-                            db,
-                            source_card,
-                            target_lang=set_lang,
-                            source_lang=fallback_lang,
-                            default_set_id=tcg_id,
-                        )
-                        if parsed:
-                            upsert_card(db, parsed)
-                else:
-                    set_data = pokemon_api.get_set_cards(tcg_id, lang=fallback_lang)
-                    for card_data in set_data.get("cards", []):
-                        parsed = clone_card_for_missing_language(
-                            db,
-                            card_data,
-                            target_lang=set_lang,
-                            source_lang=fallback_lang,
-                            default_set_id=tcg_id,
-                        )
-                        if parsed:
-                            upsert_card(db, parsed)
-                db.commit()
-            except Exception:
-                db.rollback()
-            cards = db.query(Card).filter(
-                Card.set_id == tcg_id,
-                Card.lang == set_lang,
-            ).all()
+    # exists. When cross-language fallback is enabled, fill any missing target
+    # rows from the sibling language. Do this even if one fallback row already
+    # exists, otherwise adding a single card prevents the rest of the set from
+    # appearing after fallback is turned on.
+    set_total = set_obj.total or 0
+    if fallback_enabled and (not cards or (set_total and len(cards) < set_total)):
+        try:
+            for parsed in build_missing_language_cards_for_set(db, tcg_id, set_lang, expected_total=set_total):
+                upsert_card(db, parsed)
+            db.commit()
+        except Exception:
+            db.rollback()
+        cards = query_set_cards()
 
     cards.sort(key=lambda card: _natural_card_number_key(card.number))
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -189,9 +189,10 @@ def _run_migrations(conn):
         "ALTER TABLE product_purchases ADD COLUMN IF NOT EXISTS user_id INTEGER REFERENCES users(id)",
         "ALTER TABLE portfolio_snapshots ADD COLUMN IF NOT EXISTS user_id INTEGER REFERENCES users(id)",
         "ALTER TABLE users ADD COLUMN IF NOT EXISTS must_change_password BOOLEAN DEFAULT false",
-        # v43: Track when card prices/images are copied from another language.
+        # v43: Track when card prices/images/data are copied from another language.
         "ALTER TABLE cards ADD COLUMN IF NOT EXISTS price_source_lang VARCHAR",
         "ALTER TABLE cards ADD COLUMN IF NOT EXISTS image_source_lang VARCHAR",
+        "ALTER TABLE cards ADD COLUMN IF NOT EXISTS data_source_lang VARCHAR",
         # v44: Track price sync attempts independently from general card updates.
         "ALTER TABLE cards ADD COLUMN IF NOT EXISTS last_price_sync_attempt_at TIMESTAMP",
         "ALTER TABLE cards ADD COLUMN IF NOT EXISTS last_price_sync_success_at TIMESTAMP",

--- a/backend/main.py
+++ b/backend/main.py
@@ -52,7 +52,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="Pokemon TCG Collection API",
-    version="1.13",
+    version="1.14",
     description="Complete Pokemon TCG collection management system",
     lifespan=lifespan,
 )

--- a/backend/main.py
+++ b/backend/main.py
@@ -52,7 +52,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="Pokemon TCG Collection API",
-    version="1.14",
+    version="1.15",
     description="Complete Pokemon TCG collection management system",
     lifespan=lifespan,
 )

--- a/backend/models.py
+++ b/backend/models.py
@@ -53,6 +53,7 @@ class Card(Base):
     images_small = Column(String)
     images_large = Column(String)
     image_source_lang = Column(String, nullable=True)  # Set when images are copied from another TCGdex language
+    data_source_lang = Column(String, nullable=True)   # Set when metadata is copied from another TCGdex language
     custom_image_url = Column(String, nullable=True)   # Manual temporary fallback while TCGdex has no image
     is_custom = Column(Boolean, default=False)
     lang = Column(String, default="en")      # "en" or "de"

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -37,6 +37,7 @@ class CardBase(BaseModel):
     images_small: Optional[str] = None
     images_large: Optional[str] = None
     image_source_lang: Optional[str] = None
+    data_source_lang: Optional[str] = None
     custom_image_url: Optional[str] = None
     is_custom: bool = False
     price_market: Optional[float] = None

--- a/backend/services/card_fallbacks.py
+++ b/backend/services/card_fallbacks.py
@@ -184,8 +184,6 @@ def clone_card_for_missing_language(
         return None
 
     price_enabled, image_enabled = _fallback_settings(db, price_enabled, image_enabled)
-    if not (price_enabled or image_enabled):
-        return None
 
     tcg_card_id = parsed.get("tcg_card_id") or pokemon_api.strip_lang_suffix(parsed.get("id", ""))[0]
     if not tcg_card_id:

--- a/backend/services/card_fallbacks.py
+++ b/backend/services/card_fallbacks.py
@@ -4,6 +4,12 @@ TCGdex can have images or pricing in one language response while the matching
 card in another language has no public API data. These helpers keep the native
 card row but fill missing image/price fields from the sibling language when the
 admin setting allows it, and record the source language for visible UI tags.
+
+Some new sets appear in one language before the matching card endpoints exist
+in the other language. For those temporary gaps we can also create a card row in
+the requested language from the sibling language data. The row keeps the target
+DB id/lang (for example ``me04-001_de``), but marks borrowed images/prices so a
+later native sync can replace the fallback data in place.
 """
 
 from __future__ import annotations
@@ -46,6 +52,22 @@ PRICE_FIELDS = (
     "price_tcg_holo_market",
 )
 IMAGE_FIELDS = ("images_small", "images_large")
+CARD_COPY_FIELDS = (
+    "tcg_card_id",
+    "name",
+    "set_id",
+    "number",
+    "rarity",
+    "types",
+    "supertype",
+    "subtypes",
+    "hp",
+    "artist",
+    "variants_normal",
+    "variants_reverse",
+    "variants_holo",
+    "variants_first_edition",
+)
 
 
 def _setting_enabled(db: Session, key: str, default: bool = True) -> bool:
@@ -61,6 +83,11 @@ def _other_lang(lang: Optional[str]) -> Optional[str]:
     if lang == "en":
         return "de"
     return None
+
+
+def other_supported_lang(lang: Optional[str]) -> Optional[str]:
+    """Return the supported sibling language for public callers."""
+    return _other_lang(lang)
 
 
 def _has_price(data: dict) -> bool:
@@ -84,6 +111,20 @@ def _card_to_data(card: Card) -> dict:
     return data
 
 
+def _card_to_fallback_source(card: Card) -> dict:
+    data = {field: getattr(card, field, None) for field in CARD_COPY_FIELDS}
+    data.update(_card_to_data(card))
+    return data
+
+
+def _fallback_settings(db: Session, price_enabled: Optional[bool], image_enabled: Optional[bool]) -> tuple[bool, bool]:
+    if price_enabled is None:
+        price_enabled = _setting_enabled(db, "cross_language_price_fallback", True)
+    if image_enabled is None:
+        image_enabled = _setting_enabled(db, "cross_language_image_fallback", True)
+    return price_enabled, image_enabled
+
+
 def _load_sibling_data(db: Session, tcg_card_id: str, lang: str) -> Optional[dict]:
     sibling = db.query(Card).filter(
         Card.tcg_card_id == tcg_card_id,
@@ -102,6 +143,122 @@ def _load_sibling_data(db: Session, tcg_card_id: str, lang: str) -> Optional[dic
     if not card_data:
         return None
     return pokemon_api.parse_card_for_db(card_data, lang=lang)
+
+
+def clone_card_for_missing_language(
+    db: Session,
+    source: Card | dict,
+    *,
+    target_lang: str,
+    source_lang: Optional[str] = None,
+    default_set_id: Optional[str] = None,
+    price_enabled: Optional[bool] = None,
+    image_enabled: Optional[bool] = None,
+) -> Optional[dict]:
+    """Create a target-language card row from sibling-language card data.
+
+    This is used when TCGdex has a set/card in one language, but the requested
+    language endpoint is still missing. The returned row keeps the requested
+    language id (``<tcg_id>_<target_lang>``) so collection entries can already be
+    stored as German/English and later native syncs replace the fallback data.
+    """
+    target_lang = (target_lang or "").lower()
+    source_lang = (source_lang or "").lower() or None
+    if target_lang not in SUPPORTED_LANGS:
+        return None
+
+    if isinstance(source, Card):
+        parsed = _card_to_fallback_source(source)
+        source_lang = source_lang or source.lang
+    else:
+        source_lang = source_lang or source.get("_lang") or source.get("lang")
+        parsed = pokemon_api.parse_card_for_db(source, default_set_id=default_set_id, lang=source_lang)
+
+    source_lang = (source_lang or parsed.get("lang") or "").lower()
+    if source_lang not in SUPPORTED_LANGS or source_lang == target_lang:
+        return None
+
+    price_enabled, image_enabled = _fallback_settings(db, price_enabled, image_enabled)
+    if not (price_enabled or image_enabled):
+        return None
+
+    tcg_card_id = parsed.get("tcg_card_id") or pokemon_api.strip_lang_suffix(parsed.get("id", ""))[0]
+    if not tcg_card_id:
+        return None
+
+    parsed = parsed.copy()
+    parsed["id"] = f"{tcg_card_id}_{target_lang}"
+    parsed["tcg_card_id"] = tcg_card_id
+    parsed["lang"] = target_lang
+    if default_set_id and not parsed.get("set_id"):
+        parsed["set_id"] = default_set_id
+
+    parsed["price_source_lang"] = None
+    parsed["image_source_lang"] = None
+
+    if price_enabled and _has_price(parsed):
+        parsed["price_source_lang"] = source_lang
+    else:
+        for field in PRICE_FIELDS:
+            parsed[field] = None
+
+    if image_enabled and _has_image(parsed):
+        parsed["image_source_lang"] = source_lang
+    else:
+        for field in IMAGE_FIELDS:
+            parsed[field] = None
+
+    return parsed
+
+
+def build_missing_language_card(
+    db: Session,
+    tcg_card_id: str,
+    target_lang: str,
+    *,
+    default_set_id: Optional[str] = None,
+    price_enabled: Optional[bool] = None,
+    image_enabled: Optional[bool] = None,
+) -> Optional[dict]:
+    """Fetch sibling card data and clone it into the requested language."""
+    fallback_lang = _other_lang(target_lang)
+    if not tcg_card_id or not fallback_lang:
+        return None
+
+    sibling = db.query(Card).filter(
+        Card.tcg_card_id == tcg_card_id,
+        Card.lang == fallback_lang,
+        Card.is_custom == False,
+    ).first()
+    if sibling:
+        return clone_card_for_missing_language(
+            db,
+            sibling,
+            target_lang=target_lang,
+            source_lang=fallback_lang,
+            default_set_id=default_set_id,
+            price_enabled=price_enabled,
+            image_enabled=image_enabled,
+        )
+
+    try:
+        card_data = pokemon_api.get_card(tcg_card_id, lang=fallback_lang)
+    except Exception as exc:
+        logger.debug("Failed to fetch %s in %s for missing-language fallback: %s", tcg_card_id, fallback_lang, exc)
+        return None
+
+    if not card_data:
+        return None
+
+    return clone_card_for_missing_language(
+        db,
+        card_data,
+        target_lang=target_lang,
+        source_lang=fallback_lang,
+        default_set_id=default_set_id,
+        price_enabled=price_enabled,
+        image_enabled=image_enabled,
+    )
 
 
 def apply_cross_language_fallbacks(
@@ -129,10 +286,7 @@ def apply_cross_language_fallbacks(
     need_price = not _has_price(parsed)
     need_image = not _has_image(parsed)
 
-    if price_enabled is None:
-        price_enabled = _setting_enabled(db, "cross_language_price_fallback", True)
-    if image_enabled is None:
-        image_enabled = _setting_enabled(db, "cross_language_image_fallback", True)
+    price_enabled, image_enabled = _fallback_settings(db, price_enabled, image_enabled)
 
     if not ((need_price and price_enabled) or (need_image and image_enabled)):
         return parsed

--- a/backend/services/card_fallbacks.py
+++ b/backend/services/card_fallbacks.py
@@ -8,8 +8,9 @@ admin setting allows it, and record the source language for visible UI tags.
 Some new sets appear in one language before the matching card endpoints exist
 in the other language. For those temporary gaps we can also create a card row in
 the requested language from the sibling language data. The row keeps the target
-DB id/lang (for example ``me04-001_de``), but marks borrowed images/prices so a
-later native sync can replace the fallback data in place.
+DB id/lang (for example ``me04-001_de``), but marks borrowed metadata,
+images, and prices so a later native sync can replace the fallback data in
+place.
 """
 
 from __future__ import annotations
@@ -168,6 +169,10 @@ def clone_card_for_missing_language(
         return None
 
     if isinstance(source, Card):
+        # Do not cascade metadata fallback. Missing-language rows should only be
+        # cloned from native sibling data, not from a row that was itself cloned.
+        if getattr(source, "data_source_lang", None):
+            return None
         parsed = _card_to_fallback_source(source)
         source_lang = source_lang or source.lang
     else:
@@ -195,6 +200,7 @@ def clone_card_for_missing_language(
 
     parsed["price_source_lang"] = None
     parsed["image_source_lang"] = None
+    parsed["data_source_lang"] = source_lang
 
     if price_enabled and _has_price(parsed):
         parsed["price_source_lang"] = source_lang
@@ -278,6 +284,7 @@ def apply_cross_language_fallbacks(
 
     parsed["price_source_lang"] = None
     parsed["image_source_lang"] = None
+    parsed["data_source_lang"] = None
 
     fallback_lang = _other_lang(lang)
     if not tcg_card_id or not fallback_lang or lang not in SUPPORTED_LANGS:

--- a/backend/services/card_fallbacks.py
+++ b/backend/services/card_fallbacks.py
@@ -317,8 +317,9 @@ def build_missing_language_cards_for_set(
     if not missing_language_fallback_enabled(db, price_enabled=price_enabled, image_enabled=image_enabled):
         return []
 
-    existing_target_ids = {
-        card_id for (card_id,) in db.query(Card.id).filter(
+    existing_target_sources = {
+        card_id: data_source_lang
+        for card_id, data_source_lang in db.query(Card.id, Card.data_source_lang).filter(
             Card.set_id == tcg_set_id,
             Card.lang == target_lang,
             Card.is_custom == False,
@@ -362,7 +363,10 @@ def build_missing_language_cards_for_set(
             if not source_tcg_id:
                 continue
             source_tcg_id = pokemon_api.strip_lang_suffix(source_tcg_id)[0]
-        if source_tcg_id and f"{source_tcg_id}_{target_lang}" in existing_target_ids:
+        target_id = f"{source_tcg_id}_{target_lang}" if source_tcg_id else None
+        if target_id in existing_target_sources and not existing_target_sources[target_id]:
+            # Native target-language data is present. Never overwrite it with a
+            # sibling-language fallback row.
             continue
         parsed = clone_card_for_missing_language(
             db,

--- a/backend/services/card_fallbacks.py
+++ b/backend/services/card_fallbacks.py
@@ -126,6 +126,35 @@ def _fallback_settings(db: Session, price_enabled: Optional[bool], image_enabled
     return price_enabled, image_enabled
 
 
+def missing_language_fallback_enabled(
+    db: Session,
+    *,
+    price_enabled: Optional[bool] = None,
+    image_enabled: Optional[bool] = None,
+) -> bool:
+    """Return whether whole-card missing-language fallback rows may be created."""
+    price_enabled, image_enabled = _fallback_settings(db, price_enabled, image_enabled)
+    return bool(price_enabled or image_enabled)
+
+
+def _number_sort_key(value) -> tuple:
+    value = "" if value is None else str(value)
+    digits = ""
+    prefix = ""
+    for index, char in enumerate(value):
+        if char.isdigit():
+            prefix = value[:index]
+            digits = value[index:]
+            break
+    else:
+        prefix = value
+    try:
+        number = int(digits) if digits else 999999
+    except ValueError:
+        number = 999999
+    return (prefix.casefold(), number, value)
+
+
 def _load_sibling_data(db: Session, tcg_card_id: str, lang: str) -> Optional[dict]:
     sibling = db.query(Card).filter(
         Card.tcg_card_id == tcg_card_id,
@@ -184,6 +213,8 @@ def clone_card_for_missing_language(
         return None
 
     price_enabled, image_enabled = _fallback_settings(db, price_enabled, image_enabled)
+    if not (price_enabled or image_enabled):
+        return None
 
     tcg_card_id = parsed.get("tcg_card_id") or pokemon_api.strip_lang_suffix(parsed.get("id", ""))[0]
     if not tcg_card_id:
@@ -229,6 +260,9 @@ def build_missing_language_card(
     if not tcg_card_id or not fallback_lang:
         return None
 
+    if not missing_language_fallback_enabled(db, price_enabled=price_enabled, image_enabled=image_enabled):
+        return None
+
     sibling = db.query(Card).filter(
         Card.tcg_card_id == tcg_card_id,
         Card.lang == fallback_lang,
@@ -263,6 +297,85 @@ def build_missing_language_card(
         price_enabled=price_enabled,
         image_enabled=image_enabled,
     )
+
+
+def build_missing_language_cards_for_set(
+    db: Session,
+    tcg_set_id: str,
+    target_lang: str,
+    *,
+    max_cards: Optional[int] = None,
+    expected_total: Optional[int] = None,
+    price_enabled: Optional[bool] = None,
+    image_enabled: Optional[bool] = None,
+) -> list[dict]:
+    """Clone sibling-language set cards into missing target-language rows."""
+    fallback_lang = _other_lang(target_lang)
+    if not tcg_set_id or not fallback_lang:
+        return []
+
+    if not missing_language_fallback_enabled(db, price_enabled=price_enabled, image_enabled=image_enabled):
+        return []
+
+    existing_target_ids = {
+        card_id for (card_id,) in db.query(Card.id).filter(
+            Card.set_id == tcg_set_id,
+            Card.lang == target_lang,
+            Card.is_custom == False,
+        ).all()
+    }
+
+    source_cards = db.query(Card).filter(
+        Card.set_id == tcg_set_id,
+        Card.lang == fallback_lang,
+        Card.is_custom == False,
+    ).all()
+    source_cards.sort(key=lambda card: _number_sort_key(card.number))
+
+    sources: list[Card | dict] = source_cards
+    if not sources or (expected_total and len(sources) < expected_total):
+        try:
+            set_data = pokemon_api.get_set_cards(tcg_set_id, lang=fallback_lang)
+        except Exception as exc:
+            logger.debug("Failed to fetch set %s in %s for missing-language fallback: %s", tcg_set_id, fallback_lang, exc)
+            # Prefer partial cached sibling data over an empty checklist when the
+            # public sibling API is temporarily unreachable. Existing target
+            # rows are skipped below, so this only fills still-missing cards.
+            if not sources:
+                return []
+        else:
+            fetched_sources = sorted(
+                set_data.get("cards", []),
+                key=lambda card: _number_sort_key(card.get("localId")),
+            )
+            if len(fetched_sources) > len(sources):
+                sources = fetched_sources
+
+    parsed_cards = []
+    for source in sources:
+        if max_cards and len(parsed_cards) >= max_cards:
+            break
+        if isinstance(source, Card):
+            source_tcg_id = source.tcg_card_id or pokemon_api.strip_lang_suffix(source.id or "")[0]
+        else:
+            source_tcg_id = source.get("id") or source.get("tcg_card_id")
+            if not source_tcg_id:
+                continue
+            source_tcg_id = pokemon_api.strip_lang_suffix(source_tcg_id)[0]
+        if source_tcg_id and f"{source_tcg_id}_{target_lang}" in existing_target_ids:
+            continue
+        parsed = clone_card_for_missing_language(
+            db,
+            source,
+            target_lang=target_lang,
+            source_lang=fallback_lang,
+            default_set_id=tcg_set_id,
+            price_enabled=price_enabled,
+            image_enabled=image_enabled,
+        )
+        if parsed:
+            parsed_cards.append(parsed)
+    return parsed_cards
 
 
 def apply_cross_language_fallbacks(

--- a/backend/services/card_upsert.py
+++ b/backend/services/card_upsert.py
@@ -1,0 +1,30 @@
+"""Shared card upsert helper."""
+
+from __future__ import annotations
+
+import datetime
+
+from sqlalchemy.orm import Session
+
+from models import Card, ImageCache
+
+
+def upsert_card(db: Session, card_data: dict) -> Card:
+    """Insert or update a card row consistently across sync and API flows."""
+    existing = db.query(Card).filter(Card.id == card_data["id"]).first()
+    card_data["updated_at"] = datetime.datetime.utcnow()
+    has_api_image = bool(card_data.get("images_small") or card_data.get("images_large"))
+    if existing:
+        for key, value in card_data.items():
+            if key != "id":
+                setattr(existing, key, value)
+        if has_api_image:
+            existing.custom_image_url = None
+            db.query(ImageCache).filter(ImageCache.image_key.in_([
+                f"card:{existing.id}:small:custom",
+                f"card:{existing.id}:large:custom",
+            ])).delete(synchronize_session=False)
+    else:
+        existing = Card(**card_data)
+        db.add(existing)
+    return existing

--- a/backend/services/pokemon_api.py
+++ b/backend/services/pokemon_api.py
@@ -360,6 +360,7 @@ def parse_card_for_db(card_data: Dict, default_set_id: Optional[str] = None, lan
         "images_small": f"{image}/low.webp" if image else None,
         "images_large": f"{image}/high.webp" if image else None,
         "image_source_lang": None,
+        "data_source_lang": None,
         "lang": card_lang,
         "variants_normal": variants.get("normal"),
         "variants_reverse": variants.get("reverse"),

--- a/backend/services/sync_service.py
+++ b/backend/services/sync_service.py
@@ -467,7 +467,11 @@ def perform_full_sync(db: Session) -> dict:
             has_fallback_cards = db.query(Card.id).filter(
                 Card.set_id == tcg_id,
                 Card.lang == set_lang,
-                or_(Card.image_source_lang.isnot(None), Card.price_source_lang.isnot(None)),
+                or_(
+                    Card.data_source_lang.isnot(None),
+                    Card.image_source_lang.isnot(None),
+                    Card.price_source_lang.isnot(None),
+                ),
             ).first() is not None
             set_total = set_obj.total or 0
             if existing_card_count >= set_total and existing_card_count > 0 and not has_fallback_cards:

--- a/backend/services/sync_service.py
+++ b/backend/services/sync_service.py
@@ -484,9 +484,14 @@ def perform_full_sync(db: Session) -> dict:
             existing_card_count = db.query(Card).filter(
                 Card.set_id == tcg_id, Card.lang == set_lang
             ).count()
+            fallback_card_count = db.query(Card).filter(
+                Card.set_id == tcg_id,
+                Card.lang == set_lang,
+                (Card.image_source_lang != None) | (Card.price_source_lang != None),
+            ).count()
             set_total = set_obj.total or 0
-            if existing_card_count >= set_total and existing_card_count > 0:
-                continue  # Already have all cards for this lang
+            if existing_card_count >= set_total and existing_card_count > 0 and fallback_card_count == 0:
+                continue  # Already have all native cards for this lang
             try:
                 set_detail = pokemon_api.get_set_cards(tcg_id, lang=set_lang)
                 cards_data = set_detail.get("cards", [])

--- a/backend/services/sync_service.py
+++ b/backend/services/sync_service.py
@@ -3,10 +3,11 @@ import datetime
 import math
 from typing import Any, Mapping
 from sqlalchemy.orm import Session, load_only
-from sqlalchemy import func
-from models import Card, Set, CollectionItem, WishlistItem, PriceHistory, SyncLog, PortfolioSnapshot, CustomCardMatch, Setting, ProductPurchase, User, ImageCache
+from sqlalchemy import func, or_
+from models import Card, Set, CollectionItem, WishlistItem, PriceHistory, SyncLog, PortfolioSnapshot, CustomCardMatch, Setting, ProductPurchase, User
 from services import pokemon_api, telegram
 from services.card_fallbacks import PRICE_FIELDS, apply_cross_language_fallbacks
+from services.card_upsert import upsert_card
 from services.card_values import effective_market_price
 
 logger = logging.getLogger(__name__)
@@ -244,27 +245,6 @@ def upsert_set(db: Session, set_data: dict):
     return existing
 
 
-def upsert_card(db: Session, card_data: dict):
-    """Insert or update a card in the database."""
-    existing = db.query(Card).filter(Card.id == card_data["id"]).first()
-    card_data["updated_at"] = datetime.datetime.utcnow()
-    has_api_image = bool(card_data.get("images_small") or card_data.get("images_large"))
-    if existing:
-        for key, value in card_data.items():
-            if key != "id":
-                setattr(existing, key, value)
-        if has_api_image:
-            existing.custom_image_url = None
-            db.query(ImageCache).filter(ImageCache.image_key.in_([
-                f"card:{existing.id}:small:custom",
-                f"card:{existing.id}:large:custom",
-            ])).delete(synchronize_session=False)
-    else:
-        existing = Card(**card_data)
-        db.add(existing)
-    return existing
-
-
 def record_price_history(db: Session, card: Card):
     """Record today's price for a card."""
     today = datetime.date.today()
@@ -484,13 +464,13 @@ def perform_full_sync(db: Session) -> dict:
             existing_card_count = db.query(Card).filter(
                 Card.set_id == tcg_id, Card.lang == set_lang
             ).count()
-            fallback_card_count = db.query(Card).filter(
+            has_fallback_cards = db.query(Card.id).filter(
                 Card.set_id == tcg_id,
                 Card.lang == set_lang,
-                (Card.image_source_lang != None) | (Card.price_source_lang != None),
-            ).count()
+                or_(Card.image_source_lang.isnot(None), Card.price_source_lang.isnot(None)),
+            ).first() is not None
             set_total = set_obj.total or 0
-            if existing_card_count >= set_total and existing_card_count > 0 and fallback_card_count == 0:
+            if existing_card_count >= set_total and existing_card_count > 0 and not has_fallback_cards:
                 continue  # Already have all native cards for this lang
             try:
                 set_detail = pokemon_api.get_set_cards(tcg_id, lang=set_lang)

--- a/backend/services/sync_service.py
+++ b/backend/services/sync_service.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session, load_only
 from sqlalchemy import func, or_
 from models import Card, Set, CollectionItem, WishlistItem, PriceHistory, SyncLog, PortfolioSnapshot, CustomCardMatch, Setting, ProductPurchase, User
 from services import pokemon_api, telegram
-from services.card_fallbacks import PRICE_FIELDS, apply_cross_language_fallbacks
+from services.card_fallbacks import PRICE_FIELDS, apply_cross_language_fallbacks, build_missing_language_cards_for_set
 from services.card_upsert import upsert_card
 from services.card_values import effective_market_price
 
@@ -486,10 +486,22 @@ def perform_full_sync(db: Session) -> dict:
                     parsed = pokemon_api.parse_card_for_db(card_data, default_set_id=tcg_id, lang=set_lang)
                     parsed = apply_cross_language_fallbacks(db, parsed)
                     upsert_card(db, parsed)
+                if set_total and len(cards_data) < set_total:
+                    for parsed in build_missing_language_cards_for_set(db, tcg_id, set_lang, expected_total=set_total):
+                        upsert_card(db, parsed)
                 db.commit()
             except Exception as e:
                 logger.warning(f"Failed to sync cards for set {set_obj.id}: {e}")
                 db.rollback()
+                try:
+                    fallback_cards = build_missing_language_cards_for_set(db, tcg_id, set_lang, expected_total=set_total)
+                    if fallback_cards:
+                        for parsed in fallback_cards:
+                            upsert_card(db, parsed)
+                        db.commit()
+                except Exception as fallback_error:
+                    logger.warning(f"Failed to create fallback cards for set {set_obj.id}: {fallback_error}")
+                    db.rollback()
         logger.info("Full card catalogue sync complete")
 
         # 3. Update prices for collection + wishlist cards. Use the same

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokemon-tcg-collection",
-  "version": "1.13",
+  "version": "1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pokemon-tcg-collection",
-      "version": "1.13",
+      "version": "1.14",
       "dependencies": {
         "@tanstack/react-query": "^5.18.0",
         "axios": "^1.15.2",
@@ -3304,8 +3304,8 @@
       }
     },
     "node_modules/ts-interface-checker": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.14.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3304,8 +3304,8 @@
       }
     },
     "node_modules/ts-interface-checker": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.14.tgz",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pokemon-tcg-collection",
-  "version": "1.14",
+  "version": "1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pokemon-tcg-collection",
-      "version": "1.14",
+      "version": "1.15",
       "dependencies": {
         "@tanstack/react-query": "^5.18.0",
         "axios": "^1.15.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pokemon-tcg-collection",
   "private": true,
-  "version": "1.13",
+  "version": "1.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pokemon-tcg-collection",
   "private": true,
-  "version": "1.14",
+  "version": "1.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/CardListItem.jsx
+++ b/frontend/src/components/CardListItem.jsx
@@ -71,7 +71,7 @@ export default function CardListItem({
               <span
                 key={i}
                 className={clsx(
-                  'inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium leading-none flex-shrink-0',
+                  'inline-flex min-w-0 max-w-full items-center justify-center px-1.5 py-0.5 rounded-full text-center text-[10px] font-medium leading-tight whitespace-normal break-words',
                   badgeVariantClass(badge.variant)
                 )}
               >

--- a/frontend/src/components/FallbackBadges.jsx
+++ b/frontend/src/components/FallbackBadges.jsx
@@ -3,7 +3,7 @@ import { useSettings } from '../contexts/SettingsContext'
 
 const sourceLabel = (lang) => (lang ? lang.toUpperCase() : '')
 
-export default function FallbackBadges({ card, className = '', compact = false }) {
+export default function FallbackBadges({ card, className = '', compact = false, variant = 'default' }) {
   const { t } = useSettings()
   if (!card) return null
   const dataLang = card.data_source_lang
@@ -12,15 +12,33 @@ export default function FallbackBadges({ card, className = '', compact = false }
   const hasCustomImage = Boolean(card.custom_image_url) && !(card.images_small || card.images_large || card.images?.small || card.images?.large || card.image)
   if (!dataLang && !priceLang && !imageLang && !hasCustomImage) return null
 
+  const overlay = variant === 'overlay'
   const baseClass = compact
-    ? 'text-[9px] px-1 py-0.5 rounded leading-none'
-    : 'text-[10px] px-1.5 py-0.5 rounded-full'
+    ? 'inline-flex min-h-[16px] items-center justify-center rounded px-1.5 py-0.5 text-[9px] leading-none'
+    : 'inline-flex min-h-[18px] items-center justify-center rounded-full px-1.5 py-0.5 text-[10px] leading-none'
+  const badgeClass = (tone) => clsx(
+    baseClass,
+    'font-bold whitespace-nowrap',
+    overlay && 'shadow-[0_1px_3px_rgba(0,0,0,0.85)] backdrop-blur-sm',
+    tone === 'data' && (overlay
+      ? 'bg-purple-950/95 text-purple-50 border border-purple-200/80'
+      : 'bg-purple-500/15 text-purple-300 border border-purple-500/30'),
+    tone === 'price' && (overlay
+      ? 'bg-amber-950/95 text-amber-50 border border-amber-200/80'
+      : 'bg-amber-500/15 text-amber-300 border border-amber-500/30'),
+    tone === 'image' && (overlay
+      ? 'bg-sky-950/95 text-sky-50 border border-sky-200/80'
+      : 'bg-sky-500/15 text-sky-300 border border-sky-500/30'),
+    tone === 'customImage' && (overlay
+      ? 'bg-violet-950/95 text-violet-50 border border-violet-200/80'
+      : 'bg-violet-500/15 text-violet-300 border border-violet-500/30'),
+  )
 
   return (
-    <div className={clsx('flex flex-wrap gap-1', className)}>
+    <div className={clsx('flex flex-wrap items-center gap-1', className)}>
       {dataLang && (
         <span
-          className={clsx(baseClass, 'font-bold bg-purple-500/15 text-purple-300 border border-purple-500/30')}
+          className={badgeClass('data')}
           title={t('fallback.dataFrom').replace('{lang}', sourceLabel(dataLang))}
         >
           {t('fallback.data')} {sourceLabel(dataLang)}
@@ -28,7 +46,7 @@ export default function FallbackBadges({ card, className = '', compact = false }
       )}
       {priceLang && (
         <span
-          className={clsx(baseClass, 'font-bold bg-amber-500/15 text-amber-300 border border-amber-500/30')}
+          className={badgeClass('price')}
           title={t('fallback.priceFrom').replace('{lang}', sourceLabel(priceLang))}
         >
           {t('fallback.price')} {sourceLabel(priceLang)}
@@ -36,7 +54,7 @@ export default function FallbackBadges({ card, className = '', compact = false }
       )}
       {imageLang && (
         <span
-          className={clsx(baseClass, 'font-bold bg-sky-500/15 text-sky-300 border border-sky-500/30')}
+          className={badgeClass('image')}
           title={t('fallback.imageFrom').replace('{lang}', sourceLabel(imageLang))}
         >
           {t('fallback.image')} {sourceLabel(imageLang)}
@@ -44,7 +62,7 @@ export default function FallbackBadges({ card, className = '', compact = false }
       )}
       {hasCustomImage && (
         <span
-          className={clsx(baseClass, 'font-bold bg-violet-500/15 text-violet-300 border border-violet-500/30')}
+          className={badgeClass('customImage')}
           title={t('fallback.customImageDesc')}
         >
           🖼 {t('fallback.customImage')}

--- a/frontend/src/components/FallbackBadges.jsx
+++ b/frontend/src/components/FallbackBadges.jsx
@@ -6,10 +6,11 @@ const sourceLabel = (lang) => (lang ? lang.toUpperCase() : '')
 export default function FallbackBadges({ card, className = '', compact = false }) {
   const { t } = useSettings()
   if (!card) return null
+  const dataLang = card.data_source_lang
   const priceLang = card.price_source_lang
   const imageLang = card.image_source_lang
   const hasCustomImage = Boolean(card.custom_image_url) && !(card.images_small || card.images_large || card.images?.small || card.images?.large || card.image)
-  if (!priceLang && !imageLang && !hasCustomImage) return null
+  if (!dataLang && !priceLang && !imageLang && !hasCustomImage) return null
 
   const baseClass = compact
     ? 'text-[9px] px-1 py-0.5 rounded leading-none'
@@ -17,6 +18,14 @@ export default function FallbackBadges({ card, className = '', compact = false }
 
   return (
     <div className={clsx('flex flex-wrap gap-1', className)}>
+      {dataLang && (
+        <span
+          className={clsx(baseClass, 'font-bold bg-purple-500/15 text-purple-300 border border-purple-500/30')}
+          title={t('fallback.dataFrom').replace('{lang}', sourceLabel(dataLang))}
+        >
+          {t('fallback.data')} {sourceLabel(dataLang)}
+        </span>
+      )}
       {priceLang && (
         <span
           className={clsx(baseClass, 'font-bold bg-amber-500/15 text-amber-300 border border-amber-500/30')}

--- a/frontend/src/components/FallbackBadges.jsx
+++ b/frontend/src/components/FallbackBadges.jsx
@@ -39,7 +39,7 @@ export default function FallbackBadges({ card, className = '', compact = false }
           className={clsx(baseClass, 'font-bold bg-sky-500/15 text-sky-300 border border-sky-500/30')}
           title={t('fallback.imageFrom').replace('{lang}', sourceLabel(imageLang))}
         >
-          🖼 {sourceLabel(imageLang)}
+          {t('fallback.image')} {sourceLabel(imageLang)}
         </span>
       )}
       {hasCustomImage && (

--- a/frontend/src/i18n/de.js
+++ b/frontend/src/i18n/de.js
@@ -21,8 +21,10 @@ const de = {
 
   // Common / General
   fallback: {
+    data: 'Daten',
     image: 'Bild',
     price: 'Preis',
+    dataFrom: 'Kartendaten-Fallback aus {lang}',
     imageFrom: 'Bild-Fallback aus {lang}',
     priceFrom: 'Preis-Fallback aus {lang}',
     customImage: 'Eigenes Bild',

--- a/frontend/src/i18n/de.js
+++ b/frontend/src/i18n/de.js
@@ -520,7 +520,7 @@ const de = {
     telegramInfo: 'Telegram-Benachrichtigungen über Umgebungsvariablen konfigurieren:',
     telegramNote: 'Benachrichtigungen werden gesendet wenn Wunschlisten-Preise Alarmschwellen überschreiten. Maximal eine Benachrichtigung pro Karte alle 23 Stunden.',
     about: 'Über',
-    aboutDesc1: 'Pokémon TCG Sammlungs-Manager v1.13',
+    aboutDesc1: 'Pokémon TCG Sammlungs-Manager v1.14',
     aboutDesc2: 'Erstellt mit FastAPI + React + PostgreSQL',
     aboutDesc3: 'Daten von',
     aboutDesc4: 'Preise von Cardmarket (EUR)',

--- a/frontend/src/i18n/de.js
+++ b/frontend/src/i18n/de.js
@@ -522,7 +522,7 @@ const de = {
     telegramInfo: 'Telegram-Benachrichtigungen über Umgebungsvariablen konfigurieren:',
     telegramNote: 'Benachrichtigungen werden gesendet wenn Wunschlisten-Preise Alarmschwellen überschreiten. Maximal eine Benachrichtigung pro Karte alle 23 Stunden.',
     about: 'Über',
-    aboutDesc1: 'Pokémon TCG Sammlungs-Manager v1.14',
+    aboutDesc1: 'Pokémon TCG Sammlungs-Manager v1.15',
     aboutDesc2: 'Erstellt mit FastAPI + React + PostgreSQL',
     aboutDesc3: 'Daten von',
     aboutDesc4: 'Preise von Cardmarket (EUR)',

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -520,7 +520,7 @@ const en = {
     telegramInfo: 'Configure Telegram notifications via environment variables in your .env file:',
     telegramNote: 'Notifications are sent when wishlist card prices cross your alert thresholds during sync. Maximum one notification per card per 23 hours.',
     about: 'About',
-    aboutDesc1: 'Pokemon TCG Collection Manager v1.13',
+    aboutDesc1: 'Pokemon TCG Collection Manager v1.14',
     aboutDesc2: 'Built with FastAPI + React + PostgreSQL',
     aboutDesc3: 'Data from',
     aboutDesc4: 'Prices from Cardmarket (EUR)',

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -21,8 +21,10 @@ const en = {
 
   // Common / General
   fallback: {
+    data: 'Data',
     image: 'Image',
     price: 'Price',
+    dataFrom: 'Card data fallback from {lang}',
     imageFrom: 'Image fallback from {lang}',
     priceFrom: 'Price fallback from {lang}',
     customImage: 'Custom image',

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -522,7 +522,7 @@ const en = {
     telegramInfo: 'Configure Telegram notifications via environment variables in your .env file:',
     telegramNote: 'Notifications are sent when wishlist card prices cross your alert thresholds during sync. Maximum one notification per card per 23 hours.',
     about: 'About',
-    aboutDesc1: 'Pokemon TCG Collection Manager v1.14',
+    aboutDesc1: 'Pokemon TCG Collection Manager v1.15',
     aboutDesc2: 'Built with FastAPI + React + PostgreSQL',
     aboutDesc3: 'Data from',
     aboutDesc4: 'Prices from Cardmarket (EUR)',

--- a/frontend/src/i18n/zh.js
+++ b/frontend/src/i18n/zh.js
@@ -21,8 +21,10 @@ const zh = {
 
   // Common / General
   fallback: {
+    data: '数据',
     image: '图片',
     price: '价格',
+    dataFrom: '卡牌数据回退来源：{lang}',
     imageFrom: '图片回退来源：{lang}',
     priceFrom: '价格回退来源：{lang}',
     customImage: '自定义图片',

--- a/frontend/src/i18n/zh.js
+++ b/frontend/src/i18n/zh.js
@@ -519,7 +519,7 @@ const zh = {
     telegramInfo: '通过环境变量配置Telegram通知在你的 .env 文件中:',
     telegramNote: '同步时当愿望清单价格越过你的提醒阈值会发送通知。每张卡牌每23小时最多发送一次通知。',
     about: '关于',
-    aboutDesc1: '宝可梦TCG收藏管理器 v1.13',
+    aboutDesc1: '宝可梦TCG收藏管理器 v1.14',
     aboutDesc2: '使用 FastAPI + React + PostgreSQL 构建',
     aboutDesc3: '数据来自',
     aboutDesc4: '价格来自 Cardmarket (EUR)',

--- a/frontend/src/i18n/zh.js
+++ b/frontend/src/i18n/zh.js
@@ -521,7 +521,7 @@ const zh = {
     telegramInfo: '通过环境变量配置Telegram通知在你的 .env 文件中:',
     telegramNote: '同步时当愿望清单价格越过你的提醒阈值会发送通知。每张卡牌每23小时最多发送一次通知。',
     about: '关于',
-    aboutDesc1: '宝可梦TCG收藏管理器 v1.14',
+    aboutDesc1: '宝可梦TCG收藏管理器 v1.15',
     aboutDesc2: '使用 FastAPI + React + PostgreSQL 构建',
     aboutDesc3: '数据来自',
     aboutDesc4: '价格来自 Cardmarket (EUR)',

--- a/frontend/src/pages/Collection.jsx
+++ b/frontend/src/pages/Collection.jsx
@@ -1105,7 +1105,7 @@ export default function Collection() {
                           </span>
                         )}
                         {item.variant && item.variant !== 'Normal' && (
-                          <span className="inline-flex items-center text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-yellow/15 text-yellow border border-yellow/30 truncate max-w-[80px]">
+                          <span className="inline-flex max-w-full min-w-0 items-center justify-center text-center text-[10px] font-semibold leading-tight px-1.5 py-0.5 rounded-full bg-yellow/15 text-yellow border border-yellow/30 whitespace-normal break-words">
                             ✨ {item.variant}
                           </span>
                         )}
@@ -1224,7 +1224,7 @@ export default function Collection() {
                           </td>
                           <td className="px-4 py-3 text-left">
                             {item.variant ? (
-                              <span className={clsx('badge text-xs', VARIANT_COLORS[item.variant] || 'badge-gray')}>{item.variant}</span>
+                              <span className={clsx('badge text-xs max-w-[150px] justify-center whitespace-normal break-words text-center leading-tight', VARIANT_COLORS[item.variant] || 'badge-gray')}>{item.variant}</span>
                             ) : (
                               <span className="text-text-muted text-xs">—</span>
                             )}

--- a/frontend/src/pages/SetDetail.jsx
+++ b/frontend/src/pages/SetDetail.jsx
@@ -112,6 +112,7 @@ function SetCardActionModal({ card, setLang, onClose, onAdd, onQuantityChange, o
             <div className="min-w-0">
               <h2 className="text-lg font-bold text-text-primary">{card.name}</h2>
               <p className="text-xs text-text-muted">#{card.number} · {setLang.toUpperCase()}</p>
+              <FallbackBadges card={card} className="mt-1" />
             </div>
             <button onClick={onClose} className="text-text-muted hover:text-text-primary"><X size={18} /></button>
           </div>
@@ -395,9 +396,14 @@ export default function SetDetail() {
               </div>
             )}
 
+            <FallbackBadges
+              card={card}
+              className="absolute left-1 right-1 bottom-5 z-10 justify-center pointer-events-none"
+              compact
+            />
+
             <div className="absolute inset-0 bg-black/0 group-hover:bg-black/40 transition-all flex flex-col items-center justify-center gap-1 opacity-0 group-hover:opacity-100">
               <p className="text-white text-xs font-medium text-center px-1 line-clamp-2">{card.name}</p>
-              <FallbackBadges card={card} className="justify-center" compact />
               <button onClick={(e) => { e.stopPropagation(); setSelectedCard(card) }}
                 className="bg-brand-red text-white rounded-full p-1">
                 <Plus size={12} />

--- a/frontend/src/pages/SetDetail.jsx
+++ b/frontend/src/pages/SetDetail.jsx
@@ -400,6 +400,7 @@ export default function SetDetail() {
               card={card}
               className="absolute left-1 right-1 bottom-5 z-10 justify-center pointer-events-none"
               compact
+              variant="overlay"
             />
 
             <div className="absolute inset-0 bg-black/0 group-hover:bg-black/40 transition-all flex flex-col items-center justify-center gap-1 opacity-0 group-hover:opacity-100">

--- a/frontend/src/pages/Wishlist.jsx
+++ b/frontend/src/pages/Wishlist.jsx
@@ -345,6 +345,7 @@ export default function Wishlist() {
                   if (item.price_alert_above) badges.push({ label: `↑ ${formatPrice(item.price_alert_above)}`, variant: 'yellow' })
                   if (item.price_alert_below) badges.push({ label: `↓ ${formatPrice(item.price_alert_below)}`, variant: 'blue' })
                   if (card?.rarity) badges.push({ label: card.rarity, variant: 'gray' })
+                  if (card?.data_source_lang) badges.push({ label: `${t('fallback.data')} ${card.data_source_lang.toUpperCase()}`, variant: 'purple' })
                   if (card?.price_source_lang) badges.push({ label: `${t('fallback.price')} ${card.price_source_lang.toUpperCase()}`, variant: 'yellow' })
                   if (card?.image_source_lang) badges.push({ label: `${t('fallback.image')} ${card.image_source_lang.toUpperCase()}`, variant: 'blue' })
 


### PR DESCRIPTION
## Summary

- Allows cards to be added with the requested language id, for example `me04-001_de`, even when TCGdex only has the sibling language card data yet.
- Creates temporary target-language fallback card rows from sibling-language data and marks borrowed card data, images, and prices with visible fallback source tags.
- Adds an explicit `Data EN` / `Daten EN` badge so users can see when card metadata is backed by another language and avoid confusing that with a bug.
- Keeps fallback rows refreshable so future native TCGdex data replaces them in place during sync.
- Prevents set checklist loading from relabeling sibling rows like `_en` as German cards.
- Bumps app/API version to `1.14`.

## Validation

- Fresh isolated reviewer subagent pass completed; accepted findings were fixed before this update.
- `python3 -m py_compile backend/models.py backend/database.py backend/schemas.py backend/services/card_fallbacks.py backend/services/pokemon_api.py backend/services/sync_service.py backend/api/cards.py backend/api/sets.py backend/api/collection.py`
- `npm --prefix frontend run build`
- `git diff --check`

Fixes #194
