### PR TITLE
Fix release workflow checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,15 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - name: Checkout repository
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git init .
+          git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --force --tags origin "${GITHUB_SHA}"
+          git checkout --detach FETCH_HEAD
 
       - name: Check version consistency
         run: node scripts/check-version.mjs
@@ -35,7 +40,7 @@ jobs:
         id: existing_tag
         shell: bash
         run: |
-          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+          if git rev-parse --verify --quiet "refs/tags/${{ steps.version.outputs.tag }}" >/dev/null; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
* replace `actions/checkout@v4` in the release workflow with shell-based `git` checkout because this repo only allows actions owned by `Git-Romer`
* keep full tag fetching so the release workflow can detect whether `v<VERSION>` already exists
* tighten the existing-tag check to verify the exact `refs/tags/<tag>` ref

## Validation
* `node scripts/check-version.mjs`
* `git diff --check`
* fresh isolated reviewer pass completed with no blockers

## Notes
* This fixes the `startup_failure` seen after merging #204 and #205.
* After this is merged, `v1.18.0` still needs to be created because the failed workflow run did not create the release/tag.
