### PR TITLE
Document forward auth setup for public profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Be kind. Be clear. Assume good intent. Keep feedback constructive.
 
 - [Features](#-features)
 - [Quick Start](#-quick-start)
+- [Reverse Proxy Authentication](#-reverse-proxy-authentication)
 - [Managing Users](#-managing-users)
 - [Environment Variables](#-environment-variables)
 - [Sync Behavior](#-sync-behavior)
@@ -206,6 +207,14 @@ See [National Pokédex documentation](docs/POKEDEX.md) for the data model, route
 
 ---
 
+## 🔐 Reverse Proxy Authentication
+
+If PokéCollector is protected by Authentik, Authelia, oauth2-proxy, or another forward-auth layer, the proxy checks requests before they reach PokéCollector. Enabling public profiles inside the app is therefore not enough on its own. The proxy must also allow the public pages, their public API calls, and the assets those pages use.
+
+See [Reverse proxy authentication](docs/REVERSE_PROXY_AUTH.md) for the complete route list, Authentik examples, and a verification checklist. Do not bypass authentication for all `/api` routes.
+
+---
+
 ## 👥 Managing Users
 
 User management is available from the app UI when multi-user mode is enabled.
@@ -357,6 +366,7 @@ Build and dependency installation also contact package/distribution registries s
 | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | System structure, data flow, contexts, settings model |
 | [`docs/BACKEND.md`](docs/BACKEND.md) | API routes, models, settings scoping, backup behavior |
 | [`docs/FRONTEND.md`](docs/FRONTEND.md) | Routes, pages, components, contexts, theming, i18n |
+| [`docs/REVERSE_PROXY_AUTH.md`](docs/REVERSE_PROXY_AUTH.md) | Forward-auth exceptions for public profiles and binders |
 
 ---
 

--- a/docs/REVERSE_PROXY_AUTH.md
+++ b/docs/REVERSE_PROXY_AUTH.md
@@ -1,0 +1,70 @@
+# Reverse proxy authentication
+
+PokéCollector can run behind Authentik, Authelia, oauth2-proxy, or another authentication layer at the reverse proxy.
+
+The proxy sees every request before PokéCollector does. This means the public-profile settings inside PokéCollector cannot make a route public if the proxy still requires a login for that route.
+
+## Public profile route contract
+
+Allow unauthenticated access to these paths when public profiles should be reachable outside the proxy login:
+
+| Path | Purpose |
+| --- | --- |
+| `/u` and `/u/*` | Public trainer directory, profiles, and binders |
+| `/api/public/*` | Anonymous public-profile and binder data |
+| `/api/images/card/*` | Card artwork used by public binders |
+| `/api/pokedex/images/sprites/*` | Trainer avatars used by public pages |
+| `/assets/*` | Compiled JavaScript, CSS, and lazy-loaded page bundles |
+| `/pokeball.svg` and `/cardback.jpg` | Public-page and missing-card artwork |
+| `/favicon.ico`, `/favicon-48.png`, `/apple-touch-icon.png`, `/manifest.json`, `/icon-192.png`, `/icon-512.png`, and `/robots.txt` | Browser, PWA, and crawler assets |
+
+Keep every other application route behind the proxy. In particular, do not allow all of `/api/*`. Authenticated collection, settings, sync, backup, and administration endpoints are under that prefix.
+
+PokéCollector still applies its own sharing controls after a request reaches the app:
+
+1. An administrator must enable public profiles.
+2. The trainer must publish their profile.
+3. Each collection binder must be shared separately.
+4. Collection values remain hidden unless the trainer enables them.
+
+## Authentik
+
+Authentik proxy providers support an **Unauthenticated Paths** or **Unauthenticated URLs** field. Each line is a Go regular expression.
+
+For proxy mode or forward auth for a single application, Authentik matches the request path. Add:
+
+```text
+^/u(/.*)?$
+^/api/public(/.*)?$
+^/api/images/card/.*$
+^/api/pokedex/images/sprites/.*$
+^/assets/.*$
+^/(pokeball\.svg|cardback\.jpg|favicon\.ico|favicon-48\.png|apple-touch-icon\.png|manifest\.json|icon-192\.png|icon-512\.png|robots\.txt)$
+```
+
+For domain-level forward auth, Authentik matches the complete URL instead. Replace `cards.example.com` with the PokéCollector host:
+
+```text
+^https://cards\.example\.com/u(/.*)?(\?.*)?$
+^https://cards\.example\.com/api/public(/.*)?(\?.*)?$
+^https://cards\.example\.com/api/images/card/.*$
+^https://cards\.example\.com/api/pokedex/images/sprites/.*$
+^https://cards\.example\.com/assets/.*$
+^https://cards\.example\.com/(pokeball\.svg|cardback\.jpg|favicon\.ico|favicon-48\.png|apple-touch-icon\.png|manifest\.json|icon-192\.png|icon-512\.png|robots\.txt)(\?.*)?$
+```
+
+If the installation uses HTTP or a non-standard port internally, match the URL that Authentik receives. Authentik documents the difference between provider modes in its [proxy provider documentation](https://docs.goauthentik.io/add-secure-apps/providers/proxy/#allowing-unauthenticated-requests).
+
+These exceptions expose the files and endpoints needed to render anonymous public views. Compiled frontend assets and globally visible card artwork are available through the listed routes, but protected collection data and administration APIs remain behind authentication. They do not make PokéCollector use the identity supplied by Authentik. Native OIDC support would be a separate authentication integration.
+
+## Verification
+
+Test from a private browser window without an Authentik session:
+
+1. Open `/u`.
+2. Open a trainer profile and one shared binder.
+3. Confirm trainer sprites and card images load.
+4. Confirm `/settings` still requires the proxy login.
+5. Confirm a protected API route such as `/api/collection/` still requires the proxy login.
+
+If the public page HTML loads but remains blank, inspect the browser network panel. A redirect or HTML login response for `/assets/*` usually means the frontend bundles are still protected. Missing card images usually mean `/api/images/card/*` or `/cardback.jpg` is still protected.


### PR DESCRIPTION
## Summary

* Document the full reverse-proxy allowlist needed by public trainer profiles and binders.
* Add Authentik examples for single-application and domain-level forward auth.
* Include card images, trainer sprites, compiled frontend bundles, fallback artwork, and browser assets.
* Warn against bypassing authentication for all `/api` routes.
* Explain that native OIDC remains a separate authentication integration.

## Why

Public profile routes are anonymous inside PokéCollector, but an external forward-auth proxy sees requests first. Without explicit exceptions, `/u` remains inaccessible or loads without its API data and assets.

This follows up on the deployment concern raised by @engelben in #308.

## Validation

* `git diff --check`
* `node scripts/check-version.mjs`
* Positive and negative checks for the documented path and full-URL regexes, including query strings
* Fresh reviewer pass with no blocking findings
