### PR TITLE
Fix release workflow checkout auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,9 @@ jobs:
         run: |
           git init .
           git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          git -c http.extraheader="AUTHORIZATION: bearer ${GH_TOKEN}" fetch --force --tags origin "${GITHUB_SHA}"
+          auth_header="$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 -w0)"
+          echo "::add-mask::${auth_header}"
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: Basic ${auth_header}" fetch --force --tags origin "${GITHUB_SHA}"
           git checkout --detach FETCH_HEAD
 
       - name: Check version consistency


### PR DESCRIPTION
## Summary
* Fix the custom release workflow checkout authentication.
* Keep the remote URL credential-free and avoid persisting tokens in `.git/config`.
* Mask the derived Basic auth header used for the one `git fetch` command.

## Validation
* Extracted checkout shell block and ran `bash -n`
* `git diff --check`
* Fresh isolated reviewer pass completed

## Notes
* The failed `v1.19.0` release/tag still needs to be backfilled after this workflow fix, because this PR does not change `VERSION`.
