### PR TITLE
Record recognition scan history

### DIFF
--- a/backend/api/recognize.py
+++ b/backend/api/recognize.py
@@ -1,18 +1,78 @@
 import base64
 import asyncio
+import datetime
 import httpx
 import os
 import json
 import re
 from services.tcgdex_languages import is_supported_tcgdex_language, normalize_tcgdex_language
 import logging
-from fastapi import APIRouter, UploadFile, File, HTTPException, Depends
+from fastapi import APIRouter, UploadFile, File, HTTPException, Depends, Query
 from sqlalchemy.orm import Session
 from api.auth import get_current_user
 from database import get_db
-from models import Setting, UserSetting, User, Set
+from models import Setting, UserSetting, User, Set, ScanHistory
 
 logger = logging.getLogger(__name__)
+
+SCAN_HISTORY_RETENTION_DAYS = 14
+
+
+def purge_expired_scan_history(db: Session, user_id: int | None = None, now: datetime.datetime | None = None) -> int:
+    """Delete scan-history rows past their retention window; returns rows removed."""
+    now = now or datetime.datetime.utcnow()
+    query = db.query(ScanHistory).filter(ScanHistory.expires_at < now)
+    if user_id is not None:
+        query = query.filter(ScanHistory.user_id == user_id)
+    return query.delete(synchronize_session=False)
+
+
+def record_scan_history(
+    db: Session,
+    *,
+    user_id: int,
+    source_reference: str | None,
+    recognized: dict,
+    matches: list[dict],
+    now: datetime.datetime | None = None,
+) -> ScanHistory:
+    """Persist a recognition attempt as a short-lived scan-history entry."""
+    now = now or datetime.datetime.utcnow()
+    purge_expired_scan_history(db, user_id=user_id, now=now)
+    top_match = matches[0] if matches else {}
+    entry = ScanHistory(
+        user_id=user_id,
+        source="recognizer",
+        source_reference=source_reference,
+        recognized_name=(recognized.get("name") or recognized.get("name_en") or None),
+        recognized_number=recognized.get("number"),
+        recognized_language=recognized.get("language"),
+        match_count=len(matches),
+        top_match_card_id=top_match.get("id"),
+        top_match_name=top_match.get("name"),
+        created_at=now,
+        expires_at=now + datetime.timedelta(days=SCAN_HISTORY_RETENTION_DAYS),
+    )
+    db.add(entry)
+    db.flush()
+    return entry
+
+
+def serialize_scan_history(entry: ScanHistory) -> dict:
+    return {
+        "id": entry.id,
+        "source": entry.source,
+        "source_reference": entry.source_reference,
+        "recognized_name": entry.recognized_name,
+        "recognized_number": entry.recognized_number,
+        "recognized_language": entry.recognized_language,
+        "match_count": entry.match_count,
+        "top_match_card_id": entry.top_match_card_id,
+        "top_match_name": entry.top_match_name,
+        "created_at": entry.created_at.isoformat() if entry.created_at else None,
+        "expires_at": entry.expires_at.isoformat() if entry.expires_at else None,
+        "retention_days": SCAN_HISTORY_RETENTION_DAYS,
+    }
 
 router = APIRouter()
 
@@ -436,7 +496,40 @@ Respond ONLY with this exact JSON (no markdown, no explanation):
         except Exception as e:
             logger.warning(f"Visual verification failed (non-blocking): {e}")
 
+    final_matches = deduped[:8]
+    scan_entry = record_scan_history(
+        db,
+        user_id=current_user.id,
+        source_reference=None,
+        recognized=card_info,
+        matches=final_matches,
+    )
+    db.commit()
+
     return {
         "recognized": card_info,
-        "matches": deduped[:8],
+        "matches": final_matches,
+        "scan_history": serialize_scan_history(scan_entry),
+    }
+
+
+@router.get("/scan-history")
+def get_scan_history(
+    limit: int = Query(default=25, ge=1, le=100),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Return the user's recent, non-expired recognition scans (newest first)."""
+    purge_expired_scan_history(db, user_id=current_user.id)
+    db.commit()
+    entries = (
+        db.query(ScanHistory)
+        .filter(ScanHistory.user_id == current_user.id)
+        .order_by(ScanHistory.created_at.desc(), ScanHistory.id.desc())
+        .limit(limit)
+        .all()
+    )
+    return {
+        "retention_days": SCAN_HISTORY_RETENTION_DAYS,
+        "items": [serialize_scan_history(entry) for entry in entries],
     }

--- a/backend/models.py
+++ b/backend/models.py
@@ -486,3 +486,20 @@ class ImageCache(Base):
     data = Column(LargeBinary, nullable=False)
     content_type = Column(String, default="image/webp")
     cached_at = Column(DateTime, default=func.now())
+
+
+class ScanHistory(Base):
+    __tablename__ = "scan_history"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    source = Column(String, default="recognizer", nullable=False)
+    source_reference = Column(String)
+    recognized_name = Column(String)
+    recognized_number = Column(String)
+    recognized_language = Column(String)
+    match_count = Column(Integer, default=0, nullable=False)
+    top_match_card_id = Column(String)
+    top_match_name = Column(String)
+    created_at = Column(DateTime, default=func.now(), nullable=False)
+    expires_at = Column(DateTime, nullable=False)

--- a/backend/tests/test_scan_history.py
+++ b/backend/tests/test_scan_history.py
@@ -1,0 +1,60 @@
+import datetime
+import unittest
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from api.recognize import SCAN_HISTORY_RETENTION_DAYS, purge_expired_scan_history, record_scan_history, serialize_scan_history
+from database import Base
+from models import ScanHistory, User
+
+
+class ScanHistoryTests(unittest.TestCase):
+    def setUp(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        self.db = sessionmaker(bind=engine)()
+        self.user = User(username="john", hashed_password="x", role="admin", is_active=True)
+        self.db.add(self.user)
+        self.db.commit()
+        self.db.refresh(self.user)
+
+    def tearDown(self):
+        self.db.close()
+
+    def test_record_scan_history_expires_after_retention_window(self):
+        now = datetime.datetime(2026, 7, 30, 12, 0, 0)
+        entry = record_scan_history(
+            self.db,
+            user_id=self.user.id,
+            source_reference="phone-scan.jpg",
+            recognized={"name": "Latias ex", "number": "239/191", "language": "en"},
+            matches=[{"id": "sv8-239_en", "name": "Latias ex"}],
+            now=now,
+        )
+        self.db.commit()
+
+        payload = serialize_scan_history(entry)
+        self.assertEqual(payload["retention_days"], 14)
+        self.assertEqual(payload["recognized_name"], "Latias ex")
+        self.assertEqual(payload["match_count"], 1)
+        self.assertEqual(payload["top_match_card_id"], "sv8-239_en")
+        self.assertEqual(entry.expires_at, now + datetime.timedelta(days=SCAN_HISTORY_RETENTION_DAYS))
+
+    def test_purge_expired_scan_history_only_removes_expired_rows(self):
+        now = datetime.datetime(2026, 7, 30, 12, 0, 0)
+        expired = ScanHistory(user_id=self.user.id, source="recognizer", expires_at=now - datetime.timedelta(seconds=1))
+        active = ScanHistory(user_id=self.user.id, source="recognizer", expires_at=now + datetime.timedelta(days=1))
+        self.db.add_all([expired, active])
+        self.db.commit()
+
+        removed = purge_expired_scan_history(self.db, user_id=self.user.id, now=now)
+        self.db.commit()
+
+        self.assertEqual(removed, 1)
+        remaining = self.db.query(ScanHistory).all()
+        self.assertEqual([row.id for row in remaining], [active.id])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -107,6 +107,10 @@ export const recognizeCard = (imageFile) => {
   }).then(r => r.data)
 }
 
+// Recent, non-expired recognition scans for the current user
+export const getScanHistory = (params = {}) =>
+  api.get('/cards/scan-history', { params }).then(r => r.data)
+
 // Custom card migration
 export const getCustomMatches = () => api.get('/cards/custom/matches')
 export const migrateCustomCard = (matchId) => api.post(`/cards/custom/migrate/${matchId}`)

--- a/frontend/src/components/CardScanner.jsx
+++ b/frontend/src/components/CardScanner.jsx
@@ -280,6 +280,11 @@ export default function CardScanner({ isOpen, onClose, onCardSelected }) {
                       {t('scanner.detectedLanguage')} {results.recognized.language}
                     </p>
                   )}
+                  {results.scan_history?.expires_at && (
+                    <p className="mt-3 rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-[11px] font-semibold text-text-muted">
+                      Scan history kept for {results.scan_history.retention_days ?? 14} days. This scan expires {new Date(results.scan_history.expires_at).toLocaleDateString()}.
+                    </p>
+                  )}
                 </div>
 
                 {results.matches?.length > 0 ? (


### PR DESCRIPTION
## What

Adds short-lived scan history for card recognition. Second focused salvage PR onto current `main` (breaking up the stale #337).

- **`models.py`** — new `ScanHistory` table (recognized name/number/language, match count, top match, `created_at`/`expires_at`). Auto-created via `create_all`; no migration needed.
- **`api/recognize.py`** — `purge_expired_scan_history` / `record_scan_history` / `serialize_scan_history` helpers; each successful `POST /cards/recognize` now records an entry and returns it as `scan_history` in the response; new `GET /cards/scan-history` returns recent non-expired scans (newest first, expired rows purged on read). Retention: 14 days.
- **`api/client.js`** — `getScanHistory` helper.
- **`CardScanner.jsx`** — shows a scan-expiry note from the recognize response.
- **`tests/test_scan_history.py`** — unit tests for recording and expiry purge.

## Why

`main` had no record of past scans. This is additive: a new table plus one new read endpoint, wired into the existing recognizer.

## Adaptation note

On the source branch this feature was dormant scaffolding — `record_scan_history` was only ever called from tests because recognition was disabled there. Here it's wired into main's live `recognize_card`, so it actually records scans.

## Testing

`tests/test_scan_history.py` passes (2/2) under SQLite:
```
tests/test_scan_history.py::ScanHistoryTests::test_purge_expired_scan_history_only_removes_expired_rows PASSED
tests/test_scan_history.py::ScanHistoryTests::test_record_scan_history_expires_after_retention_window PASSED
```
Ran in a local venv (Docker was unavailable in the authoring environment); the backend's normal test path is `pytest` in the backend image.

Opened from a fork (`groovecityJO/pokecollector`) as the author account has read-only access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)