### PR TITLE
Fix card entry consistency and mobile navigation

### DIFF
--- a/backend/services/pokemon_api.py
+++ b/backend/services/pokemon_api.py
@@ -1,4 +1,5 @@
 import httpx
+import math
 import re
 from functools import lru_cache
 from typing import Optional, Dict, Any, List
@@ -527,6 +528,37 @@ def parse_card_for_db(card_data: Dict, default_set_id: Optional[str] = None, lan
 
     raw_variants = card_data.get("variants") or {}
     variants = raw_variants if isinstance(raw_variants, dict) else {}
+    variant_types = {
+        str(entry.get("type") or "").replace("_", "").replace("-", "").lower()
+        for entry in raw_variants
+        if isinstance(raw_variants, list) and isinstance(entry, dict)
+    }
+    pricing = card_data.get("pricing") or {}
+    tcgplayer = pricing.get("tcgplayer") if isinstance(pricing, dict) else {}
+    tcgplayer = tcgplayer if isinstance(tcgplayer, dict) else {}
+
+    def available_variant(flag_name: str, list_name: str, price_name: str):
+        """Union TCGdex variant flags with contradictory TCGplayer evidence."""
+        flag = variants.get(flag_name) if variants else (list_name in variant_types or None)
+        price_row = tcgplayer.get(price_name)
+        def is_positive_price(value):
+            if isinstance(value, bool):
+                return False
+            try:
+                numeric_value = float(value)
+            except (TypeError, ValueError):
+                return False
+            return math.isfinite(numeric_value) and numeric_value > 0
+
+        positive_price = (
+            any(is_positive_price(value) for value in price_row.values())
+            if isinstance(price_row, dict)
+            else False
+        )
+        if positive_price:
+            return True
+        return flag
+
     is_full_detail = "category" in card_data
     dex_ids = extract_dex_ids(card_data)
     if dex_ids is None and is_full_detail:
@@ -538,11 +570,6 @@ def parse_card_for_db(card_data: Dict, default_set_id: Optional[str] = None, lan
         dex_ids = []
     if is_full_detail and cardmarket_products is None:
         cardmarket_products = []
-    variant_types = {
-        str(entry.get("type") or "").replace("_", "").replace("-", "").lower()
-        for entry in raw_variants
-        if isinstance(raw_variants, list) and isinstance(entry, dict)
-    }
     retreat_raw = card_data.get("retreat")
     try:
         retreat = int(retreat_raw) if retreat_raw is not None else None
@@ -595,9 +622,9 @@ def parse_card_for_db(card_data: Dict, default_set_id: Optional[str] = None, lan
         "cardmarket_products": cardmarket_products,
         "retreat": retreat,
         "playable_fingerprint": playable_fingerprint(card_data),
-        "variants_normal": variants.get("normal") if variants else ("normal" in variant_types or None),
-        "variants_reverse": variants.get("reverse") if variants else ("reverse" in variant_types or None),
-        "variants_holo": variants.get("holo") if variants else ("holo" in variant_types or None),
+        "variants_normal": available_variant("normal", "normal", "normal"),
+        "variants_reverse": available_variant("reverse", "reverse", "reverse-holofoil"),
+        "variants_holo": available_variant("holo", "holo", "holofoil"),
         "variants_first_edition": variants.get("firstEdition") if variants else ("firstedition" in variant_types or None),
         "price_source_lang": None,
         **prices,

--- a/backend/tests/test_pokedex_feature.py
+++ b/backend/tests/test_pokedex_feature.py
@@ -71,6 +71,44 @@ class PokedexMetadataTests(unittest.TestCase):
         # Rich variant arrays also populate the legacy availability booleans.
         self.assertTrue(parsed["variants_holo"])
 
+    def test_tcgplayer_prices_override_contradictory_variant_flags(self):
+        parsed = parse_card_for_db({
+            "id": "me04-068",
+            "localId": "068",
+            "name": "Goodra",
+            "category": "Pokemon",
+            "variants": {"normal": True, "reverse": False, "holo": False},
+            "pricing": {
+                "tcgplayer": {
+                    "reverse-holofoil": {"marketPrice": 0.22},
+                    "holofoil": {"marketPrice": 0.41},
+                },
+            },
+        }, lang="en")
+
+        self.assertTrue(parsed["variants_normal"])
+        self.assertTrue(parsed["variants_reverse"])
+        self.assertTrue(parsed["variants_holo"])
+
+    def test_empty_tcgplayer_prices_do_not_override_variant_flags(self):
+        parsed = parse_card_for_db({
+            "id": "me04-069",
+            "localId": "069",
+            "name": "Test card",
+            "category": "Pokemon",
+            "variants": {"normal": True, "reverse": False, "holo": False},
+            "pricing": {
+                "tcgplayer": {
+                    "reverse-holofoil": {"marketPrice": None, "lowPrice": 0},
+                    "holofoil": {"marketPrice": float("nan")},
+                },
+            },
+        }, lang="en")
+
+        self.assertTrue(parsed["variants_normal"])
+        self.assertFalse(parsed["variants_reverse"])
+        self.assertFalse(parsed["variants_holo"])
+
     def test_missing_dex_id_falls_back_to_mega_species_name(self):
         self.assertEqual(infer_dex_ids_from_name({
             "name": "Mega-Glurak Y-ex",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import { forceChangePassword } from './api/client'
 import Layout from './components/Layout'
 import { useSettings } from './contexts/SettingsContext'
 import PublicHomeButton from './components/PublicHomeButton'
+import { ConfirmDialogProvider } from './contexts/ConfirmDialogContext'
 
 const HomeScreen = lazy(() => import('./pages/HomeScreen'))
 const Dashboard = lazy(() => import('./pages/Dashboard'))
@@ -188,18 +189,20 @@ export default function App() {
   return (
     <AuthProvider>
       <SettingsProvider>
-        <BrowserRouter>
-          <Routes>
-            {import.meta.env.DEV && <Route path="/__card-system" element={lazyRoute(<CardSystemGallery />)} />}
-            <Route path="/login" element={lazyRoute(<Login />)} />
-            <Route path="/u" element={<PublicRoutes />}>
-              <Route index element={lazyRoute(<PublicDirectory />)} />
-              <Route path=":handle" element={lazyRoute(<PublicProfile />)} />
-              <Route path=":handle/binder/:binderId" element={lazyRoute(<PublicBinderView />)} />
-            </Route>
-            <Route path="/*" element={<ProtectedRoutes />} />
-          </Routes>
-        </BrowserRouter>
+        <ConfirmDialogProvider>
+          <BrowserRouter>
+            <Routes>
+              {import.meta.env.DEV && <Route path="/__card-system" element={lazyRoute(<CardSystemGallery />)} />}
+              <Route path="/login" element={lazyRoute(<Login />)} />
+              <Route path="/u" element={<PublicRoutes />}>
+                <Route index element={lazyRoute(<PublicDirectory />)} />
+                <Route path=":handle" element={lazyRoute(<PublicProfile />)} />
+                <Route path=":handle/binder/:binderId" element={lazyRoute(<PublicBinderView />)} />
+              </Route>
+              <Route path="/*" element={<ProtectedRoutes />} />
+            </Routes>
+          </BrowserRouter>
+        </ConfirmDialogProvider>
       </SettingsProvider>
     </AuthProvider>
   )

--- a/frontend/src/components/CardItem.jsx
+++ b/frontend/src/components/CardItem.jsx
@@ -4,9 +4,10 @@ import { useNavigate } from 'react-router-dom'
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query'
 import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
 import { Plus, Heart, X, PenLine, Pencil, Trash2, ExternalLink } from 'lucide-react'
-import { addToCollection, addToWishlist, cloneCustomCard, createCustomCard, updateCustomCard, updateCardCustomImage, deleteCustomCard, getSets, getPriceHistory } from '../api/client'
+import { addToCollection, addToWishlist, cloneCustomCard, createCustomCard, updateCustomCard, updateCardCustomImage, deleteCustomCard, getSets, getPriceHistory, updateCollectionItem, removeFromCollection } from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
 import { useSettings } from '../contexts/SettingsContext'
+import { useConfirmDialog } from '../contexts/ConfirmDialogContext'
 import toast from 'react-hot-toast'
 import clsx from 'clsx'
 import { cardImageUrl, resolveCardImageUrl } from '../utils/imageUrl'
@@ -14,6 +15,7 @@ import { CARD_VARIANTS, getAvailableVariants, getDefaultVariant } from '../utils
 import MoneyInput from './MoneyInput'
 import { getEffectiveCardPrice } from '../utils/prices'
 import { tcgdexLanguageLabel } from '../utils/tcgdexLanguages'
+import TcgdexLanguageSelect from './TcgdexLanguageSelect'
 import { invalidateCardState, invalidateTcgdexFilterLanguages } from '../utils/queryInvalidation'
 import { parseMoneyInputValue } from '../utils/moneyInput'
 import { cardmarketLinks } from '../utils/cardmarket'
@@ -53,6 +55,7 @@ const POKEMON_TYPES = ['Fire', 'Water', 'Grass', 'Lightning', 'Psychic', 'Fighti
 
 export function CustomCardModal({ onClose, onCreated, sets: setsProp = [], autoAddCollection = false, editCard = null }) {
   const { t, settings, exchangeRate, exchangeRateReady } = useSettings()
+  const confirmDialog = useConfirmDialog()
   const [name, setName] = useState(editCard?.name || '')
   const [setChoice, setSetChoice] = useState('')
   const [customSetId, setCustomSetId] = useState('')
@@ -191,9 +194,15 @@ export function CustomCardModal({ onClose, onCreated, sets: setsProp = [], autoA
     setSelectedTypes(prev => prev.includes(tp) ? prev.filter(t => t !== tp) : [...prev, tp])
   }
 
-  const handleDelete = () => {
+  const handleDelete = async () => {
     if (!editCard) return
-    if (!window.confirm(t('common.confirm_delete'))) return
+    const confirmed = await confirmDialog({
+      title: t('common.delete'),
+      message: t('common.confirm_delete'),
+      confirmLabel: t('common.delete'),
+      destructive: true,
+    })
+    if (!confirmed) return
     deleteMutation.mutate()
   }
 
@@ -446,7 +455,13 @@ export const CardItem = memo(function CardItem({ card, showActions = true, onAdd
         languageLabel={languageLabel}
         compact={compact}
         dimWhenUnowned={dimWhenUnowned}
-        onClick={() => openModal('overview')}
+        onClick={() => openModal(
+          isForeignTemplate
+            ? 'overview'
+            : showActions && !onAddToBinder
+              ? 'add'
+              : 'overview'
+        )}
         onAdd={showActions
           ? () => {
               if (isForeignTemplate) cloneMutation.mutate()
@@ -482,6 +497,54 @@ export const CardItem = memo(function CardItem({ card, showActions = true, onAdd
   )
 })
 
+function OwnedVersionRow({ item, onQuantityChange, onRemove, isUpdating, isRemoving, t }) {
+  const [quantity, setQuantity] = useState(item.quantity || 1)
+
+  useEffect(() => {
+    setQuantity(item.quantity || 1)
+  }, [item.id, item.quantity])
+
+  const commitQuantity = () => {
+    const nextQuantity = Math.max(1, parseInt(quantity, 10) || 1)
+    setQuantity(nextQuantity)
+    if (nextQuantity !== item.quantity) onQuantityChange(item, nextQuantity)
+  }
+
+  return (
+    <div className="flex items-center gap-2 rounded-xl bg-bg-card border border-border p-2">
+      <div className="flex-1 min-w-0">
+        <p className="text-sm text-text-primary font-medium truncate">
+          {[item.variant || 'Normal', item.condition].filter(Boolean).join(' · ')}
+        </p>
+      </div>
+      <input
+        type="number"
+        min="1"
+        value={quantity}
+        onChange={(event) => setQuantity(event.target.value)}
+        onBlur={commitQuantity}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') event.currentTarget.blur()
+        }}
+        disabled={isUpdating || isRemoving}
+        className="input text-center px-2 py-1.5"
+        style={{ width: '4.25rem', colorScheme: 'dark' }}
+        aria-label={t('card.quantity')}
+        title={t('card.quantity')}
+      />
+      <button
+        type="button"
+        onClick={() => onRemove(item)}
+        disabled={isRemoving}
+        className="btn-ghost text-brand-red border-brand-red/30 hover:bg-brand-red/10 px-2 py-1.5"
+        title={t('collection.remove')}
+      >
+        <Trash2 size={14} />
+      </button>
+    </div>
+  )
+}
+
 export function CardModal({ card, onClose, onEdit, defaultLang = 'en', ownedItems = null, initialTab = 'overview', isForeignTemplate = false, onCopyTemplate, copyTemplatePending = false }) {
   if (!card || !card.id) return null
 
@@ -489,11 +552,13 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en', ownedItem
   const [quantity, setQuantity] = useState(1)
   const [condition, setCondition] = useState('NM')
   const [variant, setVariant] = useState(() => getDefaultVariant(card))
+  const [collectionLang, setCollectionLang] = useState(card.lang || defaultLang || 'en')
   const [purchasePrice, setPurchasePrice] = useState('')
   const [resolvedCardId, setResolvedCardId] = useState(card.id)
   const [customImageUrl, setCustomImageUrl] = useState(card.custom_image_url || '')
   const [savedCustomImageUrl, setSavedCustomImageUrl] = useState(card.custom_image_url || '')
   const [customImageVersion, setCustomImageVersion] = useState(0)
+  const [localOwnedItems, setLocalOwnedItems] = useState(() => ownedItems || card.owned_items || [])
   const customImageInputId = useId()
   const { t, formatPrice, formatUsdPrice, pricePrimary, pricePrimaryField, exchangeRate, exchangeRateReady } = useSettings()
   const queryClient = useQueryClient()
@@ -502,6 +567,10 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en', ownedItem
   useEffect(() => {
     setActiveTab(initialTab)
   }, [card.id, initialTab])
+
+  useEffect(() => {
+    setResolvedCardId(card.id)
+  }, [card.id])
 
   // Price history chart
   const cardIdForHistory = card?.card_id || (typeof card?.id === 'string' ? card.id : null)
@@ -518,6 +587,14 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en', ownedItem
     setCustomImageUrl(nextUrl)
     setSavedCustomImageUrl(nextUrl)
   }, [card.id, card.custom_image_url])
+
+  useEffect(() => {
+    setCollectionLang(card.lang || defaultLang || 'en')
+  }, [card.id, card.lang, defaultLang])
+
+  useEffect(() => {
+    setLocalOwnedItems(ownedItems || card.owned_items || [])
+  }, [card.id, card.owned_items, ownedItems])
 
   const safePriceHistory = Array.isArray(priceHistory) ? priceHistory : []
   const hasApiImage = Boolean(card?.images?.large || card?.images_large || card?.images?.small || card?.images_small || card?.image)
@@ -545,8 +622,9 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en', ownedItem
     onClose()
     navigate(target)
   }
-  const modalOwnedItems = ownedItems || card.owned_items || []
-  const ownedQuantity = card.owned_quantity ?? modalOwnedItems.reduce((sum, item) => sum + (item.quantity || 0), 0)
+  const modalOwnedItems = localOwnedItems
+  const detailedOwnedQuantity = modalOwnedItems.reduce((sum, item) => sum + (Number(item.quantity) || 0), 0)
+  const ownedQuantity = modalOwnedItems.length > 0 ? detailedOwnedQuantity : (card.owned_quantity ?? 0)
   const availableVariants = getAvailableVariants(card)
   const selectableVariants = availableVariants.length > 0 ? availableVariants : CARD_VARIANTS
   const availableVariantKey = availableVariants.join('|')
@@ -578,6 +656,32 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en', ownedItem
       onClose()
     },
     onError: () => toast.error(t('card.wishlistFailed')),
+  })
+
+  const quantityMutation = useMutation({
+    mutationFn: ({ item, quantity: nextQuantity }) => updateCollectionItem(item.id, { quantity: nextQuantity }),
+    onSuccess: (_response, { item, quantity: nextQuantity }) => {
+      setLocalOwnedItems(current => current.map(row => (
+        row.id === item.id ? { ...row, quantity: nextQuantity } : row
+      )))
+      toast.success(t('collection.updated'))
+      invalidateCardState(queryClient)
+      invalidateTcgdexFilterLanguages(queryClient)
+    },
+    onError: () => toast.error(t('collection.updateFailed')),
+  })
+
+  const removeMutation = useMutation({
+    mutationFn: (item) => removeFromCollection(item.id),
+    onSuccess: (_response, item) => {
+      const remaining = localOwnedItems.filter(row => row.id !== item.id)
+      setLocalOwnedItems(remaining)
+      if (remaining.length === 0) setActiveTab('add')
+      toast.success(t('collection.removed'))
+      invalidateCardState(queryClient)
+      invalidateTcgdexFilterLanguages(queryClient)
+    },
+    onError: () => toast.error(t('collection.removeFailed')),
   })
 
   const customImageMutation = useMutation({
@@ -917,11 +1021,17 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en', ownedItem
                 <div className="rounded-xl border border-green/30 bg-green/10 p-3">
                   <p className="text-sm font-semibold text-green">✓ {t('cardSearch.alreadyOwned')} · {ownedQuantity}x</p>
                   {modalOwnedItems.length > 0 && (
-                    <div className="mt-2 flex flex-wrap gap-1">
+                    <div className="mt-3 space-y-2">
                       {modalOwnedItems.map(item => (
-                        <span key={item.id} className="text-[10px] px-2 py-1 rounded-full bg-bg-elevated text-text-secondary border border-border">
-                          {[item.variant || 'Normal', item.condition, `${item.quantity}x`].filter(Boolean).join(' · ')}
-                        </span>
+                        <OwnedVersionRow
+                          key={item.id}
+                          item={item}
+                          onQuantityChange={(row, nextQuantity) => quantityMutation.mutate({ item: row, quantity: nextQuantity })}
+                          onRemove={(row) => removeMutation.mutate(row)}
+                          isUpdating={quantityMutation.isPending}
+                          isRemoving={removeMutation.isPending}
+                          t={t}
+                        />
                       ))}
                     </div>
                   )}
@@ -961,6 +1071,10 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en', ownedItem
                 </div>
               )}
               <div>
+                <label className="text-xs text-text-muted mb-1.5 block">🌐 {t('lang.selectLabel')}</label>
+                <TcgdexLanguageSelect value={collectionLang} onChange={setCollectionLang} className="select w-full" />
+              </div>
+              <div>
                 <label className="text-xs text-text-muted mb-1 block">{t('card.purchasePrice')}</label>
                 <MoneyInput
                   placeholder={t('card.purchasePricePlaceholder')}
@@ -974,7 +1088,7 @@ export function CardModal({ card, onClose, onEdit, defaultLang = 'en', ownedItem
                   card_id: resolvedCardId, quantity, condition,
                   variant,
                   purchase_price: parseMoneyInputValue(purchasePrice, exchangeRate),
-                  lang: card.lang || 'en',
+                  lang: collectionLang,
                 })} disabled={addMutation.isPending || !exchangeRateReady}>
                   <Plus size={16} /> {addMutation.isPending ? t('card.adding') : t('card.addToCollection')}
                 </button>

--- a/frontend/src/components/CardScanner.jsx
+++ b/frontend/src/components/CardScanner.jsx
@@ -5,6 +5,7 @@ import { Camera, Upload, ImagePlus, Trash2, X, Check, Loader2, RefreshCw, Plus }
 import { recognizeCard, addToCollection, enqueueScanJob } from '../api/client'
 import { useQueryClient } from '@tanstack/react-query'
 import { useSettings } from '../contexts/SettingsContext'
+import { useConfirmDialog } from '../contexts/ConfirmDialogContext'
 import toast from 'react-hot-toast'
 import { CARD_VARIANTS, getDefaultVariant } from '../utils/cardVariants'
 import TcgdexLanguageSelect from './TcgdexLanguageSelect'
@@ -163,6 +164,7 @@ export default function CardScanner({ isOpen, onClose, onCardSelected }) {
   const scanPreviewRef = useRef(null)
   const stagedFilesRef = useRef([])
   const { t } = useSettings()
+  const confirmDialog = useConfirmDialog()
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -244,8 +246,16 @@ export default function CardScanner({ isOpen, onClose, onCardSelected }) {
     setStagedFiles([])
   }
 
-  const closeScanner = () => {
-    if (stagedFiles.length && !window.confirm(t('scanner.discardStagedConfirm'))) return
+  const closeScanner = async () => {
+    if (stagedFiles.length) {
+      const confirmed = await confirmDialog({
+        title: t('common.close'),
+        message: t('scanner.discardStagedConfirm'),
+        confirmLabel: t('common.close'),
+        destructive: true,
+      })
+      if (!confirmed) return
+    }
     clearStagedFiles()
     reset()
     onClose?.()

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,9 +1,11 @@
 import { Outlet, useLocation } from 'react-router-dom'
 import AppNav from './AppNav'
+import { useReleaseManualHistoryScrollRestoration } from '../hooks/useListScrollRestoration'
 
 export default function Layout() {
   const location = useLocation()
   const isHome = location.pathname === '/'
+  useReleaseManualHistoryScrollRestoration()
 
   return (
     <div className="min-h-dvh flex flex-col bg-bg overflow-x-hidden">

--- a/frontend/src/components/ui/ConfirmDialog.jsx
+++ b/frontend/src/components/ui/ConfirmDialog.jsx
@@ -19,6 +19,7 @@ export default function ConfirmDialog({
       title={title}
       size="sm"
       mobileSheet={false}
+      overlayClassName="z-[500]"
     >
       <div className="space-y-4 p-5">
         <div className="flex items-start gap-3">

--- a/frontend/src/components/ui/Modal.jsx
+++ b/frontend/src/components/ui/Modal.jsx
@@ -17,6 +17,7 @@ const DESKTOP_MEDIA_QUERY = '(min-width: 1024px)'
  *   children  {node}      — modal content
  *   size      {string}    — 'sm' | 'md' | 'lg' | 'xl' (default: 'md')
  *   className {string}    — extra classes for the inner panel
+ *   overlayClassName {string} — stacking class for the backdrop (default: 'z-50')
  *   mobileSheet {boolean} — if true, renders as Sheet on mobile (default: true)
  */
 export default function Modal({
@@ -26,6 +27,7 @@ export default function Modal({
   children,
   size = 'md',
   className = '',
+  overlayClassName = 'z-50',
   mobileSheet = true,
   isObscured = false,
 }) {
@@ -101,6 +103,7 @@ export default function Modal({
         closeLabel={t('common.close')}
         dialogLabel={t('common.dialog')}
         isObscured={isObscured}
+        overlayClassName={overlayClassName}
       >
         {children}
       </DesktopModal>
@@ -118,13 +121,14 @@ export default function Modal({
       closeLabel={t('common.close')}
       dialogLabel={t('common.dialog')}
       isObscured={isObscured}
+      overlayClassName={overlayClassName}
     >
       {children}
     </DesktopModal>
   )
 }
 
-function DesktopModal({ isOpen, onClose, title, children, sizeClass, className = '', closeLabel = 'Close', dialogLabel = 'Dialog', isObscured = false }) {
+function DesktopModal({ isOpen, onClose, title, children, sizeClass, className = '', overlayClassName = 'z-50', closeLabel = 'Close', dialogLabel = 'Dialog', isObscured = false }) {
   const titleId = useId()
   const { dialogRef, onDialogKeyDown } = useDialogBehavior(isOpen, onClose, { restoreFocus: false })
   if (!isOpen) return null
@@ -133,7 +137,7 @@ function DesktopModal({ isOpen, onClose, title, children, sizeClass, className =
     <>
       {/* Backdrop */}
       <div
-        className="fixed inset-0 z-50 bg-black/60 animate-fade-in flex items-end sm:items-center justify-center p-4"
+        className={`fixed inset-0 ${overlayClassName} bg-black/60 animate-fade-in flex items-end sm:items-center justify-center p-4`}
         onClick={onClose}
       >
         {/* Panel — stop propagation so clicks inside don't close */}

--- a/frontend/src/contexts/ConfirmDialogContext.jsx
+++ b/frontend/src/contexts/ConfirmDialogContext.jsx
@@ -1,0 +1,48 @@
+import { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react'
+import ConfirmDialog from '../components/ui/ConfirmDialog'
+import { useSettings } from './SettingsContext'
+
+const ConfirmDialogContext = createContext(null)
+
+export function ConfirmDialogProvider({ children }) {
+  const { t } = useSettings()
+  const [request, setRequest] = useState(null)
+  const resolveRef = useRef(null)
+
+  const confirm = useCallback((options) => new Promise(resolve => {
+    resolveRef.current?.(false)
+    resolveRef.current = resolve
+    setRequest(options)
+  }), [])
+
+  const close = useCallback((confirmed) => {
+    const resolve = resolveRef.current
+    resolveRef.current = null
+    setRequest(null)
+    resolve?.(Boolean(confirmed))
+  }, [])
+
+  const value = useMemo(() => confirm, [confirm])
+
+  return (
+    <ConfirmDialogContext.Provider value={value}>
+      {children}
+      <ConfirmDialog
+        isOpen={Boolean(request)}
+        onClose={() => close(false)}
+        onConfirm={() => close(true)}
+        title={request?.title || request?.confirmLabel || t('common.delete')}
+        message={request?.message || ''}
+        confirmLabel={request?.confirmLabel || t('common.delete')}
+        cancelLabel={request?.cancelLabel || t('common.cancel')}
+        destructive={request?.destructive ?? true}
+      />
+    </ConfirmDialogContext.Provider>
+  )
+}
+
+export function useConfirmDialog() {
+  const confirm = useContext(ConfirmDialogContext)
+  if (!confirm) throw new Error('useConfirmDialog must be used within ConfirmDialogProvider')
+  return confirm
+}

--- a/frontend/src/hooks/useListScrollRestoration.js
+++ b/frontend/src/hooks/useListScrollRestoration.js
@@ -44,6 +44,57 @@ export const getNextDetailNavigationState = (state, listKey) => {
   }
 }
 
+export const restoreListScrollPosition = (saved, browserWindow = window, browserDocument = document) => {
+  browserWindow.scrollTo({ top: saved.scrollY, left: 0, behavior: 'auto' })
+
+  // A resized viewport or changed results can clamp the saved offset.
+  if (Math.abs(browserWindow.scrollY - saved.scrollY) > 2) {
+    browserDocument.getElementById(saved.anchorId)?.scrollIntoView({ block: 'center', behavior: 'auto' })
+  }
+}
+
+let activeHistoryRestoration = null
+
+export const releaseManualHistoryScrollRestoration = () => {
+  if (!activeHistoryRestoration) return
+  activeHistoryRestoration.browserHistory.scrollRestoration = activeHistoryRestoration.previousValue
+  activeHistoryRestoration = null
+}
+
+export const scheduleManualHistoryScrollRestorationRelease = (
+  delay = 1000,
+  browserWindow = globalThis,
+) => {
+  const restoration = activeHistoryRestoration
+  if (!restoration) return () => {}
+
+  const timeoutId = browserWindow.setTimeout(() => {
+    if (activeHistoryRestoration === restoration) releaseManualHistoryScrollRestoration()
+  }, delay)
+  return () => browserWindow.clearTimeout(timeoutId)
+}
+
+export const enableManualHistoryScrollRestoration = (
+  browserHistory = window.history,
+) => {
+  if (!browserHistory || !('scrollRestoration' in browserHistory)) return () => {}
+
+  if (activeHistoryRestoration?.browserHistory !== browserHistory) {
+    activeHistoryRestoration = {
+      browserHistory,
+      previousValue: browserHistory.scrollRestoration,
+    }
+  }
+
+  browserHistory.scrollRestoration = 'manual'
+  return releaseManualHistoryScrollRestoration
+}
+
+export const isListScrollSurfaceVisible = (key, browserDocument = document) => {
+  const surface = browserDocument.querySelector(`[data-scroll-list="${key}"]`)
+  return Boolean(surface?.getClientRects?.().length)
+}
+
 /**
  * React Router's <ScrollRestoration /> requires a data router, while this app
  * uses BrowserRouter. We also need to delay restoration until async list items
@@ -86,24 +137,24 @@ export function useListScrollRestoration({ key, isReady, listState = null }) {
     const saved = readSavedPosition(key)
     if (!isSavedPositionForLocation(saved, location)) return
 
-    let frame
-    let nestedFrame
-    const restore = () => {
-      window.scrollTo({ top: saved.scrollY, left: 0, behavior: 'auto' })
-
-      // A resized viewport or changed results can clamp the saved offset.
-      if (Math.abs(window.scrollY - saved.scrollY) > 2) {
-        document.getElementById(saved.anchorId)?.scrollIntoView({ block: 'center', behavior: 'auto' })
+    let frameId = null
+    const restoreWhenVisible = () => {
+      // React can prepare the returning route offscreen while keeping the detail
+      // route visible. Wait for the list surface itself to become visible so its
+      // offset is never applied to the old detail DOM.
+      if (!isListScrollSurfaceVisible(key)) {
+        frameId = window.requestAnimationFrame(restoreWhenVisible)
+        return
       }
+
+      restoreListScrollPosition(saved)
       restoredLocationKey.current = location.key
+      releaseManualHistoryScrollRestoration()
     }
 
-    frame = requestAnimationFrame(() => {
-      nestedFrame = requestAnimationFrame(restore)
-    })
+    frameId = window.requestAnimationFrame(restoreWhenVisible)
     return () => {
-      cancelAnimationFrame(frame)
-      cancelAnimationFrame(nestedFrame)
+      if (frameId !== null) window.cancelAnimationFrame(frameId)
     }
   }, [isReady, key, location.key, location.pathname, location.search, navigationType])
 
@@ -113,6 +164,17 @@ export function useListScrollRestoration({ key, isReady, listState = null }) {
 export function useDetailBackNavigation(listKey, fallbackPath) {
   const location = useLocation()
   const navigate = useNavigate()
+
+  useEffect(() => {
+    if (location.state?.fromList !== listKey) return undefined
+
+    // The list restores itself before paint. Native restoration would apply the
+    // saved list offset to the still-mounted detail DOM during the POP instead.
+    // The layout releases this only after the next non-detail route commits, so
+    // native restoration stays disabled for the entire POP transition.
+    enableManualHistoryScrollRestoration()
+    return undefined
+  }, [listKey, location.state])
 
   const goBack = useCallback(() => {
     const delta = getDetailBackDelta(location.state, listKey)
@@ -124,6 +186,15 @@ export function useDetailBackNavigation(listKey, fallbackPath) {
   }, [fallbackPath, listKey, location.state, navigate])
 
   return goBack
+}
+
+export function useReleaseManualHistoryScrollRestoration() {
+  const location = useLocation()
+
+  useEffect(() => {
+    if (location.state?.fromList) return
+    return scheduleManualHistoryScrollRestorationRelease()
+  }, [location.key, location.state])
 }
 
 export function useScrollToTopOnPush() {

--- a/frontend/src/hooks/useListScrollRestoration.test.js
+++ b/frontend/src/hooks/useListScrollRestoration.test.js
@@ -1,10 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
+  enableManualHistoryScrollRestoration,
   getDetailBackDelta,
   getNextDetailNavigationState,
   getSavedListScrollPosition,
+  isListScrollSurfaceVisible,
   isSavedPositionForLocation,
+  releaseManualHistoryScrollRestoration,
+  restoreListScrollPosition,
   saveListScrollPosition,
+  scheduleManualHistoryScrollRestorationRelease,
 } from './useListScrollRestoration'
 
 const createSessionStorage = () => {
@@ -100,5 +105,93 @@ describe('detail navigation history', () => {
     expect(getDetailBackDelta({ ...sourceState, detailHistoryDepth: -4 }, 'pokedex')).toBe(-1)
     expect(getDetailBackDelta(sourceState, 'sets')).toBeNull()
     expect(getNextDetailNavigationState(sourceState, 'sets')).toBeUndefined()
+  })
+})
+
+describe('browser history restoration', () => {
+  it('temporarily disables native restoration during a detail return', () => {
+    const browserHistory = { scrollRestoration: 'auto' }
+
+    const restore = enableManualHistoryScrollRestoration(browserHistory)
+    expect(browserHistory.scrollRestoration).toBe('manual')
+
+    restore()
+    expect(browserHistory.scrollRestoration).toBe('auto')
+  })
+
+  it('keeps restoration manual across repeated detail effect setup', () => {
+    const browserHistory = { scrollRestoration: 'auto' }
+
+    enableManualHistoryScrollRestoration(browserHistory)
+    enableManualHistoryScrollRestoration(browserHistory)
+    expect(browserHistory.scrollRestoration).toBe('manual')
+
+    releaseManualHistoryScrollRestoration()
+    expect(browserHistory.scrollRestoration).toBe('auto')
+  })
+
+  it('ignores history implementations without restoration support', () => {
+    const browserHistory = {}
+    expect(() => enableManualHistoryScrollRestoration(browserHistory)()).not.toThrow()
+  })
+
+  it('does not let an earlier route release a later detail session', () => {
+    const browserHistory = { scrollRestoration: 'auto' }
+    let scheduledCallback = null
+    const browserWindow = {
+      setTimeout: (callback) => {
+        scheduledCallback = callback
+        return 1
+      },
+      clearTimeout: () => { scheduledCallback = null },
+    }
+
+    scheduleManualHistoryScrollRestorationRelease(1000, browserWindow)
+    enableManualHistoryScrollRestoration(browserHistory)
+    scheduledCallback?.()
+
+    expect(browserHistory.scrollRestoration).toBe('manual')
+    releaseManualHistoryScrollRestoration()
+  })
+
+  it('detects only a visibly committed list surface', () => {
+    const hiddenSurface = { getClientRects: () => [] }
+    const visibleSurface = { getClientRects: () => [{ width: 390, height: 844 }] }
+    const browserDocument = {
+      querySelector: (selector) => selector === '[data-scroll-list="sets"]' ? hiddenSurface : null,
+    }
+
+    expect(isListScrollSurfaceVisible('sets', browserDocument)).toBe(false)
+    browserDocument.querySelector = () => visibleSurface
+    expect(isListScrollSurfaceVisible('sets', browserDocument)).toBe(true)
+  })
+})
+
+describe('restoring a saved list position', () => {
+  it('restores the exact offset before the list becomes interactive', () => {
+    const scrollTo = (...args) => {
+      fakeWindow.scrollY = args[0].top
+      fakeWindow.lastScroll = args[0]
+    }
+    const fakeWindow = { scrollY: 0, scrollTo }
+    const fakeDocument = { getElementById: () => null }
+
+    restoreListScrollPosition({ scrollY: 640, anchorId: 'set-me04_de' }, fakeWindow, fakeDocument)
+
+    expect(fakeWindow.lastScroll).toEqual({ top: 640, left: 0, behavior: 'auto' })
+  })
+
+  it('uses the saved anchor when the browser clamps the offset', () => {
+    let anchorOptions = null
+    const fakeWindow = { scrollY: 100, scrollTo: () => {} }
+    const fakeDocument = {
+      getElementById: (id) => id === 'set-me04_de'
+        ? { scrollIntoView: options => { anchorOptions = options } }
+        : null,
+    }
+
+    restoreListScrollPosition({ scrollY: 640, anchorId: 'set-me04_de' }, fakeWindow, fakeDocument)
+
+    expect(anchorOptions).toEqual({ block: 'center', behavior: 'auto' })
   })
 })

--- a/frontend/src/i18n/de.js
+++ b/frontend/src/i18n/de.js
@@ -470,11 +470,12 @@ const de = {
     deleted: 'Binder gelöscht!',
     createFailed: 'Fehler beim Erstellen',
     updateFailed: 'Fehler beim Aktualisieren',
-    deleteConfirm: 'Binder löschen?',
+    deleteConfirm: 'Binder "{name}" löschen?',
     sharePublicly: 'Öffentlich teilen',
     publicUpdated: 'Freigabe aktualisiert',
     enablePublicProfileHint: 'Aktiviere dein öffentliches Profil in den Einstellungen',
     copyPublicLink: 'Öffentlichen Link kopieren',
+    addCards: 'Karten hinzufügen',
   },
 
   // Analytics

--- a/frontend/src/i18n/en.js
+++ b/frontend/src/i18n/en.js
@@ -471,11 +471,12 @@ const en = {
     deleted: 'Binder deleted!',
     createFailed: 'Failed to create binder',
     updateFailed: 'Failed to update binder',
-    deleteConfirm: 'Delete binder?',
+    deleteConfirm: 'Delete binder "{name}"?',
     sharePublicly: 'Share publicly',
     publicUpdated: 'Sharing setting updated',
     enablePublicProfileHint: 'Enable your public profile in Settings to share',
     copyPublicLink: 'Copy public link',
+    addCards: 'Add cards',
   },
 
   // Analytics

--- a/frontend/src/pages/BinderDetail.jsx
+++ b/frontend/src/pages/BinderDetail.jsx
@@ -695,7 +695,7 @@ export default function BinderDetail() {
             }}
             className="btn-primary flex-shrink-0"
           >
-            <Plus size={16} /> {t('common.add')} {t('nav.cards')}
+            <Plus size={16} /> {t('binders.addCards')}
           </button>
           {isCollection && (
             <button

--- a/frontend/src/pages/Binders.jsx
+++ b/frontend/src/pages/Binders.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom'
 import { Plus, Trash2, Edit2, BookOpen, Star, Package, Check, X, Library, Heart, Globe, Lock, Copy } from 'lucide-react'
 import { getBinders, createBinder, updateBinder, deleteBinder, getWishlist, getProfile } from '../api/client'
 import { useSettings } from '../contexts/SettingsContext'
+import { useConfirmDialog } from '../contexts/ConfirmDialogContext'
 import TabNav from '../components/TabNav'
 import AvatarPicker from '../components/AvatarPicker'
 import toast from 'react-hot-toast'
@@ -142,6 +143,7 @@ function BinderForm({ initial = {}, onSubmit, onCancel, loading }) {
 export default function Binders() {
   const navigate = useNavigate()
   const { t } = useSettings()
+  const confirmDialog = useConfirmDialog()
   const queryClient = useQueryClient()
   const [creating, setCreating] = useState(false)
   const [editingId, setEditingId] = useState(null)
@@ -355,10 +357,17 @@ export default function Binders() {
                         className="text-text-muted hover:text-text-primary bg-bg/80 rounded p-1 transition-colors">
                         <Edit2 size={12} />
                       </button>
-                      <button onClick={(e) => {
+                      <button onClick={async (e) => {
                         e.stopPropagation()
-                        if (confirm(`${t('binders.deleteConfirm')} "${binder.name}"?`)) deleteMutation.mutate(binder.id)
-                      }} className="text-text-muted hover:text-brand-red bg-bg/80 rounded p-1 transition-colors">
+                        const confirmed = await confirmDialog({
+                          title: t('common.delete'),
+                          message: t('binders.deleteConfirm').replace('{name}', binder.name),
+                          confirmLabel: t('common.delete'),
+                          destructive: true,
+                        })
+                        if (confirmed) deleteMutation.mutate(binder.id)
+                      }} className="text-text-muted hover:text-brand-red bg-bg/80 rounded p-1 transition-colors"
+                        aria-label={`${t('common.delete')}: ${binder.name}`}>
                         <Trash2 size={12} />
                       </button>
                     </div>

--- a/frontend/src/pages/CardSearch.jsx
+++ b/frontend/src/pages/CardSearch.jsx
@@ -142,7 +142,7 @@ export default function CardSearch() {
   const [showCustomModal, setShowCustomModal] = useState(false)
   const [showScanner, setShowScanner] = useState(false)
   const [selectedCard, setSelectedCard] = useState(null)
-  const [selectedCardTab, setSelectedCardTab] = useState('overview')
+  const [selectedCardTab, setSelectedCardTab] = useState('add')
   const [selectMode, setSelectMode] = useState(false)
   const [selectedItems, setSelectedItems] = useState(new Map()) // card.id -> { card_id, lang }
   const pageSize = 20
@@ -773,7 +773,7 @@ export default function CardSearch() {
                     onClick={() => {
                       if (selectMode) toggleSelected(card)
                       else {
-                        setSelectedCardTab('overview')
+                        setSelectedCardTab('add')
                         setSelectedCard(card)
                       }
                     }}

--- a/frontend/src/pages/Collection.jsx
+++ b/frontend/src/pages/Collection.jsx
@@ -6,6 +6,7 @@ import { Trash2, Check, X, Filter, SortAsc, Download, Upload, ChevronUp, Chevron
 import { getCollection, updateCollectionItem, updateCardCustomImage, removeFromCollection, importCollectionCsv, exportCSV, exportPDF, getSets, addToCollection, getBinders, addCollectionItemToBinder, getWishlist, getApiErrorMessage } from '../api/client'
 import { CustomCardModal } from '../components/CardItem'
 import { useSettings } from '../contexts/SettingsContext'
+import { useConfirmDialog } from '../contexts/ConfirmDialogContext'
 import CardImage from '../components/CardImage'
 import { CardDialog, CardDisplay, CardIdentity, CardLegend, CardRow, withCollectionItemState } from '../components/card-system'
 import MoneyInput from '../components/MoneyInput'
@@ -258,6 +259,7 @@ function CsvImportModal({ t, onClose, onChooseFile, onDownloadTemplate, isImport
 // Opens when clicking any card in the collection. Allows editing + deleting.
 function CollectionEditModal({ item, onClose }) {
   const { t, formatPrice, pricePrimaryField, exchangeRate, exchangeRateReady } = useSettings()
+  const confirmDialog = useConfirmDialog()
   const queryClient = useQueryClient()
   const card = item.card
   const itemPriceInput = formatMoneyInputValue(item.purchase_price, exchangeRate)
@@ -423,8 +425,14 @@ function CollectionEditModal({ item, onClose }) {
     },
   })
 
-  const handleDelete = () => {
-    if (confirm(`${card?.name || 'Karte'} ${t('collection.removeConfirm')}`)) {
+  const handleDelete = async () => {
+    const confirmed = await confirmDialog({
+      title: t('common.remove'),
+      message: `${card?.name || t('collection.card')} ${t('collection.removeConfirm')}`,
+      confirmLabel: t('common.remove'),
+      destructive: true,
+    })
+    if (confirmed) {
       deleteMutation.mutate()
     }
   }

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,4 +1,5 @@
 
+import { useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import {
@@ -6,23 +7,23 @@ import {
   ResponsiveContainer, Area, AreaChart
 } from 'recharts'
 import { TrendingUp, TrendingDown } from 'lucide-react'
-import { getDashboard } from '../api/client'
+import { getDashboard, getInvestmentTracker } from '../api/client'
 import { useSettings } from '../contexts/SettingsContext'
 import { useAuth } from '../contexts/AuthContext'
-import { format, parseISO } from 'date-fns'
 import TrainerCard from '../components/TrainerCard'
 import PokeBallLoader from '../components/PokeBallLoader'
 import { resolveCardImageUrl } from '../utils/imageUrl'
 import { collectionItemTargetUrl } from '../utils/navigation'
 import AnalyticsSectionNav from '../components/AnalyticsSectionNav'
 import { CardDisplay, CardLegend, withCollectionItemState } from '../components/card-system'
+import { mapPortfolioChartData, portfolioApiPeriod, PORTFOLIO_PERIODS } from '../utils/portfolioChart'
 
 const CustomTooltip = ({ active, payload, label }) => {
   const { formatPrice, t } = useSettings()
   if (active && payload && payload.length) {
     return (
       <div className="bg-bg-surface border border-border rounded-lg p-3 text-sm shadow-xl">
-        <p className="text-text-muted mb-1">{label}</p>
+        <p className="text-text-muted mb-1">{payload[0]?.payload?.tooltipLabel || label}</p>
         {payload.map((entry, i) => (
           <p key={i} style={{ color: entry.color }} className="font-medium">
             {entry.name}: {formatPrice(entry.value)}
@@ -42,12 +43,24 @@ export default function Dashboard() {
   const { user } = useAuth()
   const navigate = useNavigate()
   const priceField = pricePrimaryField
+  const [chartPeriod, setChartPeriod] = useState('1M')
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['dashboard', priceField],
     queryFn: () => getDashboard({ price_field: priceField }).then(r => r.data),
     refetchInterval: 60000,
   })
+
+  const { data: investmentData = [] } = useQuery({
+    queryKey: ['investment-tracker', chartPeriod, priceField],
+    queryFn: () => getInvestmentTracker({ period: portfolioApiPeriod(chartPeriod), price_field: priceField }).then(r => r.data),
+    refetchInterval: 120000,
+  })
+
+  const chartData = useMemo(
+    () => mapPortfolioChartData(investmentData, chartPeriod, t('home.legacySnapshot')),
+    [investmentData, chartPeriod, t],
+  )
 
   if (isLoading) {
     return (
@@ -92,14 +105,6 @@ export default function Dashboard() {
       </div>
     )
   }
-
-  const valueHistory = data?.value_history || []
-  const chartData = valueHistory.map(item => ({
-    date: format(parseISO(item.date), 'MMM d'),
-    value: item.value,
-    cost: item.cost,
-    legacy: Boolean(item.legacy),
-  }))
 
   const pnl = data?.pnl || 0
   const performanceCostBasis = Number(data?.performance_cost_basis ?? data?.total_cost ?? 0)
@@ -261,10 +266,28 @@ export default function Dashboard() {
       {/* ─── 6. PORTFOLIO CHART ─────────────────────────────────────── */}
       <section>
         <div className="bg-bg-card border border-border rounded-2xl p-4">
-          <h2 className="text-sm font-bold text-text-primary uppercase tracking-wider mb-4">
-            {t('dashboard.portfolioHistory')}
-          </h2>
-          {chartData.length > 0 ? (
+          <div className="mb-4 flex items-center justify-between gap-3">
+            <h2 className="text-sm font-bold text-text-primary uppercase tracking-wider">
+              {t('dashboard.portfolioHistory')}
+            </h2>
+            <div className="flex gap-1">
+              {PORTFOLIO_PERIODS.map(period => (
+                <button
+                  key={period.key}
+                  type="button"
+                  onClick={() => setChartPeriod(period.key)}
+                  className={`rounded-lg border px-2 py-1 text-[10px] font-bold transition-colors ${
+                    chartPeriod === period.key
+                      ? 'border-gold/30 bg-gold/15 text-gold'
+                      : 'border-transparent bg-bg-elevated text-text-muted hover:text-text-primary'
+                  }`}
+                >
+                  {period.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          {chartData.length > 1 ? (
             <ResponsiveContainer width="100%" height={220}>
               <AreaChart data={chartData}>
                 <defs>
@@ -278,7 +301,7 @@ export default function Dashboard() {
                   </linearGradient>
                 </defs>
                 <CartesianGrid strokeDasharray="3 3" stroke="#2a2a3d" />
-                <XAxis dataKey="date" tick={{ fill: '#606078', fontSize: 11 }} />
+                <XAxis dataKey="date" tick={{ fill: '#606078', fontSize: 11 }} interval="preserveStartEnd" />
                 <YAxis tick={{ fill: '#606078', fontSize: 11 }} tickFormatter={(v) => formatPrice(v)} />
                 <Tooltip content={<CustomTooltip />} />
                 <Area

--- a/frontend/src/pages/HomeScreen.jsx
+++ b/frontend/src/pages/HomeScreen.jsx
@@ -12,7 +12,6 @@ import { getDashboard, triggerPriceSync, getSyncStatus, getInvestmentTracker, ge
 import { useSettings } from '../contexts/SettingsContext'
 import { useAuth } from '../contexts/AuthContext'
 import toast from 'react-hot-toast'
-import { format, parseISO } from 'date-fns'
 import { resolveCardImageUrl } from '../utils/imageUrl'
 import { collectionItemTargetUrl } from '../utils/navigation'
 import { CardDisplay, CardLegend, withCollectionItemState } from '../components/card-system'
@@ -21,6 +20,7 @@ import {
   hasActiveScanJobs,
   scanAttentionCount,
 } from '../utils/scanJobs'
+import { mapPortfolioChartData, portfolioApiPeriod, PORTFOLIO_PERIODS } from '../utils/portfolioChart'
 
 // Compact number formatter for mobile (1.2k, 3.4M, etc.)
 function compactNum(n) {
@@ -30,14 +30,6 @@ function compactNum(n) {
   if (n >= 1_000) return (n / 1_000).toFixed(1).replace(/\.0$/, '') + 'k'
   return n.toLocaleString()
 }
-
-// ── Time-range definitions ────────────────────────────────────────────────────
-const PERIODS = [
-  { key: '1W',  label: '1W',   apiPeriod: '1w' },
-  { key: '1M',  label: '1M',   apiPeriod: '1m' },
-  { key: '1Y',  label: '1Y',   apiPeriod: '1y' },
-  { key: 'MAX', label: 'Max',  apiPeriod: 'max' },
-]
 
 // ── Custom chart tooltip ──────────────────────────────────────────────────────
 function ChartTooltip({ active, payload, label, formatPrice }) {
@@ -163,10 +155,9 @@ export default function HomeScreen() {
   const scansActive = hasActiveScanJobs(scanJobs)
 
   // Portfolio history for chart — uses analytics/investment-tracker
-  const activePeriod = PERIODS.find(p => p.key === chartPeriod)
   const { data: investmentData = [] } = useQuery({
     queryKey: ['investment-tracker', chartPeriod, pricePrimaryField],
-    queryFn: () => getInvestmentTracker({ period: activePeriod?.apiPeriod ?? 'max', price_field: pricePrimaryField }).then(r => r.data),
+    queryFn: () => getInvestmentTracker({ period: portfolioApiPeriod(chartPeriod), price_field: pricePrimaryField }).then(r => r.data),
     refetchInterval: 120000,
   })
 
@@ -223,22 +214,10 @@ export default function HomeScreen() {
   const openCollectionItem = (card) => navigate(collectionItemTargetUrl(card))
 
   // Map chart data — backend already filters and downsamples
-  const chartData = useMemo(() => {
-    const fmtMap = { '1W': 'EEE dd.MM', '1Y': 'MMM yy', 'MAX': 'MMM yy' }
-    const dateFmt = fmtMap[chartPeriod] ?? 'dd.MM.'
-    return (investmentData || []).map(d => {
-      const snapshotDate = parseISO(d.date)
-      return {
-        date: format(snapshotDate, dateFmt),
-        tooltipLabel: chartPeriod === '1W'
-          ? format(snapshotDate, 'EEE dd.MM HH:mm')
-          : format(snapshotDate, dateFmt),
-        value: d.value,
-        legacy: Boolean(d.legacy),
-        legacyLabel: t('home.legacySnapshot'),
-      }
-    })
-  }, [investmentData, chartPeriod, t])
+  const chartData = useMemo(
+    () => mapPortfolioChartData(investmentData, chartPeriod, t('home.legacySnapshot')),
+    [investmentData, chartPeriod, t],
+  )
 
   // Determine chart color based on trend
   const chartColor = useMemo(() => {
@@ -483,7 +462,7 @@ export default function HomeScreen() {
           <div className="flex items-center justify-between mb-3">
             <p className="text-xs font-bold text-white uppercase tracking-wider">{t('home.portfolioHistory')}</p>
             <div className="flex gap-1">
-              {PERIODS.map(p => (
+              {PORTFOLIO_PERIODS.map(p => (
                 <button
                   key={p.key}
                   onClick={() => setChartPeriod(p.key)}

--- a/frontend/src/pages/Pokedex.jsx
+++ b/frontend/src/pages/Pokedex.jsx
@@ -152,7 +152,7 @@ export default function Pokedex() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-7xl space-y-5 px-4 pb-28 pt-2 sm:px-6 lg:px-8">
+    <div data-scroll-list="pokedex" className="mx-auto w-full max-w-7xl space-y-5 px-4 pb-28 pt-2 sm:px-6 lg:px-8">
       <section className="rounded-3xl border border-border bg-gradient-to-br from-bg-card to-bg-surface p-5 sm:p-6">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
           <div>

--- a/frontend/src/pages/PokedexSpecies.jsx
+++ b/frontend/src/pages/PokedexSpecies.jsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react'
+import { flushSync } from 'react-dom'
 import { useQuery } from '@tanstack/react-query'
 import { Link, useLocation, useParams, useSearchParams } from 'react-router-dom'
 import { ArrowLeft, ChevronLeft, ChevronRight, SortAsc } from 'lucide-react'
@@ -70,6 +71,11 @@ export default function PokedexSpecies() {
   const language = settings.language === 'de' ? 'de' : 'en'
   const [cardLanguage, setCardLanguage] = useState('all')
   const [cardSort, setCardSort] = useState('price_asc')
+  const [isReturningToPokedex, setIsReturningToPokedex] = useState(false)
+  const returnToPokedex = () => {
+    flushSync(() => setIsReturningToPokedex(true))
+    goBack()
+  }
   const visibleLanguages = useVisibleTcgdexLanguages()
   const cardLanguageCodes = useMemo(() => [...new Set(
     visibleLanguages
@@ -109,6 +115,10 @@ export default function PokedexSpecies() {
     })
   }, [cardsQuery.data, cardSort, pricePrimaryField])
 
+  if (isReturningToPokedex) {
+    return <div className="fixed inset-0 z-40 bg-bg" aria-hidden="true" />
+  }
+
   if (speciesQuery.isLoading) return <div className="flex justify-center py-20"><PokeBallLoader size={52} /></div>
   if (speciesQuery.isError || !speciesQuery.data) return <p className="p-6 text-brand-red">{t('common.error')}</p>
 
@@ -121,7 +131,7 @@ export default function PokedexSpecies() {
 
   return (
     <div className="mx-auto w-full max-w-7xl space-y-6 px-4 pb-28 pt-2 sm:px-6 lg:px-8">
-      <button type="button" onClick={goBack} className="btn-ghost inline-flex items-center gap-2">
+      <button type="button" onClick={returnToPokedex} className="btn-ghost inline-flex items-center gap-2">
         <ArrowLeft size={16} /> {t('common.back')}
       </button>
 

--- a/frontend/src/pages/Products.jsx
+++ b/frontend/src/pages/Products.jsx
@@ -7,6 +7,7 @@ import {
 import { Plus, Trash2, Edit2, TrendingUp, TrendingDown, Package, Check, X, SortAsc, Filter, ChevronUp, ChevronDown, Link2, DollarSign, History, AlertCircle, Search, ExternalLink } from 'lucide-react'
 import { getProducts, createProductBatch, updateProduct, bulkUpdateProductLifecycle, deleteProduct, getProductsSummary, getCollection, linkProductCards, unlinkProductCard, sellProductCard, addProductLedgerEntry, getApiErrorMessage } from '../api/client'
 import { useSettings } from '../contexts/SettingsContext'
+import { useConfirmDialog } from '../contexts/ConfirmDialogContext'
 import { CardRow } from '../components/card-system'
 import MoneyInput from '../components/MoneyInput'
 import PeriodSelector, { PRODUCT_PERIODS, getPeriodCutoff } from '../components/PeriodSelector'
@@ -737,6 +738,7 @@ function ProductCardsModal({
 
 export default function Products() {
   const { t, formatPrice, pricePrimaryField } = useSettings()
+  const confirmDialog = useConfirmDialog()
   const [creating, setCreating] = useState(false)
   const [editingId, setEditingId] = useState(null)
   const [cardProductId, setCardProductId] = useState(null)
@@ -936,8 +938,14 @@ export default function Products() {
                 <button
                   className="btn-ghost justify-center"
                   disabled={bulkLifecycleMutation.isPending}
-                  onClick={() => {
-                    if (!confirm(t('products.confirmAllOpened').replace('{count}', reviewProducts.length))) return
+                  onClick={async () => {
+                    const confirmed = await confirmDialog({
+                      title: t('products.markAllOpened'),
+                      message: t('products.confirmAllOpened').replace('{count}', reviewProducts.length),
+                      confirmLabel: t('products.markAllOpened'),
+                      destructive: false,
+                    })
+                    if (!confirmed) return
                     bulkLifecycleMutation.mutate({
                       product_ids: reviewProducts.map(product => product.id),
                       lifecycle_status: 'opened',
@@ -949,8 +957,14 @@ export default function Products() {
                 <button
                   className="btn-ghost justify-center"
                   disabled={bulkLifecycleMutation.isPending}
-                  onClick={() => {
-                    if (!confirm(t('products.confirmAllSealed').replace('{count}', reviewProducts.length))) return
+                  onClick={async () => {
+                    const confirmed = await confirmDialog({
+                      title: t('products.markAllSealed'),
+                      message: t('products.confirmAllSealed').replace('{count}', reviewProducts.length),
+                      confirmLabel: t('products.markAllSealed'),
+                      destructive: false,
+                    })
+                    if (!confirmed) return
                     bulkLifecycleMutation.mutate({
                       product_ids: reviewProducts.map(product => product.id),
                       lifecycle_status: 'sealed',
@@ -1274,8 +1288,14 @@ export default function Products() {
                             <button onClick={() => setEditingId(p.id)} className="text-text-muted hover:text-text-primary p-1 transition-colors" aria-label={`${t('common.edit')}: ${p.product_name}`}>
                               <Edit2 size={14} />
                             </button>
-                            <button onClick={() => {
-                              if (confirm(`${t('products.deleteConfirm')} "${p.product_name}"?`)) deleteMutation.mutate(p.id)
+                            <button onClick={async () => {
+                              const confirmed = await confirmDialog({
+                                title: t('common.delete'),
+                                message: `${t('products.deleteConfirm')} "${p.product_name}"?`,
+                                confirmLabel: t('common.delete'),
+                                destructive: true,
+                              })
+                              if (confirmed) deleteMutation.mutate(p.id)
                             }} className="text-text-muted hover:text-brand-red p-1 transition-colors" aria-label={`${t('common.delete')}: ${p.product_name}`}>
                               <Trash2 size={14} />
                             </button>
@@ -1373,8 +1393,14 @@ export default function Products() {
                     </button>
                     <button
                       type="button"
-                      onClick={() => {
-                        if (confirm(`${t('products.deleteConfirm')} "${p.product_name}"?`)) deleteMutation.mutate(p.id)
+                      onClick={async () => {
+                        const confirmed = await confirmDialog({
+                          title: t('common.delete'),
+                          message: `${t('products.deleteConfirm')} "${p.product_name}"?`,
+                          confirmLabel: t('common.delete'),
+                          destructive: true,
+                        })
+                        if (confirmed) deleteMutation.mutate(p.id)
                       }}
                       className="flex h-11 w-11 items-center justify-center rounded-lg text-text-muted transition-colors hover:text-brand-red"
                       aria-label={`${t('common.delete')}: ${p.product_name}`}

--- a/frontend/src/pages/SetDetail.jsx
+++ b/frontend/src/pages/SetDetail.jsx
@@ -1,23 +1,17 @@
-import { useEffect, useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
+import { useRef, useState } from 'react'
+import { createPortal, flushSync } from 'react-dom'
 import { useParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { ArrowLeft, Plus, Trash2, X, Heart, BookMarked, HelpCircle } from 'lucide-react'
-import { getSetChecklist, addToCollection, addToWishlist, updateCollectionItem, removeFromCollection, getBinders, addOwnedSetToBinder, addOwnedSetToAutoBinder } from '../api/client'
+import { ArrowLeft, Plus, X, BookMarked, HelpCircle } from 'lucide-react'
+import { getSetChecklist, getBinders, addOwnedSetToBinder, addOwnedSetToAutoBinder } from '../api/client'
 import { useSettings } from '../contexts/SettingsContext'
 import toast from 'react-hot-toast'
 import clsx from 'clsx'
 import { resolveCardImageUrl, resolveSetImageUrl } from '../utils/imageUrl'
-import { CARD_VARIANTS, getAvailableVariants, getDefaultVariantOrNull } from '../utils/cardVariants'
 import { HOLO_FIELD_MAP } from '../utils/prices'
-import TcgdexLanguageSelect from '../components/TcgdexLanguageSelect'
-import { invalidateCardState, invalidateTcgdexFilterLanguages } from '../utils/queryInvalidation'
-import MoneyInput from '../components/MoneyInput'
-import { parseMoneyInputValue } from '../utils/moneyInput'
 import { useDetailBackNavigation, useScrollToTopOnPush } from '../hooks/useListScrollRestoration'
-import { CardDialog, CardDisplay, CardLegend } from '../components/card-system'
-
-const CONDITIONS = ['Mint', 'NM', 'LP', 'MP', 'HP']
+import { CardDisplay, CardLegend } from '../components/card-system'
+import { CardModal } from '../components/CardItem'
 
 const SET_SORT_OPTIONS = [
   'number',
@@ -83,234 +77,6 @@ function sortSetCards(cards, sortBy, pricePrimaryField) {
   return sorted
 }
 
-function OwnedVersionRow({ item, onQuantityChange, onRemove, isUpdating, isRemoving, t }) {
-  const [quantity, setQuantity] = useState(item.quantity || 1)
-  const [savedQuantity, setSavedQuantity] = useState(item.quantity || 1)
-
-  const commitQuantity = () => {
-    const nextQuantity = Math.max(1, parseInt(quantity, 10) || 1)
-    setQuantity(nextQuantity)
-    if (nextQuantity !== savedQuantity) {
-      setSavedQuantity(nextQuantity)
-      onQuantityChange(item, nextQuantity)
-    }
-  }
-
-  return (
-    <div className="flex items-center gap-2 rounded-xl bg-bg-card border border-border p-2">
-      <div className="flex-1 min-w-0">
-        <p className="text-sm text-text-primary font-medium truncate">
-          {[item.variant || 'Normal', item.condition].filter(Boolean).join(' · ')}
-        </p>
-      </div>
-      <input
-        type="number"
-        min="1"
-        value={quantity}
-        onChange={(e) => setQuantity(e.target.value)}
-        onBlur={commitQuantity}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') e.currentTarget.blur()
-        }}
-        disabled={isUpdating || isRemoving}
-        className="input text-center px-2 py-1.5"
-        style={{ width: '4.25rem', colorScheme: 'dark' }}
-        aria-label={t('card.quantity')}
-        title={t('card.quantity')}
-      />
-      <button
-        onClick={() => onRemove(item)}
-        disabled={isRemoving}
-        className="btn-ghost text-brand-red border-brand-red/30 hover:bg-brand-red/10 px-2 py-1.5"
-        title={t('collection.remove')}
-      >
-        <Trash2 size={14} />
-      </button>
-    </div>
-  )
-}
-
-function SetCardActionModal({ card, setLang, initialTab = 'overview', onClose, onAdd, onAddWishlist, onQuantityChange, onRemove, isAdding, isAddingWishlist, isUpdatingQuantity, isRemoving, t }) {
-  const { exchangeRate, exchangeRateReady, formatPrice, pricePrimaryField } = useSettings()
-  const [addQuantity, setAddQuantity] = useState(1)
-  const [addCondition, setAddCondition] = useState('NM')
-  const [addVariant, setAddVariant] = useState('Normal')
-  const [addLang, setAddLang] = useState(setLang)
-  const [addPrice, setAddPrice] = useState('')
-  const [activeTab, setActiveTab] = useState(initialTab)
-
-  useEffect(() => {
-    if (!card) return
-    setAddQuantity(1)
-    setAddCondition('NM')
-    setAddVariant(getDefaultVariantOrNull(card))
-    setAddLang(setLang)
-    setAddPrice('')
-    setActiveTab(initialTab)
-  }, [card, initialTab, setLang])
-
-  if (!card) return null
-  const availableVariants = getAvailableVariants(card)
-  const variants = availableVariants.length > 0 ? availableVariants : CARD_VARIANTS
-  const ownedItems = card.owned_items || []
-  const marketPrice = setSortPrice(card, pricePrimaryField)
-  const tabs = [
-    { id: 'overview', label: t('cardTabs.overview') },
-    { id: 'prices', label: t('cardTabs.prices') },
-    ...(ownedItems.length > 0 ? [{ id: 'owned', label: t('cardTabs.owned') }] : []),
-    { id: 'add', label: t('cardTabs.add') },
-    { id: 'wishlist', label: t('cardTabs.wishlist') },
-  ]
-
-  const submitAddVersion = (event) => {
-    event.preventDefault()
-    if (!exchangeRateReady) return
-    onAdd({
-      card,
-      quantity: Math.max(1, parseInt(addQuantity, 10) || 1),
-      condition: addCondition,
-      variant: addVariant,
-      lang: addLang,
-      purchase_price: parseMoneyInputValue(addPrice, exchangeRate),
-    })
-  }
-
-  return (
-    <CardDialog
-      card={card}
-      image={resolveCardImageUrl(card)}
-      price={marketPrice > 0 ? formatPrice(marketPrice) : null}
-      tabs={tabs}
-      activeTab={activeTab}
-      onTabChange={setActiveTab}
-      onClose={onClose}
-    >
-      {activeTab === 'overview' && (
-        <div className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-3">
-          {[
-            [t('card.rarity'), card.rarity],
-            [t('card.type'), card.supertype],
-            [t('card.hp'), card.hp],
-            [t('card.artist'), card.artist],
-            [t('lang.selectLabel'), setLang.toUpperCase()],
-          ].filter(([, value]) => value).map(([label, value]) => (
-            <div key={label} className="rounded-xl border border-border bg-bg-card p-3">
-              <p className="text-xs text-text-muted">{label}</p>
-              <p className="mt-1 text-sm font-bold text-text-primary">{value}</p>
-            </div>
-          ))}
-        </div>
-      )}
-
-      {activeTab === 'prices' && (
-        <div className="rounded-xl border border-border bg-bg-card p-4">
-          <p className="text-xs font-bold uppercase tracking-wide text-text-muted">{t('collection.marketPrice')}</p>
-          <p className="mt-2 text-2xl font-black text-green">{marketPrice > 0 ? formatPrice(marketPrice) : '—'}</p>
-        </div>
-      )}
-
-      {activeTab === 'add' && (
-        <form onSubmit={submitAddVersion} className="space-y-3 rounded-xl border border-brand-red/30 bg-bg-card p-3">
-              <p className="text-xs font-semibold text-text-muted mb-2 uppercase tracking-wide">{t('setDetail.addVersion')}</p>
-              <p className="text-xs text-text-secondary -mt-1">{t('collection.addAnotherVersionHelp')}</p>
-
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <label className="text-xs text-text-muted mb-1 block">{t('card.quantity')}</label>
-                  <input
-                    type="number"
-                    min="1"
-                    value={addQuantity}
-                    onChange={(e) => setAddQuantity(e.target.value)}
-                    className="input"
-                  />
-                </div>
-                <div>
-                  <label className="text-xs text-text-muted mb-1 block">{t('card.condition')}</label>
-                  <select value={addCondition} onChange={(e) => setAddCondition(e.target.value)} className="select">
-                    {CONDITIONS.map(condition => <option key={condition} value={condition}>{condition}</option>)}
-                  </select>
-                </div>
-              </div>
-
-              <div>
-                <label className="text-xs text-text-muted mb-1 block">✨ {t('card.variant')}</label>
-                <select value={addVariant} onChange={(e) => setAddVariant(e.target.value)} className="select">
-                  {variants.map(variant => <option key={variant} value={variant}>{variant}</option>)}
-                </select>
-              </div>
-
-              <div>
-                <label className="text-xs text-text-muted mb-1.5 block">🌐 {t('lang.selectLabel')}</label>
-                <TcgdexLanguageSelect value={addLang} onChange={setAddLang} className="select w-full" />
-              </div>
-
-              <div>
-                <label className="text-xs text-text-muted mb-1 block">{t('card.purchasePrice')}</label>
-                <MoneyInput
-                  placeholder={t('card.purchasePricePlaceholder')}
-                  value={addPrice}
-                  onChange={(e) => setAddPrice(e.target.value)}
-                />
-              </div>
-
-              <div>
-                <button type="submit" disabled={isAdding || !exchangeRateReady} className="btn-primary justify-center">
-                  <Plus size={14} /> {isAdding ? t('card.adding') : t('collection.addVersionToCollection')}
-                </button>
-              </div>
-        </form>
-      )}
-
-      {activeTab === 'wishlist' && (
-        <div className="space-y-3 rounded-xl border border-border bg-bg-card p-4">
-          <label className="block">
-            <span className="mb-1 block text-xs text-text-muted">{t('card.quantity')}</span>
-            <input
-              type="number"
-              min="1"
-              max="99"
-              value={addQuantity}
-              onChange={(event) => setAddQuantity(event.target.value)}
-              className="input"
-            />
-          </label>
-          <button
-            type="button"
-            disabled={isAddingWishlist}
-            className="btn-primary w-full justify-center"
-            onClick={() => onAddWishlist({
-              card,
-              quantity: Math.max(1, Math.min(99, parseInt(addQuantity, 10) || 1)),
-            })}
-          >
-            <Heart size={14} /> {t('binderTypes.addToWishlist')}
-          </button>
-        </div>
-      )}
-
-      {activeTab === 'owned' && ownedItems.length > 0 && (
-        <div>
-          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-muted">{t('setDetail.ownedVersions')}</p>
-          <div className="space-y-2">
-            {ownedItems.map(item => (
-              <OwnedVersionRow
-                key={item.id}
-                item={item}
-                onQuantityChange={onQuantityChange}
-                onRemove={onRemove}
-                isUpdating={isUpdatingQuantity}
-                isRemoving={isRemoving}
-                t={t}
-              />
-            ))}
-          </div>
-        </div>
-      )}
-    </CardDialog>
-  )
-}
-
 export default function SetDetail() {
   const { setId } = useParams()
   const goBack = useDetailBackNavigation('sets', '/sets')
@@ -321,9 +87,15 @@ export default function SetDetail() {
   const [sortBy, setSortBy] = useState('number')
   const [rarityFilter, setRarityFilter] = useState('all')
   const [selectedCard, setSelectedCard] = useState(null)
-  const [selectedCardTab, setSelectedCardTab] = useState('overview')
+  const [selectedCardTab, setSelectedCardTab] = useState('add')
   const [binderPickerOpen, setBinderPickerOpen] = useState(false)
   const [badgeLegendOpen, setBadgeLegendOpen] = useState(false)
+  const [isReturningToSets, setIsReturningToSets] = useState(false)
+
+  const returnToSets = () => {
+    flushSync(() => setIsReturningToSets(true))
+    goBack()
+  }
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['set-checklist', setId],
@@ -331,59 +103,6 @@ export default function SetDetail() {
   })
 
   const setLang = data?.set?.lang || 'en'
-
-  const addMutation = useMutation({
-    mutationFn: ({ card, quantity = 1, condition = 'NM', variant, lang = setLang, purchase_price }) => addToCollection({
-      card_id: card.id,
-      quantity,
-      condition,
-      variant: variant === undefined ? getDefaultVariantOrNull(card) : variant,
-      lang,
-      purchase_price,
-    }),
-    onSuccess: () => {
-      toast.success(t('card.addedToCollection'))
-      invalidateCardState(queryClient, { setId })
-      invalidateTcgdexFilterLanguages(queryClient)
-      setSelectedCard(null)
-    },
-    onError: () => toast.error(t('card.addFailed')),
-  })
-
-  const wishlistMutation = useMutation({
-    mutationFn: ({ card, quantity = 1 }) => addToWishlist({
-      card_id: card.id,
-      quantity,
-    }),
-    onSuccess: () => {
-      toast.success(t('card.addedToWishlist'))
-      invalidateCardState(queryClient, { setId })
-      invalidateTcgdexFilterLanguages(queryClient)
-      setSelectedCard(null)
-    },
-    onError: () => toast.error(t('card.wishlistFailed')),
-  })
-
-  const removeMutation = useMutation({
-    mutationFn: (item) => removeFromCollection(item.id),
-    onSuccess: () => {
-      toast.success(t('collection.removed'))
-      invalidateCardState(queryClient, { setId })
-      invalidateTcgdexFilterLanguages(queryClient)
-      setSelectedCard(null)
-    },
-    onError: () => toast.error(t('collection.removeFailed')),
-  })
-
-  const quantityMutation = useMutation({
-    mutationFn: ({ item, quantity }) => updateCollectionItem(item.id, { quantity }),
-    onSuccess: () => {
-      toast.success(t('collection.updated'))
-      invalidateCardState(queryClient, { setId })
-      invalidateTcgdexFilterLanguages(queryClient)
-    },
-    onError: () => toast.error(t('collection.updateFailed')),
-  })
 
   const bindersQuery = useQuery({
     queryKey: ['binders'],
@@ -417,6 +136,10 @@ export default function SetDetail() {
     addOwnedMutation.mutate(args)
   }
 
+  if (isReturningToSets) {
+    return <div className="fixed inset-0 z-40 bg-bg" aria-hidden="true" />
+  }
+
   if (isLoading) {
     return (
       <div className="space-y-4">
@@ -433,7 +156,7 @@ export default function SetDetail() {
     return (
       <div className="card text-center py-12">
         <p className="text-brand-red">{t('setDetail.loadFailed')} {error.message}</p>
-        <button onClick={goBack} className="btn-ghost mt-4 mx-auto">
+        <button onClick={returnToSets} className="btn-ghost mt-4 mx-auto">
           <ArrowLeft size={16} /> {t('setDetail.goBack')}
         </button>
       </div>
@@ -458,7 +181,7 @@ export default function SetDetail() {
 
   return (
     <div className="space-y-4 pb-2">
-      <button onClick={goBack} className="btn-ghost text-sm py-1.5">
+      <button onClick={returnToSets} className="btn-ghost text-sm py-1.5">
         <ArrowLeft size={14} /> {t('nav.sets')}
       </button>
 
@@ -605,7 +328,7 @@ export default function SetDetail() {
             price={setSortPrice(card, pricePrimaryField) > 0 ? formatPrice(setSortPrice(card, pricePrimaryField)) : null}
             dimWhenUnowned
             onClick={() => {
-              setSelectedCardTab('overview')
+              setSelectedCardTab('add')
               setSelectedCard(card)
             }}
             onAdd={() => {
@@ -616,21 +339,13 @@ export default function SetDetail() {
         ))}
       </div>
 
-      <SetCardActionModal
+      {selectedCard && <CardModal
+        key={selectedCard.id}
         card={selectedCard}
-        setLang={setLang}
+        defaultLang={setLang}
         initialTab={selectedCardTab}
         onClose={() => setSelectedCard(null)}
-        onAdd={(payload) => addMutation.mutate(payload)}
-        onAddWishlist={(payload) => wishlistMutation.mutate(payload)}
-        onQuantityChange={(item, quantity) => quantityMutation.mutate({ item, quantity })}
-        onRemove={(item) => removeMutation.mutate(item)}
-        isAdding={addMutation.isPending}
-        isAddingWishlist={wishlistMutation.isPending}
-        isUpdatingQuantity={quantityMutation.isPending}
-        isRemoving={removeMutation.isPending}
-        t={t}
-      />
+      />}
 
       {binderPickerOpen && createPortal(
         <div

--- a/frontend/src/pages/Sets.jsx
+++ b/frontend/src/pages/Sets.jsx
@@ -9,7 +9,7 @@ import { resolveSetImageUrl } from '../utils/imageUrl'
 import TcgdexLanguageSelect from '../components/TcgdexLanguageSelect'
 import { useVisibleTcgdexLanguages } from '../hooks/useVisibleTcgdexLanguages'
 import { normalizeTcgdexLanguage, tcgdexLanguageBadgeClass, tcgdexLanguageLabel } from '../utils/tcgdexLanguages'
-import { textIncludes } from '../utils/textSearch'
+import { setMatchesSearch } from '../utils/textSearch'
 import { getSavedListScrollPosition, isSavedPositionForLocation, useListScrollRestoration } from '../hooks/useListScrollRestoration'
 
 const DEFAULT_SET_FILTERS = {
@@ -197,7 +197,7 @@ export default function Sets() {
   const filtered = useMemo(() => {
     let result = sets.filter(s => {
       if (!showHiddenSets && hiddenSetIdSet.has(String(s.id))) return false
-      if (search && !textIncludes(s.name, search)) return false
+      if (search && !setMatchesSearch(s, search)) return false
       if (series && s.series !== series) return false
       const owned = s.owned_count ?? 0
       const total = s.total ?? 0
@@ -249,7 +249,7 @@ export default function Sets() {
   const hasActiveFilters = search || series || sortBy !== DEFAULT_SET_FILTERS.sortBy || sortOrder !== DEFAULT_SET_FILTERS.sortOrder || progressFilter !== DEFAULT_SET_FILTERS.progressFilter || langFilter !== DEFAULT_SET_FILTERS.langFilter || showHiddenSets !== DEFAULT_SET_FILTERS.showHiddenSets
 
   return (
-    <div className="space-y-4 pb-2">
+    <div data-scroll-list="sets" className="space-y-4 pb-2">
 
       {/* ─── Header ───────────────────────────────────────────────── */}
       <div className="flex items-center justify-between gap-2 mb-4 flex-wrap">

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -14,6 +14,7 @@ import api from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
 import { useTheme } from '../hooks/useTheme'
 import { useSettings } from '../contexts/SettingsContext'
+import { useConfirmDialog } from '../contexts/ConfirmDialogContext'
 import Modal from '../components/ui/Modal'
 import AvatarPicker from '../components/AvatarPicker'
 import { formatDistanceToNow } from 'date-fns'
@@ -309,6 +310,7 @@ export default function Settings() {
   const navigate = useNavigate()
   const { user, updateCurrentUser, multiUser } = useAuth()
   const { settings, updateSettings, t, pricePrimaryField, exchangeRate } = useSettings()
+  const confirmDialog = useConfirmDialog()
   const publicProfilesEnabled = settings.public_profiles_enabled === 'true'
   const { theme, setTheme, themes } = useTheme()
   const [activeTab, setActiveTab] = useState('general')
@@ -617,7 +619,13 @@ export default function Settings() {
   }
 
   const handleDeleteScanDiagnostics = async () => {
-    if (!window.confirm(t('settings.scanDiagnosticsDeleteConfirm'))) return
+    const confirmed = await confirmDialog({
+      title: t('common.delete'),
+      message: t('settings.scanDiagnosticsDeleteConfirm'),
+      confirmLabel: t('common.delete'),
+      destructive: true,
+    })
+    if (!confirmed) return
     setScanDiagnosticsDeleting(true)
     try {
       await deleteScanDiagnostics()
@@ -656,7 +664,16 @@ export default function Settings() {
       toast.error(t('settings.selectSql'))
       return
     }
-    if (!confirm(t('settings.restoreConfirm'))) return
+    const confirmed = await confirmDialog({
+      title: t('common.restore'),
+      message: t('settings.restoreConfirm'),
+      confirmLabel: t('common.restore'),
+      destructive: true,
+    })
+    if (!confirmed) {
+      e.target.value = ''
+      return
+    }
 
     setRestoring(true)
     try {
@@ -1227,7 +1244,13 @@ export default function Settings() {
               <SettingsRow label={t('settings.clearImageCache')} description={t('settings.clearImageCacheDesc')}>
                 <button
                   onClick={async () => {
-                    if (!confirm(t('settings.clearImageCacheConfirm'))) return
+                    const confirmed = await confirmDialog({
+                      title: t('settings.clearImageCache'),
+                      message: t('settings.clearImageCacheConfirm'),
+                      confirmLabel: t('common.clear'),
+                      destructive: true,
+                    })
+                    if (!confirmed) return
                     try {
                       await api.post('/backup/clear-image-cache')
                       toast.success(t('settings.clearImageCacheSuccess'))
@@ -1491,6 +1514,7 @@ export default function Settings() {
 }
 
 function UsersTab({ t, queryClient }) {
+  const confirmDialog = useConfirmDialog()
   const [showModal, setShowModal] = useState(false)
   const [editingUser, setEditingUser] = useState(null)
   const [formUsername, setFormUsername] = useState('')
@@ -1578,7 +1602,15 @@ function UsersTab({ t, queryClient }) {
                   </button>
                   <button onClick={() => openEdit(u)} className="text-text-muted hover:text-text-primary"><Pencil size={15} /></button>
                   {u.id !== currentUser?.id && (
-                    <button onClick={() => { if (window.confirm(t('settings.users.deleteConfirm'))) deleteMut.mutate(u.id) }} className="text-text-muted hover:text-brand-red"><Trash2 size={15} /></button>
+                    <button onClick={async () => {
+                      const confirmed = await confirmDialog({
+                        title: t('common.delete'),
+                        message: t('settings.users.deleteConfirm'),
+                        confirmLabel: t('common.delete'),
+                        destructive: true,
+                      })
+                      if (confirmed) deleteMut.mutate(u.id)
+                    }} className="text-text-muted hover:text-brand-red"><Trash2 size={15} /></button>
                   )}
                 </div>
               </SettingsRow>

--- a/frontend/src/pages/Wishlist.jsx
+++ b/frontend/src/pages/Wishlist.jsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Trash2, Edit2, Check, X, Heart, Filter, SortAsc, ChevronUp, ChevronDown, Library, BookOpen, Minus, Plus } from 'lucide-react'
 import { getWishlist, removeFromWishlist, updateWishlistItem, addToCollection } from '../api/client'
 import { useSettings } from '../contexts/SettingsContext'
+import { useConfirmDialog } from '../contexts/ConfirmDialogContext'
 import { CardDialog, CardIdentity, CardRow, getCardSetNumber } from '../components/card-system'
 import TabNav from '../components/TabNav'
 import toast from 'react-hot-toast'
@@ -126,6 +127,7 @@ function WishlistCardModal({ item, onClose, onAddToCollection, onRemove }) {
 
 export default function Wishlist() {
   const { t, formatPrice, pricePrimaryField } = useSettings()
+  const confirmDialog = useConfirmDialog()
   const [editingId, setEditingId] = useState(null)
   const [selectedItem, setSelectedItem] = useState(null)
   const [sortBy, setSortBy] = useState('created_at')
@@ -414,8 +416,14 @@ export default function Wishlist() {
                                 className="text-text-muted hover:text-green transition-colors p-1" title={t('wishlist.addToCollection')}>
                                 <Check size={14} />
                               </button>
-                              <button onClick={() => {
-                                if (confirm(`${card?.name} ${t('wishlist.removeConfirm')}`)) removeMutation.mutate(item.id)
+                              <button onClick={async () => {
+                                const confirmed = await confirmDialog({
+                                  title: t('common.remove'),
+                                  message: `${card?.name} ${t('wishlist.removeConfirm')}`,
+                                  confirmLabel: t('common.remove'),
+                                  destructive: true,
+                                })
+                                if (confirmed) removeMutation.mutate(item.id)
                               }} className="text-text-muted hover:text-brand-red transition-colors p-1">
                                 <Trash2 size={14} />
                               </button>
@@ -473,9 +481,15 @@ export default function Wishlist() {
                             className="text-text-muted hover:text-green transition-colors p-1" title={t('wishlist.addToCollection')}>
                             <Check size={12} />
                           </button>
-                          <button onClick={(e) => {
+                          <button onClick={async (e) => {
                             e.stopPropagation()
-                            if (confirm(`${card?.name} ${t('wishlist.removeConfirm')}`)) removeMutation.mutate(item.id)
+                            const confirmed = await confirmDialog({
+                              title: t('common.remove'),
+                              message: `${card?.name} ${t('wishlist.removeConfirm')}`,
+                              confirmLabel: t('common.remove'),
+                              destructive: true,
+                            })
+                            if (confirmed) removeMutation.mutate(item.id)
                           }} className="text-text-muted hover:text-brand-red transition-colors p-1">
                             <Trash2 size={12} />
                           </button>
@@ -494,8 +508,14 @@ export default function Wishlist() {
           item={selectedItem}
           onClose={() => setSelectedItem(null)}
           onAddToCollection={(cardId) => addToColMutation.mutate(cardId)}
-          onRemove={(item) => {
-            if (confirm(`${item.card?.name} ${t('wishlist.removeConfirm')}`)) {
+          onRemove={async (item) => {
+            const confirmed = await confirmDialog({
+              title: t('common.remove'),
+              message: `${item.card?.name} ${t('wishlist.removeConfirm')}`,
+              confirmLabel: t('common.remove'),
+              destructive: true,
+            })
+            if (confirmed) {
               removeMutation.mutate(item.id)
               setSelectedItem(null)
             }

--- a/frontend/src/utils/cardVariants.js
+++ b/frontend/src/utils/cardVariants.js
@@ -18,16 +18,50 @@ export const VARIANT_PILL_META = Object.fromEntries(
   VARIANT_DEFINITIONS.map(({ name, code, className }) => [name, { code, className }])
 )
 
+const hasPositivePrice = (card, fields) => fields.some(field => {
+  const value = Number(card?.[field])
+  return Number.isFinite(value) && value > 0
+})
+
+// TCGdex occasionally publishes variant flags that contradict its own pricing
+// payload. Price rows are strong evidence that the corresponding physical print
+// exists, so include them without waiting for a later catalogue refresh.
+export const hasVariantPriceEvidence = (card, variant) => {
+  if (variant === 'Normal') {
+    return hasPositivePrice(card, [
+      'price_tcg_normal_low',
+      'price_tcg_normal_mid',
+      'price_tcg_normal_high',
+      'price_tcg_normal_market',
+    ])
+  }
+  if (variant === 'Reverse Holo') {
+    return hasPositivePrice(card, [
+      'price_tcg_reverse_low',
+      'price_tcg_reverse_mid',
+      'price_tcg_reverse_market',
+    ])
+  }
+  if (variant === 'Holo') {
+    return hasPositivePrice(card, [
+      'price_tcg_holo_low',
+      'price_tcg_holo_mid',
+      'price_tcg_holo_market',
+    ])
+  }
+  return false
+}
+
 export const getAvailableVariants = (card) => [
-  card?.variants_normal && 'Normal',
-  card?.variants_reverse && 'Reverse Holo',
-  card?.variants_holo && 'Holo',
+  (card?.variants_normal || hasVariantPriceEvidence(card, 'Normal')) && 'Normal',
+  (card?.variants_reverse || hasVariantPriceEvidence(card, 'Reverse Holo')) && 'Reverse Holo',
+  (card?.variants_holo || hasVariantPriceEvidence(card, 'Holo')) && 'Holo',
   card?.variants_first_edition && 'First Edition',
 ].filter(Boolean)
 
 export const getDefaultVariant = (card) => {
   // Normal availability means the safest default is the plain/non-holo card.
-  if (card?.variants_normal) return 'Normal'
+  if (card?.variants_normal || hasVariantPriceEvidence(card, 'Normal')) return 'Normal'
   const available = getAvailableVariants(card)
   // If there is no Normal print, default to a real advertised variant instead
   // of creating an impossible Normal collection row.

--- a/frontend/src/utils/cardVariants.test.js
+++ b/frontend/src/utils/cardVariants.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getOwnedVariants } from './cardVariants'
+import { getAvailableVariants, getOwnedVariants } from './cardVariants'
 
 const row = (over = {}) => ({
   id: 1, card_id: 'sv01-003_en', card: { id: 'sv01-003_en', name: 'Card' },
@@ -86,6 +86,27 @@ describe('getOwnedVariants', () => {
 
   it('returns an empty array for no rows', () => {
     expect(getOwnedVariants([])).toEqual([])
+  })
+})
+
+describe('getAvailableVariants', () => {
+  it('uses TCGplayer pricing as evidence when TCGdex flags contradict it', () => {
+    expect(getAvailableVariants({
+      variants_normal: true,
+      variants_reverse: false,
+      variants_holo: false,
+      price_tcg_reverse_market: 0.22,
+      price_tcg_holo_market: 0.41,
+    })).toEqual(['Normal', 'Reverse Holo', 'Holo'])
+  })
+
+  it('does not infer a variant from missing or zero prices', () => {
+    expect(getAvailableVariants({
+      variants_normal: false,
+      variants_reverse: false,
+      variants_holo: false,
+      price_tcg_reverse_market: 0,
+    })).toEqual([])
   })
 })
 

--- a/frontend/src/utils/portfolioChart.js
+++ b/frontend/src/utils/portfolioChart.js
@@ -1,0 +1,30 @@
+import { format, parseISO } from 'date-fns'
+
+export const PORTFOLIO_PERIODS = [
+  { key: '1W', label: '1W', apiPeriod: '1w' },
+  { key: '1M', label: '1M', apiPeriod: '1m' },
+  { key: '1Y', label: '1Y', apiPeriod: '1y' },
+  { key: 'MAX', label: 'Max', apiPeriod: 'max' },
+]
+
+export const portfolioApiPeriod = (period) => (
+  PORTFOLIO_PERIODS.find(option => option.key === period)?.apiPeriod || 'max'
+)
+
+export function mapPortfolioChartData(data, period, legacyLabel) {
+  const formatByPeriod = { '1W': 'EEE dd.MM', '1Y': 'MMM yy', 'MAX': 'MMM yy' }
+  const dateFormat = formatByPeriod[period] || 'dd.MM.'
+
+  return (data || []).map(snapshot => {
+    const snapshotDate = parseISO(snapshot.date)
+    return {
+      ...snapshot,
+      date: format(snapshotDate, dateFormat),
+      tooltipLabel: period === '1W'
+        ? format(snapshotDate, 'EEE dd.MM HH:mm')
+        : format(snapshotDate, dateFormat),
+      legacy: Boolean(snapshot.legacy),
+      legacyLabel,
+    }
+  })
+}

--- a/frontend/src/utils/portfolioChart.test.js
+++ b/frontend/src/utils/portfolioChart.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { mapPortfolioChartData, portfolioApiPeriod } from './portfolioChart'
+
+describe('portfolio chart helpers', () => {
+  it.each([
+    ['1W', '1w'],
+    ['1M', '1m'],
+    ['1Y', '1y'],
+    ['MAX', 'max'],
+    ['unknown', 'max'],
+  ])('maps %s to the analytics period %s', (period, expected) => {
+    expect(portfolioApiPeriod(period)).toBe(expected)
+  })
+
+  it('keeps intraday snapshots distinguishable in the weekly tooltip', () => {
+    const snapshots = [
+      { date: '2026-08-10T08:00:00Z', value: 10, cost: 5 },
+      { date: '2026-08-10T12:00:00Z', value: 12, cost: 5 },
+    ]
+
+    const result = mapPortfolioChartData(snapshots, '1W', 'Legacy')
+
+    expect(result).toHaveLength(2)
+    expect(result[0].tooltipLabel).not.toBe(result[1].tooltipLabel)
+    expect(result.map(point => point.value)).toEqual([10, 12])
+  })
+
+  it('uses compact month labels for long periods and retains snapshot metadata', () => {
+    const result = mapPortfolioChartData([
+      { date: '2025-04-01', value: 25, cost: 20, legacy: true },
+    ], '1Y', 'Imported snapshot')
+
+    expect(result[0]).toMatchObject({
+      date: 'Apr 25',
+      tooltipLabel: 'Apr 25',
+      value: 25,
+      cost: 20,
+      legacy: true,
+      legacyLabel: 'Imported snapshot',
+    })
+  })
+})

--- a/frontend/src/utils/textSearch.js
+++ b/frontend/src/utils/textSearch.js
@@ -13,3 +13,9 @@ export function textIncludes(value, query) {
   if (!normalizedQuery) return true
   return normalizeSearchText(value).includes(normalizedQuery)
 }
+
+export function setMatchesSearch(set, query) {
+  if (!normalizeSearchText(query)) return true
+  return [set?.name, set?.abbreviation, set?.tcg_set_id, set?.id]
+    .some(value => textIncludes(value, query))
+}

--- a/frontend/src/utils/textSearch.test.js
+++ b/frontend/src/utils/textSearch.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { setMatchesSearch } from './textSearch'
+
+const set = {
+  id: 'me04_de',
+  tcg_set_id: 'me04',
+  name: 'Wachsendes Chaos',
+  abbreviation: 'CRI',
+}
+
+describe('setMatchesSearch', () => {
+  it('matches a localized set name', () => {
+    expect(setMatchesSearch(set, 'wachsendes')).toBe(true)
+  })
+
+  it('matches the official abbreviation case-insensitively', () => {
+    expect(setMatchesSearch(set, 'cri')).toBe(true)
+  })
+
+  it('matches the TCGdex set ID and composite database ID', () => {
+    expect(setMatchesSearch(set, 'me04')).toBe(true)
+    expect(setMatchesSearch(set, 'me04_de')).toBe(true)
+  })
+
+  it('rejects unrelated searches', () => {
+    expect(setMatchesSearch(set, 'sv01')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- make card taps open the add-to-collection workflow consistently on mobile and desktop, including Card Search and Set Detail
- give Card Search the same editable owned-copy quantity and removal controls as Set Detail
- infer selectable Normal, Holo, and Reverse Holo variants from positive TCGplayer prices when TCGdex flags contradict its pricing data
- allow set searches by localized name, abbreviation such as `CRI`, and TCGdex set ID
- restore Sets and Pokédex scroll positions before their lists become interactive, while preventing detail-page flashes when returning
- add `1W`, `1M`, `1Y`, and `Max` periods to the Dashboard portfolio chart and keep axis labels readable
- correct the German binder action to `Karten hinzufügen`
- replace the remaining native browser confirmations with the shared styled confirmation dialog
- preserve the custom-card ownership and copy-only shared-template behavior from #349

## Validation

- backend: 510 tests passed, 8 skipped
- frontend: 28 files and 190 tests passed
- translation-key check passed
- production frontend and backend Docker builds passed
- local PostgreSQL and mobile Chromium smoke testing passed
- verified foreign shared template Overview -> copy -> collection uses the independent clone ID
- verified Set and Pokédex return navigation, scroll restoration, confirmations, chart periods, card variants, and card entry flows locally
- completed a fresh isolated reviewer pass; all blocking findings were fixed and the final recommendation is ready
