### PR TITLE
Update UI after adding a card to collection

### DIFF
--- a/frontend/src/components/CardItem.jsx
+++ b/frontend/src/components/CardItem.jsx
@@ -135,6 +135,7 @@ export function CustomCardModal({ onClose, onCreated, sets: setsProp = [], autoA
       toast.success(`${createdCard.name} ${t('card.addedToCollection')}`)
       queryClient.invalidateQueries({ queryKey: ['collection'] })
       queryClient.invalidateQueries({ queryKey: ['dashboard'] })
+      queryClient.invalidateQueries({ predicate: (query) => query.queryKey[0] === 'card-search' })
       onCreated && onCreated(createdCard)
       onClose()
     },
@@ -375,6 +376,7 @@ export const CardItem = memo(function CardItem({ card, showActions = true, onAdd
       toast.success(`${card.name} ${t('card.addedToCollection')}`)
       queryClient.invalidateQueries({ queryKey: ['collection'] })
       queryClient.invalidateQueries({ queryKey: ['dashboard'] })
+      queryClient.invalidateQueries({ predicate: (query) => query.queryKey[0] === 'card-search' })
     },
     onError: () => toast.error(t('card.addFailed')),
   })
@@ -575,6 +577,7 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en', ownedItem
       toast.success(`${t('common.add')} ${quantity}x ${card.name}!`)
       queryClient.invalidateQueries({ queryKey: ['collection'] })
       queryClient.invalidateQueries({ queryKey: ['dashboard'] })
+      queryClient.invalidateQueries({ predicate: (query) => query.queryKey[0] === 'card-search' })
       onClose()
     },
     onError: () => toast.error(t('card.addFailed')),

--- a/frontend/src/pages/CardSearch.jsx
+++ b/frontend/src/pages/CardSearch.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query'
 import { Search, X, ChevronLeft, ChevronRight, ChevronUp, ChevronDown, SortAsc, Hash, PenLine, SlidersHorizontal, Camera, CheckSquare, Plus, Check } from 'lucide-react'
 import toast from 'react-hot-toast'
@@ -217,6 +217,31 @@ export default function CardSearch() {
   const hasActiveFilters = !!(filters.type || filters.rarity || filters.set_id || filters.series || filters.artist || filters.hp_min || filters.hp_max || filters.sort_by)
   const activeFilterCount = [filters.type, filters.rarity, filters.set_id, filters.series, filters.artist, filters.hp_min, filters.hp_max, filters.sort_by].filter(Boolean).length
   const totalPages = data ? Math.ceil(data.total_count / pageSize) : 0
+
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (event.defaultPrevented) return
+      if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return
+
+      const target = event.target
+      const tagName = target?.tagName?.toLowerCase?.()
+      if (tagName === 'input' || tagName === 'textarea' || tagName === 'select' || target?.isContentEditable) {
+        return
+      }
+
+      if (event.key === 'ArrowLeft' && page > 1) {
+        setPage((current) => Math.max(1, current - 1))
+        event.preventDefault()
+      }
+      if (event.key === 'ArrowRight' && totalPages > 0 && page < totalPages) {
+        setPage((current) => Math.min(totalPages, current + 1))
+        event.preventDefault()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [page, totalPages])
 
   const handleCustomCreated = () => {
     queryClient.invalidateQueries({ queryKey: ['custom-cards'] })

--- a/frontend/src/pages/CardSearch.jsx
+++ b/frontend/src/pages/CardSearch.jsx
@@ -350,6 +350,7 @@ export default function CardSearch() {
       toast.success(parts.join(' · '))
       queryClient.invalidateQueries({ queryKey: ['collection'] })
       queryClient.invalidateQueries({ queryKey: ['dashboard'] })
+      queryClient.invalidateQueries({ predicate: (query) => query.queryKey[0] === 'card-search' })
       exitSelectMode()
     },
     onError: () => toast.error(t('cardSearch.bulkAddFailed')),


### PR DESCRIPTION
When a card is added to the collection from the search results, the counter isn't updated in the search results because the search query cache isn't being invalidated.

This should fix it.