### PR TITLE
Harden release workflow checkout token handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           git init .
-          git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git fetch --force --tags origin "${GITHUB_SHA}"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git -c http.extraheader="AUTHORIZATION: bearer ${GH_TOKEN}" fetch --force --tags origin "${GITHUB_SHA}"
           git checkout --detach FETCH_HEAD
 
       - name: Check version consistency


### PR DESCRIPTION
## Summary
* avoid storing the temporary GitHub workflow token in `.git/config` during the release workflow checkout
* keep the remote URL credential-free and pass the token only as a one-command `http.extraheader` for `git fetch`

## Why
This is a hardening follow-up after #206. The workflow token is short-lived and masked by GitHub, but it is cleaner not to persist it in the temporary checkout config at all.

## Access model
This does not give other users version or release access. The release workflow can only publish the version already merged to `main`, or be manually run by someone with repository workflow permissions.

## Validation
* `node scripts/check-version.mjs`
* `git diff --check`
