### PR TITLE
Add Yulemanden to supporters

### DIFF
--- a/SUPPORTERS.csv
+++ b/SUPPORTERS.csv
@@ -1,3 +1,4 @@
 date,name,amount,currency,url
 2026-05-29,scoutante112,1,EUR,https://github.com/scoutante112
 2026-05-29,f0rr3stfunk,10,EUR,https://github.com/f0rr3stfunk
+2026-08-13,Yulemanden,10,EUR,https://loops.video/@Yulemanden


### PR DESCRIPTION
## Summary
- record Yulemanden's €10 donation in the supporters list
- link the supporter entry to the profile supplied with the donation

## Validation
- all 8 supporter parser tests passed
- parsed the actual CSV and verified the name, €10 EUR amount, donation count, date, and profile URL
- profile URL returns HTTP 200
- version remains 1.38.1; no version files changed
- fresh isolated reviewer pass completed