### PR TITLE
Fix fallback badges in card grids

### DIFF
--- a/frontend/src/components/FallbackBadges.jsx
+++ b/frontend/src/components/FallbackBadges.jsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx'
+import { Flag } from 'lucide-react'
 import { useSettings } from '../contexts/SettingsContext'
 import { tcgdexLanguageLabel } from '../utils/tcgdexLanguages'
 
@@ -13,10 +14,36 @@ export default function FallbackBadges({ card, className = '', compact = false, 
   const hasCustomImage = Boolean(card.custom_image_url) && !(card.images_small || card.images_large || card.images?.small || card.images?.large || card.image)
   if (!dataLang && !priceLang && !imageLang && !hasCustomImage) return null
 
+  const fallbackDescriptions = [
+    dataLang && t('fallback.dataFrom').replace('{lang}', sourceLabel(dataLang)),
+    priceLang && t('fallback.priceFrom').replace('{lang}', sourceLabel(priceLang)),
+    imageLang && t('fallback.imageFrom').replace('{lang}', sourceLabel(imageLang)),
+    hasCustomImage && t('fallback.customImageDesc'),
+  ].filter(Boolean)
+
+  if (compact) {
+    const description = fallbackDescriptions.join(' · ')
+    return (
+      <span
+        className={clsx('group/fallback relative inline-flex flex-shrink-0', className)}
+        tabIndex={0}
+        aria-label={description}
+      >
+        <span className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-amber-500/40 bg-amber-500/15 text-amber-300">
+          <Flag size={10} strokeWidth={2.5} aria-hidden="true" />
+        </span>
+        <span
+          role="tooltip"
+          className="pointer-events-none absolute bottom-full right-0 z-30 mb-2 hidden w-max max-w-56 rounded-lg border border-border bg-bg-elevated px-2.5 py-2 text-left text-[10px] font-medium leading-relaxed text-text-secondary shadow-xl group-hover/fallback:block group-focus/fallback:block"
+        >
+          {fallbackDescriptions.map((item) => <span key={item} className="block">{item}</span>)}
+        </span>
+      </span>
+    )
+  }
+
   const overlay = variant === 'overlay'
-  const baseClass = compact
-    ? 'inline-flex min-h-[16px] items-center justify-center rounded px-1.5 py-0.5 text-[9px] leading-none'
-    : 'inline-flex min-h-[18px] items-center justify-center rounded-full px-1.5 py-0.5 text-[10px] leading-none'
+  const baseClass = 'inline-flex min-h-[18px] items-center justify-center rounded-full px-1.5 py-0.5 text-[10px] leading-none'
   const badgeClass = (tone) => clsx(
     baseClass,
     'font-bold whitespace-nowrap',


### PR DESCRIPTION
### Motivation
- Compact fallback badges (data/price/image/custom-image) were overflowing card grids for non-English cards that use fallback sources and broke layout. 
- Provide a compact, predictable visual indicator in tight card UIs while keeping full details discoverable and accessible.

### Description
- Replace the stacked compact fallback badges in `FallbackBadges.jsx` with a single small flag icon (using `Flag` from `lucide-react`) when `compact` is true. 
- Expose the localized fallback-source details as a hover/focus tooltip and provide an accessible combined label via `aria-label` and `tabIndex`. 
- Preserve the original detailed badge presentation for non-compact contexts and keep visual/tone styling for `data`, `price`, `image`, and `customImage` badges unchanged. 
- Simplify the compact vs non-compact base class handling to avoid cramped small-badge rendering.

I considered other options to flag the fallback, such as highlighting the card frame, but found this the least intrusive. Open to alternatives of course. Right now no colors are used in the tt - can be added back of course.

Current behavior:
<img width="199" height="387" alt="Screenshot 2026-07-28 160248" src="https://github.com/user-attachments/assets/8243b397-9668-464a-8140-b98aad37e47a" />

Compact behavior with this PR:
<img width="206" height="383" alt="Screenshot 2026-07-28 160112" src="https://github.com/user-attachments/assets/b2efae1c-2808-4dec-895e-035b4d661e4a" />
<img width="244" height="341" alt="Screenshot 2026-07-28 160131" src="https://github.com/user-attachments/assets/471c0849-8217-43e2-8d8b-a35edc7731a0" />
