### PR TITLE
Prioritise alphanumeric and suffixed collector numbers

### DIFF
--- a/backend/api/recognize.py
+++ b/backend/api/recognize.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from api.auth import get_current_user
 from database import get_db
 from models import Setting, UserSetting, User, Set
+from services.card_numbers import card_number_variants
 
 logger = logging.getLogger(__name__)
 
@@ -29,22 +30,39 @@ def normalize_scanner_card_number(value) -> str | None:
     return str(int(match.group(1))) if match else None
 
 
+def _number_match_keys(value) -> set:
+    """Comparable forms of a printed number, casefolded.
+
+    Both sides of a comparison go through this, so "63/100" and "063" meet on
+    "63" while the set total is ignored.
+    """
+    return {variant.casefold() for variant in card_number_variants(value)}
+
+
 def prioritize_cards_by_number(
     cards: list[dict],
     recognized_number,
     *,
     number_field: str = "number",
 ) -> tuple[list[dict], int]:
-    """Stable-partition cards so recognized collector-number matches come first."""
-    target_number = normalize_scanner_card_number(recognized_number)
-    if not target_number:
+    """Stable-partition cards so recognized collector-number matches come first.
+
+    Matching is on shared number variants rather than the leading digits, for
+    two reasons. Trainer gallery and promo numbers such as "TG01" have no
+    leading digits at all, so a digits-only rule cannot prioritise them and the
+    card stays buried below the candidate cap - the exact truncation this
+    function exists to prevent. And "74a" reduced to "74" names a different,
+    real card, so a suffixed number must not match the plain one.
+    """
+    wanted = _number_match_keys(recognized_number)
+    if not wanted:
         return cards, 0
 
     matches = []
     rest = []
     for card in cards:
-        candidate_number = normalize_scanner_card_number(card.get(number_field))
-        (matches if candidate_number == target_number else rest).append(card)
+        candidate = _number_match_keys(card.get(number_field))
+        (matches if candidate & wanted else rest).append(card)
 
     if not matches:
         return cards, 0

--- a/backend/services/card_numbers.py
+++ b/backend/services/card_numbers.py
@@ -43,3 +43,51 @@ def card_number_matches(stored_number: Optional[str], requested_number: object) 
     if stored == requested:
         return True
     return normalize_card_number(stored) == normalize_card_number(requested)
+
+
+_PRINTED_NUMBER_RE = re.compile(r"^\s*([A-Za-z0-9]+)\s*(?:/\s*[A-Za-z0-9]+)?\s*$")
+COMMON_PAD_WIDTH = 3
+
+
+def printed_number_variants(number: object) -> list:
+    """Forms of a printed number worth querying, most literal first.
+
+    The set total after the slash is dropped and the rest is kept **verbatim**,
+    so alphanumeric numbers survive: "74a" stays "74a" and "TG01" stays "TG01".
+    Only a purely numeric value gains an unpadded alternative, because TCGdex is
+    inconsistent about zero padding between sets - Base Set Charizard is localId
+    "4" while Phantasmal Flames Charmeleon is "012".
+
+    Reducing "74a" to "74" would name a different, real card, so it is not done.
+    """
+    if not number:
+        return []
+    match = _PRINTED_NUMBER_RE.match(str(number))
+    if not match:
+        return []
+    printed = match.group(1)
+    variants = [printed]
+    if printed.isdigit():
+        unpadded = printed.lstrip("0") or printed
+        if unpadded != printed:
+            variants.append(unpadded)
+    return variants
+
+
+def card_number_variants(number: object) -> list:
+    """Every plausible localId for a printed number, most literal first.
+
+    Adds the zero-padded form for numeric values, because a number typed by hand
+    as "12" belongs to a card TCGdex stores as "012". Non-numeric values are
+    offered unchanged rather than being coerced into a numeric shape.
+    """
+    variants = []
+    for variant in printed_number_variants(number):
+        candidates = [variant]
+        if variant.isdigit():
+            unpadded = variant.lstrip("0") or variant
+            candidates += [unpadded, unpadded.zfill(COMMON_PAD_WIDTH)]
+        for candidate in candidates:
+            if candidate not in variants:
+                variants.append(candidate)
+    return variants

--- a/backend/tests/test_card_numbers.py
+++ b/backend/tests/test_card_numbers.py
@@ -1,6 +1,6 @@
 import unittest
 
-from services.card_numbers import card_number_matches, normalize_card_number
+from services.card_numbers import card_number_matches, normalize_card_number, card_number_variants, printed_number_variants
 
 
 class CardNumberTests(unittest.TestCase):
@@ -23,3 +23,30 @@ class CardNumberTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class NumberVariantTests(unittest.TestCase):
+    """Forms a printed number can legitimately take in the catalogue."""
+
+    def test_the_set_total_is_dropped(self):
+        self.assertEqual(printed_number_variants("63/100"), ["63"])
+
+    def test_zero_padding_is_offered_both_ways(self):
+        # TCGdex is inconsistent between sets: Base Set Charizard is localId "4"
+        # while Phantasmal Flames Charmeleon is "012".
+        self.assertEqual(card_number_variants("63/100"), ["63", "063"])
+        self.assertEqual(card_number_variants("063"), ["063", "63"])
+
+    def test_an_alphanumeric_number_is_kept_verbatim(self):
+        self.assertEqual(card_number_variants("TG01"), ["TG01"])
+        self.assertEqual(card_number_variants("SV107"), ["SV107"])
+
+    def test_a_suffix_is_never_reduced_away(self):
+        # "74" is a different, real card.
+        self.assertEqual(card_number_variants("74a"), ["74a"])
+        self.assertNotIn("74", card_number_variants("74a"))
+
+    def test_unreadable_values_yield_nothing(self):
+        for value in (None, "", "No. 039"):
+            with self.subTest(value=value):
+                self.assertEqual(card_number_variants(value), [])

--- a/backend/tests/test_scanner_number_matching.py
+++ b/backend/tests/test_scanner_number_matching.py
@@ -1,0 +1,90 @@
+import unittest
+
+try:
+    from api.recognize import prioritize_cards_by_number
+    DEPS_AVAILABLE = True
+except ModuleNotFoundError:
+    DEPS_AVAILABLE = False
+
+skip_without_deps = unittest.skipUnless(
+    DEPS_AVAILABLE, "FastAPI/SQLAlchemy are not installed in this lightweight test environment"
+)
+
+
+@skip_without_deps
+class AlphanumericNumberTests(unittest.TestCase):
+    """Trainer gallery, promo and suffixed collector numbers.
+
+    Matching on leading digits alone cannot see these: "TG01" has none, so
+    nothing is prioritised and the card stays below the candidate cap - the
+    truncation this prioritising exists to prevent.
+    """
+
+    def test_a_trainer_gallery_number_is_prioritised(self):
+        cards = [{"id": f"filler-{n}", "number": str(n)} for n in range(1, 40)]
+        cards.append({"id": "wanted", "number": "TG01"})
+
+        prioritized, count = prioritize_cards_by_number(cards, "TG01")
+
+        self.assertEqual(count, 1)
+        self.assertEqual(prioritized[0]["id"], "wanted")
+        # The candidate list is capped downstream, so first place is what counts.
+        self.assertIn("wanted", [c["id"] for c in prioritized[:8]])
+
+    def test_a_promo_style_number_is_prioritised(self):
+        cards = [{"id": "other", "number": "12"}, {"id": "wanted", "number": "SV107"}]
+        prioritized, count = prioritize_cards_by_number(cards, "SV107")
+        self.assertEqual(count, 1)
+        self.assertEqual(prioritized[0]["id"], "wanted")
+
+
+@skip_without_deps
+class SuffixedNumberTests(unittest.TestCase):
+    """"74a" and "74" are different, real cards."""
+
+    def test_a_suffixed_number_does_not_match_the_plain_one(self):
+        cards = [{"id": "plain-74", "number": "74"}]
+        prioritized, count = prioritize_cards_by_number(cards, "74a")
+        self.assertEqual(count, 0)
+        self.assertEqual([c["id"] for c in prioritized], ["plain-74"])
+
+    def test_a_suffixed_number_matches_its_own_card(self):
+        cards = [{"id": "plain-74", "number": "74"}, {"id": "suffixed", "number": "74a"}]
+        prioritized, count = prioritize_cards_by_number(cards, "74a")
+        self.assertEqual(count, 1)
+        self.assertEqual(prioritized[0]["id"], "suffixed")
+
+    def test_the_plain_number_does_not_match_the_suffixed_card(self):
+        cards = [{"id": "suffixed", "number": "74a"}]
+        prioritized, count = prioritize_cards_by_number(cards, "74")
+        self.assertEqual(count, 0)
+
+
+@skip_without_deps
+class ExistingBehaviourTests(unittest.TestCase):
+    """The cases upstream already handles must keep working."""
+
+    def test_leading_zeros_and_set_totals_still_meet(self):
+        cards = [
+            {"id": "before", "number": "5"},
+            {"id": "first-match", "number": "063"},
+            {"id": "second-match", "number": "63/100"},
+        ]
+        prioritized, count = prioritize_cards_by_number(cards, "063/100")
+        self.assertEqual(count, 2)
+        self.assertEqual(
+            [c["id"] for c in prioritized],
+            ["first-match", "second-match", "before"],
+        )
+
+    def test_an_unreadable_number_leaves_the_order_alone(self):
+        cards = [{"id": "first", "number": "1"}, {"id": "second", "number": "2"}]
+        for recognized in (None, "", "No. 039", "999"):
+            with self.subTest(recognized=recognized):
+                prioritized, count = prioritize_cards_by_number(cards, recognized)
+                self.assertEqual(count, 0)
+                self.assertEqual([c["id"] for c in prioritized], ["first", "second"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What and why

Fixes #335.

Scanning a trainer gallery or promo card (`TG01`, `SV107`) could not find it. `prioritize_cards_by_number` matches on leading digits, and those numbers have none, so nothing was prioritised and the card stayed below the candidate cap - the truncation #317 fixed, still reachable for these numbers.

In the other direction the rule was too loose: `74a` reduced to `74`, which is a different, real card.

Both sides of the comparison now go through `card_number_variants`, so `63/100` and `063` still meet on `63`, `TG01` matches `TG01`, and `74a` no longer matches `74`. `normalize_scanner_card_number` keeps its existing contract and callers, so its behaviour and its tests are unchanged.

`printed_number_variants` and `card_number_variants` are added to `services/card_numbers.py`, alongside the existing number helpers. They drop the set total and offer both zero-padded and unpadded forms for purely numeric values, because TCGdex is inconsistent between sets - Base Set Charizard is localId `4` while Phantasmal Flames Charmeleon is `012`.

## Validation

- [x] Relevant automated checks pass - full backend suite on this branch: 407 tests, no new failures. (`test_accent_search` reports the same 5 errors on an untouched `v1.33.2` checkout, so they are unrelated to this change.)
- [x] Documentation was updated when behavior changed - no user-facing docs describe scanner number matching; the behaviour is documented in docstrings and tests.

## Card UI (when applicable)

Not applicable - backend only, no UI change, so screenshots are not relevant.

## Tests

- `test_scanner_number_matching.py` - `TG01` and `SV107` prioritised; `74a` does not match `74` and vice versa; the existing leading-zero and set-total behaviour preserved; unreadable numbers still leave the order untouched.
- `test_card_numbers.py` - variant generation, including that a suffix is never reduced away.

Each new assertion was checked against the pre-fix implementation: restoring the digits-only match fails the five new behavioural tests while the existing 23 scanner tests stay green.
