### PR TITLE
Serve full card detail for another trainer's most valuable card

### DIFF
--- a/backend/api/social.py
+++ b/backend/api/social.py
@@ -2,9 +2,10 @@ from collections import defaultdict
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import func
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from api.auth import get_current_user
+from api.cards import _card_to_dict
 from database import get_db
 from models import Card, CollectionItem, ProductPurchase, Set, User, WishlistItem
 from services.card_values import effective_market_price, normalize_price_field
@@ -181,14 +182,21 @@ ACHIEVEMENTS = [
 
 
 def _card_payload(card: Card | None):
+    """Catalogue detail for a card shown on someone else's profile.
+
+    The card modal renders rarity, HP, artist, types and supertype, so a
+    summary of just a name and a thumbnail leaves its overview blank. The raw
+    custom_image_url stays behind: images resolve through the card-id proxy,
+    and it is a user-supplied URL on another user's card.
+    """
     if not card:
         return None
-    return {
-        "name": card.name,
-        "images_small": card.images_small,
-        "price_market": round(card.price_market or 0, 2),
-        "set_id": card.set_id,
-    }
+    payload = _card_to_dict(card)
+    custom_image_url = payload.pop("custom_image_url", None)
+    payload["has_custom_image_fallback"] = bool(
+        custom_image_url and not (card.images_small or card.images_large)
+    )
+    return payload
 
 
 def _load_user_stats(db: Session, user_ids: list[int] | None = None, price_field: str = "price_trend"):
@@ -293,6 +301,8 @@ def _load_user_stats(db: Session, user_ids: list[int] | None = None, price_field
         items_by_user[row.user_id].append(row)
 
     stats = {}
+    most_valuable_rows: dict[int, object] = {}
+
     for user in users:
         rows = items_by_user.get(user.id, [])
         total_cards = sum(row.quantity or 0 for row in rows)
@@ -301,22 +311,7 @@ def _load_user_stats(db: Session, user_ids: list[int] | None = None, price_field
 
         most_valuable = None
         if rows:
-            most_valuable_row = max(rows, key=lambda row: _get_price(row))
-            most_valuable = {
-                "id": most_valuable_row.card_db_id,
-                "card_id": most_valuable_row.card_db_id,
-                "name": most_valuable_row.name,
-                "images_small": most_valuable_row.images_small,
-                "price_market": round(_get_price(most_valuable_row), 2),
-                "set_id": most_valuable_row.set_id,
-                "data_source_lang": most_valuable_row.data_source_lang,
-                "price_source_lang": most_valuable_row.price_source_lang,
-                "image_source_lang": most_valuable_row.image_source_lang,
-                "has_custom_image_fallback": bool(
-                    most_valuable_row.custom_image_url
-                    and not (most_valuable_row.images_small or most_valuable_row.images_large)
-                ),
-            }
+            most_valuable_rows[user.id] = max(rows, key=lambda row: _get_price(row))
 
         owned_by_set = defaultdict(set)
         owned_set_ids = set()
@@ -359,6 +354,31 @@ def _load_user_stats(db: Session, user_ids: list[int] | None = None, price_field
             "illustration_rare_flag": 1 if has_illustration_rare else 0,
             "public_handle": user.public_handle if sharing_enabled and user.is_profile_public else None,
         }
+
+    if most_valuable_rows:
+        card_ids = {row.card_db_id for row in most_valuable_rows.values()}
+        cards = {
+            card.id: card
+            for card in db.query(Card)
+            .options(joinedload(Card.set_ref))
+            .filter(Card.id.in_(card_ids))
+            .all()
+        }
+        for user_id, row in most_valuable_rows.items():
+            payload = _card_payload(cards.get(row.card_db_id))
+            if payload is None:
+                continue
+            # The row carries the variant-aware price and the language the copy
+            # was actually valued in, which the card alone cannot know.
+            payload.update({
+                "id": row.card_db_id,
+                "card_id": row.card_db_id,
+                "price_market": round(_get_price(row), 2),
+                "data_source_lang": row.data_source_lang,
+                "price_source_lang": row.price_source_lang,
+                "image_source_lang": row.image_source_lang,
+            })
+            stats[user_id]["most_valuable_card"] = payload
 
     return stats
 

--- a/backend/tests/test_leaderboard_card_detail.py
+++ b/backend/tests/test_leaderboard_card_detail.py
@@ -1,0 +1,84 @@
+import unittest
+
+try:
+    from api.social import _card_payload
+    DEPS_AVAILABLE = True
+except ModuleNotFoundError:
+    DEPS_AVAILABLE = False
+
+skip_without_deps = unittest.skipUnless(
+    DEPS_AVAILABLE, "FastAPI/SQLAlchemy are not installed in this lightweight test environment"
+)
+
+
+class _StubCard:
+    """A Card stand-in. Unset columns read as None rather than being listed
+    here, so this does not need updating every time the serialiser grows."""
+
+    def __init__(self, images_small=None, images_large=None, custom_image_url=None):
+        self.id = "sv1-1"
+        self.name = "Pikachu"
+        self.number = "1"
+        self.set_id = "sv1"
+        self.lang = "en"
+        self.rarity = "Rare"
+        self.hp = "60"
+        self.artist = "Ken Sugimori"
+        self.types = ["Lightning"]
+        self.supertype = "Pokémon"
+        self.is_custom = False
+        self.is_digital = False
+        self.images_small = images_small
+        self.images_large = images_large
+        self.custom_image_url = custom_image_url
+        self.price_market = 1.0
+        self.price_trend = 1.0
+
+    def __getattr__(self, name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+        return None
+
+
+@skip_without_deps
+class LeaderboardCardDetailTests(unittest.TestCase):
+    """The leaderboard and compare pages open the shared card modal, which
+    renders rarity, HP, artist, types and supertype. The payload used to carry
+    a name, a thumbnail, a price and a set id, so that modal opened blank."""
+
+    def test_the_fields_the_modal_renders_are_present(self):
+        payload = _card_payload(_StubCard())
+        for field in ("rarity", "hp", "artist", "types", "supertype"):
+            self.assertIn(field, payload, f"{field} missing - the overview renders it")
+            self.assertIsNotNone(payload[field])
+
+    def test_the_existing_fields_are_kept(self):
+        # Both pages read name and price_market directly.
+        payload = _card_payload(_StubCard())
+        self.assertEqual(payload["name"], "Pikachu")
+        self.assertIn("images_small", payload)
+        self.assertIn("set_id", payload)
+
+    def test_the_raw_custom_image_url_is_not_shared(self):
+        # Someone else's card, and a user-supplied URL. Images resolve through
+        # the card-id proxy, so the raw value never needs to travel.
+        payload = _card_payload(_StubCard(custom_image_url="https://example.invalid/secret.png"))
+        self.assertNotIn("custom_image_url", payload)
+        self.assertNotIn("example.invalid", str(payload))
+
+    def test_a_custom_image_fallback_is_still_signalled(self):
+        payload = _card_payload(_StubCard(custom_image_url="https://example.invalid/a.png"))
+        self.assertTrue(payload["has_custom_image_fallback"])
+
+    def test_no_fallback_when_the_card_has_its_own_art(self):
+        payload = _card_payload(
+            _StubCard(images_small="x", custom_image_url="https://example.invalid/a.png")
+        )
+        self.assertFalse(payload["has_custom_image_fallback"])
+
+    def test_a_missing_card_stays_none(self):
+        self.assertIsNone(_card_payload(None))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What and why

Fixes #340.

Clicking another trainer's most valuable card on the Leaderboard or Compare page opened the shared card modal with an empty Overview tab. The modal renders `rarity`, `hp`, `artist`, `types` and `supertype`; the payload carried only `name`, `images_small`, `price_market`, `set_id` and the language fields, so there was nothing to show.

The card is chosen from a partial query row in `_load_user_stats`, which is why the detail was missing rather than null - those columns are never selected. The winning rows are now collected during the existing per-user pass and their cards fetched in a single query afterwards, so the full detail costs one extra query for the whole request rather than one per user, with `set_ref` eager-loaded.

`_card_payload` was dead code in this module and now has a job: it serialises the card with `_card_to_dict`, the same shape every other page feeds the modal.

It also withholds the raw `custom_image_url`. That is a user-supplied URL on someone else's card, images already resolve through the `/api/images/card/{id}` proxy, and `services/public_profile.py` deliberately shares a proxied image plus a boolean rather than the raw value. The existing `has_custom_image_fallback` flag the page relies on is unchanged.

## Validation

- [x] Relevant automated checks pass - full backend suite on this branch: 401 tests, no new failures. (`test_accent_search` reports the same 5 errors on an untouched `v1.33.2` checkout, so they are unrelated to this change.)
- [x] Documentation was updated when behavior changed - no user-facing docs describe this payload; the behaviour is covered by docstrings and tests.

## Card UI (when applicable)

No UI change - this is a backend payload fix, and the modal it feeds is the existing shared component. Screenshots would show the same modal before and after with the Overview populated, so they are not especially informative here; happy to add them if you would like.

## Tests

`backend/tests/test_leaderboard_card_detail.py` covers the fields the modal renders being present, the existing `name`/`images_small`/`set_id`/price keys being kept, the raw custom image URL not being shared, the fallback flag still being set correctly in both directions, and a missing card still returning `None`.

Each assertion was checked against the pre-fix implementation: restoring the trimmed payload fails the detail test, and reverting the URL handling fails the disclosure test.
