### PR TITLE
feat: skip full sync when one is already running

### DIFF
--- a/backend/services/sync_service.py
+++ b/backend/services/sync_service.py
@@ -502,8 +502,32 @@ def check_custom_card_matches(db: Session):
             logger.warning(f"Failed to check API match for custom card {card.id}: {e}")
 
 
+# A full sync takes ~20 min. A "running" full-sync row older than this is
+# treated as orphaned (left by a crash or container restart) so a stale row can
+# never block future syncs forever.
+FULL_SYNC_STALE_AFTER = datetime.timedelta(minutes=60)
+
+
+def _full_sync_in_progress(db: Session) -> bool:
+    """True if another full sync is actively running.
+
+    Guards against two overlapping full syncs racing and colliding on card
+    primary keys. Works across processes and callers (scheduler, API, manual)
+    because it checks the shared sync_log table rather than an in-process flag.
+    """
+    cutoff = datetime.datetime.utcnow() - FULL_SYNC_STALE_AFTER
+    return db.query(SyncLog.id).filter(
+        SyncLog.sync_type == "full",
+        SyncLog.status == "running",
+        SyncLog.started_at >= cutoff,
+    ).first() is not None
+
+
 def perform_full_sync(db: Session) -> dict:
     """Perform a full sync cycle: sets + cards + prices."""
+    if _full_sync_in_progress(db):
+        logger.info("Full sync skipped: another full sync is already running")
+        return {"cards_updated": 0, "sets_updated": 0, "status": "skipped"}
     log = SyncLog(started_at=datetime.datetime.utcnow(), status="running", sync_type="full")
     db.add(log)
     db.commit()

--- a/backend/services/sync_service.py
+++ b/backend/services/sync_service.py
@@ -1,9 +1,10 @@
 import logging
 import datetime
 import math
+from contextlib import contextmanager
 from typing import Any, Mapping
 from sqlalchemy.orm import Session, load_only
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, text
 from models import Card, Set, CollectionItem, WishlistItem, BinderCard, PriceHistory, SyncLog, PortfolioSnapshot, CustomCardMatch, ProductPurchase, User, UserSetting
 from services import pokemon_api, telegram
 from services.card_fallbacks import apply_cross_language_fallbacks, build_missing_language_cards_for_set
@@ -506,6 +507,7 @@ def check_custom_card_matches(db: Session):
 # treated as orphaned (left by a crash or container restart) so a stale row can
 # never block future syncs forever.
 FULL_SYNC_STALE_AFTER = datetime.timedelta(minutes=60)
+FULL_SYNC_ADVISORY_LOCK_ID = 0x506F6B6546756C6C  # "PokeFull" as a signed 64-bit int.
 
 
 def _full_sync_in_progress(db: Session) -> bool:
@@ -523,11 +525,61 @@ def _full_sync_in_progress(db: Session) -> bool:
     ).first() is not None
 
 
+def _db_dialect_name(db: Session) -> str | None:
+    bind = db.get_bind()
+    dialect = getattr(bind, "dialect", None)
+    return getattr(dialect, "name", None)
+
+
+@contextmanager
+def _full_sync_lock(db: Session):
+    """Yield True only when this process owns the full-sync lock.
+
+    PostgreSQL advisory locks are atomic across connections and processes. Keep
+    the lock on a dedicated connection because perform_full_sync intentionally
+    commits throughout a long-running sync, which would release a transaction
+    lock or return a session-level lock to the pool too early.
+    """
+    if _db_dialect_name(db) != "postgresql":
+        yield not _full_sync_in_progress(db)
+        return
+
+    bind = db.get_bind()
+    lock_conn = bind.connect()
+    acquired = False
+    try:
+        acquired = bool(lock_conn.execute(
+            text("SELECT pg_try_advisory_lock(:lock_id)"),
+            {"lock_id": FULL_SYNC_ADVISORY_LOCK_ID},
+        ).scalar())
+        yield acquired
+    finally:
+        if acquired:
+            unlocked = False
+            try:
+                unlocked = bool(lock_conn.execute(
+                    text("SELECT pg_advisory_unlock(:lock_id)"),
+                    {"lock_id": FULL_SYNC_ADVISORY_LOCK_ID},
+                ).scalar())
+                if not unlocked:
+                    logger.warning("Full sync advisory lock was not held at release time")
+            except Exception:
+                logger.exception("Failed to release full sync advisory lock")
+            if not unlocked:
+                lock_conn.invalidate()
+        lock_conn.close()
+
+
 def perform_full_sync(db: Session) -> dict:
     """Perform a full sync cycle: sets + cards + prices."""
-    if _full_sync_in_progress(db):
-        logger.info("Full sync skipped: another full sync is already running")
-        return {"cards_updated": 0, "sets_updated": 0, "status": "skipped"}
+    with _full_sync_lock(db) as lock_acquired:
+        if not lock_acquired or _full_sync_in_progress(db):
+            logger.info("Full sync skipped: another full sync is already running")
+            return {"cards_updated": 0, "sets_updated": 0, "status": "skipped"}
+        return _perform_full_sync_locked(db)
+
+
+def _perform_full_sync_locked(db: Session) -> dict:
     log = SyncLog(started_at=datetime.datetime.utcnow(), status="running", sync_type="full")
     db.add(log)
     db.commit()
@@ -785,6 +837,7 @@ def perform_full_sync(db: Session) -> dict:
 
     except Exception as e:
         logger.error(f"Full sync failed: {e}")
+        db.rollback()
         log.finished_at = datetime.datetime.utcnow()
         log.status = "error"
         log.error_message = str(e)

--- a/backend/tests/test_full_sync_guard.py
+++ b/backend/tests/test_full_sync_guard.py
@@ -1,0 +1,81 @@
+import datetime
+import unittest
+
+try:
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    from database import Base
+    from models import SyncLog
+    from services.sync_service import (
+        FULL_SYNC_STALE_AFTER,
+        _full_sync_in_progress,
+        perform_full_sync,
+    )
+    DEPS = True
+except ModuleNotFoundError:
+    DEPS = False
+
+
+@unittest.skipUnless(DEPS, "SQLAlchemy not installed in this lightweight test environment")
+class FullSyncGuardTests(unittest.TestCase):
+    """A full sync must skip if another full sync is already running, so two
+    overlapping runs cannot race and collide on card primary keys. Stale
+    'running' rows (left by a crash/restart) must NOT block forever.
+    """
+
+    def _db(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        return sessionmaker(bind=engine, autoflush=False)()
+
+    def _running_full(self, minutes_ago):
+        return SyncLog(
+            sync_type="full",
+            status="running",
+            started_at=datetime.datetime.utcnow() - datetime.timedelta(minutes=minutes_ago),
+        )
+
+    def test_no_rows_not_in_progress(self):
+        self.assertFalse(_full_sync_in_progress(self._db()))
+
+    def test_recent_running_full_blocks(self):
+        db = self._db()
+        db.add(self._running_full(minutes_ago=1))
+        db.commit()
+        self.assertTrue(_full_sync_in_progress(db))
+
+    def test_stale_running_full_does_not_block(self):
+        db = self._db()
+        stale_minutes = int(FULL_SYNC_STALE_AFTER.total_seconds() // 60) + 5
+        db.add(self._running_full(minutes_ago=stale_minutes))
+        db.commit()
+        self.assertFalse(_full_sync_in_progress(db))
+
+    def test_running_price_sync_does_not_block_full(self):
+        db = self._db()
+        db.add(SyncLog(sync_type="price", status="running", started_at=datetime.datetime.utcnow()))
+        db.commit()
+        self.assertFalse(_full_sync_in_progress(db))
+
+    def test_finished_full_does_not_block(self):
+        db = self._db()
+        now = datetime.datetime.utcnow()
+        db.add(SyncLog(sync_type="full", status="success", started_at=now, finished_at=now))
+        db.commit()
+        self.assertFalse(_full_sync_in_progress(db))
+
+    def test_perform_full_sync_skips_without_new_row_or_network(self):
+        # A recent running full sync exists -> perform_full_sync must short-circuit
+        # BEFORE creating its own log row or doing any network work.
+        db = self._db()
+        db.add(self._running_full(minutes_ago=1))
+        db.commit()
+        before = db.query(SyncLog).count()
+        result = perform_full_sync(db)
+        self.assertEqual(result["status"], "skipped")
+        self.assertEqual(db.query(SyncLog).count(), before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_full_sync_guard.py
+++ b/backend/tests/test_full_sync_guard.py
@@ -1,5 +1,6 @@
 import datetime
 import unittest
+from unittest.mock import patch
 
 try:
     from sqlalchemy import create_engine
@@ -8,7 +9,9 @@ try:
     from database import Base
     from models import SyncLog
     from services.sync_service import (
+        FULL_SYNC_ADVISORY_LOCK_ID,
         FULL_SYNC_STALE_AFTER,
+        _full_sync_lock,
         _full_sync_in_progress,
         perform_full_sync,
     )
@@ -75,6 +78,135 @@ class FullSyncGuardTests(unittest.TestCase):
         result = perform_full_sync(db)
         self.assertEqual(result["status"], "skipped")
         self.assertEqual(db.query(SyncLog).count(), before)
+
+    def test_postgres_advisory_lock_is_released(self):
+        conn = FakeLockConnection(acquire_result=True)
+        db = FakePostgresDb(conn)
+
+        with _full_sync_lock(db) as acquired:
+            self.assertTrue(acquired)
+
+        self.assertEqual(
+            conn.statements,
+            [
+                ("SELECT pg_try_advisory_lock(:lock_id)", {"lock_id": FULL_SYNC_ADVISORY_LOCK_ID}),
+                ("SELECT pg_advisory_unlock(:lock_id)", {"lock_id": FULL_SYNC_ADVISORY_LOCK_ID}),
+            ],
+        )
+        self.assertTrue(conn.closed)
+
+    def test_postgres_advisory_lock_busy_skips_without_unlock(self):
+        conn = FakeLockConnection(acquire_result=False)
+        db = FakePostgresDb(conn)
+
+        with _full_sync_lock(db) as acquired:
+            self.assertFalse(acquired)
+
+        self.assertEqual(
+            conn.statements,
+            [("SELECT pg_try_advisory_lock(:lock_id)", {"lock_id": FULL_SYNC_ADVISORY_LOCK_ID})],
+        )
+        self.assertTrue(conn.closed)
+        self.assertFalse(conn.invalidated)
+
+    def test_postgres_advisory_lock_invalidates_connection_when_unlock_fails(self):
+        conn = FakeLockConnection(acquire_result=True, unlock_raises=True)
+        db = FakePostgresDb(conn)
+
+        with patch("services.sync_service.logger.exception") as log_exception:
+            with _full_sync_lock(db) as acquired:
+                self.assertTrue(acquired)
+
+        log_exception.assert_called_once()
+        self.assertTrue(conn.invalidated)
+        self.assertTrue(conn.closed)
+
+    def test_postgres_advisory_lock_invalidates_connection_when_unlock_returns_false(self):
+        conn = FakeLockConnection(acquire_result=True, unlock_result=False)
+        db = FakePostgresDb(conn)
+
+        with patch("services.sync_service.logger.warning") as log_warning:
+            with _full_sync_lock(db) as acquired:
+                self.assertTrue(acquired)
+
+        log_warning.assert_called_once()
+        self.assertTrue(conn.invalidated)
+        self.assertTrue(conn.closed)
+
+    def test_perform_full_sync_rolls_back_before_marking_log_error(self):
+        db = self._db()
+        with patch.object(db, "rollback", wraps=db.rollback) as rollback, \
+             patch("services.sync_service.logger.error"), \
+             patch("services.sync_service._get_tcgdex_sync_languages", return_value=["en"]), \
+             patch("services.sync_service.digital_sets_enabled", return_value=False), \
+             patch("services.sync_service.refresh_digital_catalogue_flags", return_value={"sets_marked": 0, "cards_marked": 0}), \
+             patch("services.sync_service.get_pinned_set_language_pairs", return_value=set()), \
+             patch("services.sync_service.pokemon_api.get_all_sets", side_effect=RuntimeError("catalogue failed")):
+            with self.assertRaises(RuntimeError):
+                perform_full_sync(db)
+
+        rollback.assert_called_once()
+        log = db.query(SyncLog).one()
+        self.assertEqual(log.sync_type, "full")
+        self.assertEqual(log.status, "error")
+        self.assertEqual(log.error_message, "catalogue failed")
+
+
+class FakeResult:
+    def __init__(self, value):
+        self.value = value
+
+    def scalar(self):
+        return self.value
+
+
+class FakeLockConnection:
+    def __init__(self, acquire_result, unlock_result=True, unlock_raises=False):
+        self.acquire_result = acquire_result
+        self.unlock_result = unlock_result
+        self.unlock_raises = unlock_raises
+        self.statements = []
+        self.closed = False
+        self.invalidated = False
+
+    def execute(self, statement, params):
+        sql = str(statement)
+        self.statements.append((sql, params))
+        if "pg_try_advisory_lock" in sql:
+            return FakeResult(self.acquire_result)
+        if "pg_advisory_unlock" in sql:
+            if self.unlock_raises:
+                raise RuntimeError("unlock failed")
+            return FakeResult(self.unlock_result)
+        raise AssertionError(f"Unexpected SQL: {sql}")
+
+    def invalidate(self):
+        self.invalidated = True
+
+    def close(self):
+        self.closed = True
+
+
+class FakePostgresDialect:
+    name = "postgresql"
+
+
+class FakePostgresBind:
+    dialect = FakePostgresDialect()
+
+    def __init__(self, conn):
+        self.conn = conn
+
+    def connect(self):
+        return self.conn
+
+
+class FakePostgresDb:
+    def __init__(self, conn):
+        self.bind = FakePostgresBind(conn)
+
+    def get_bind(self):
+        return self.bind
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #293.

## Summary

Adds a DB-level guard so two full syncs cannot run concurrently and race on card primary keys. `perform_full_sync` now checks the shared `sync_log` table for a recently-started running full sync and returns early if one is already in progress.

Using shared DB state (rather than the existing in-process `_sync_running` flag, which only guards the manual API path) means this covers **every** caller — the scheduler, the API, and direct/manual invocation — and is process-safe.

A `running` full-sync row older than 60 minutes is treated as orphaned (e.g. left behind by a crash or container restart), so a stale row can never block future syncs forever.

## Testing

New `backend/tests/test_full_sync_guard.py` (6 tests, `unittest`):

- no rows → not in progress
- recent running full → blocks
- stale running full (>60m) → does **not** block
- running *price* sync → does not block a full sync
- finished full → does not block
- `perform_full_sync` short-circuits to `{"status": "skipped"}` without creating a new log row or doing any network work when a full sync is already running

`python -m unittest tests.test_full_sync_guard` → 6/6 passing.
