### PR TITLE
Fall back to the synced catalogue when the remote one is unreachable

### DIFF
--- a/backend/api/recognize.py
+++ b/backend/api/recognize.py
@@ -32,7 +32,7 @@ from services.scan_providers import (
 )
 import logging
 from fastapi import APIRouter, UploadFile, File, HTTPException, Depends
-from sqlalchemy import or_
+from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
 from api.auth import get_current_user
 from database import get_db
@@ -794,29 +794,60 @@ def _local_catalogue_candidates(db, card_info, search_pairs) -> list:
     entries, and matching a scan against one would invent a result the live
     search could never have produced.
     """
-    names = []
-    for _language, search_name in search_pairs:
-        if search_name and search_name not in names:
-            names.append(search_name)
-    if not names:
+    # Each pair is searched as a pair. Splitting them into a list of names and
+    # a list of languages would admit their product, so a name only ever
+    # searched in English could match a row in another language. That is not
+    # hypothetical: swsh2-201 is Milo in English and Yarrow in Italian, while
+    # swsh7-201 is Milo in Italian, all numbered 201, so an Italian scan of
+    # Yarrow would admit an unrelated Italian Milo through the English name.
+    pairs = []
+    for language, search_name in search_pairs:
+        if search_name and (language, search_name) not in pairs:
+            pairs.append((language, search_name))
+    if not pairs:
         return []
 
-    languages = []
-    for language, _search_name in search_pairs:
-        if language not in languages:
-            languages.append(language)
-
-    rows = (
+    query = (
         db.query(Card)
         .filter(
             Card.tcg_card_id.isnot(None),
-            Card.is_custom.is_(False),
-            or_(*[Card.name.ilike(name) for name in names]),
-            Card.lang.in_(languages),
+            # is_custom is nullable, and the card-id migration in database.py
+            # already treats "NULL or false" as catalogue data. A synced row
+            # left NULL must not be invisible here.
+            Card.is_custom.isnot(True),
+            or_(*[
+                and_(Card.lang == language, Card.name.ilike(search_name))
+                for language, search_name in pairs
+            ]),
         )
-        .limit(60)
-        .all()
     )
+
+    # Ordered so the row set is deterministic. An unordered LIMIT in
+    # PostgreSQL may return a different subset each time, and the truncation
+    # below has to be applied to a stable set for the narrowing to mean
+    # anything.
+    rows = query.order_by(
+        Card.lang.asc(), Card.set_id.asc(), Card.number.asc(), Card.id.asc()
+    ).limit(500).all()
+
+    # Narrow on the printed collector number BEFORE truncating. Truncating
+    # first could drop the right printing while leaving a different card of the
+    # same name, which the ranker then reads as a unique number and marks
+    # confident: a wrong card filed automatically by "add all confident", which
+    # is worse than no match at all. The same normaliser the live search uses,
+    # so the two cannot drift apart on what counts as the same number.
+    target_number = normalize_scanner_card_number(card_info.get("number_local"))
+    if target_number:
+        # No fallback to the unnarrowed rows when nothing matches. The live
+        # search can safely return same-name results because it is searching
+        # the whole catalogue; this is a partial local copy, and a lone
+        # same-name row of the wrong number is precisely what the ranker reads
+        # as a unique number and marks confident.
+        rows = [
+            row for row in rows
+            if normalize_scanner_card_number(row.number) == target_number
+        ]
+    rows = rows[:60]
 
     set_names = {}
     set_ids = {row.set_id for row in rows if row.set_id}
@@ -929,7 +960,7 @@ async def _search_and_rank_candidates(
             unreachable += 1
             continue
 
-    if not candidates and unreachable:
+    if not candidates and attempted and unreachable == attempted:
         # The catalogue is unreachable, but this installation already holds a
         # synced copy of it. Searching that is not as good as a live lookup, it
         # only knows the sets that have been synced, but it is far better than

--- a/backend/api/recognize.py
+++ b/backend/api/recognize.py
@@ -809,6 +809,8 @@ async def _search_and_rank_candidates(
             search_pairs.append(("en", card_name_en))
 
     candidates = []
+    attempted = 0
+    unreachable = 0
     for search_language, search_name in search_pairs:
         if len(candidates) >= 15:
             break
@@ -818,6 +820,11 @@ async def _search_and_rank_candidates(
                     f"https://api.tcgdex.net/v2/{search_language}/cards",
                     params={"name": search_name},
                 )
+            attempted += 1
+            # A 5xx is the catalogue failing, not an answer. A 4xx is an answer
+            # we should not retry forever, so it is not counted as unreachable.
+            if response.status_code >= 500:
+                unreachable += 1
             cards = response.json() if response.status_code == 200 else []
             if trace:
                 trace.record_tcgdex(
@@ -859,7 +866,23 @@ async def _search_and_rank_candidates(
                     count=None,
                     error=type(exc).__name__,
                 )
+            attempted += 1
+            unreachable += 1
             continue
+
+    if not candidates and attempted and unreachable == attempted:
+        # Every lookup failed to reach the catalogue, so we do not know whether
+        # this card exists. Saying "no matches" here is a lie that looks like a
+        # missing card, and it sent at least one user hunting through their own
+        # install during an upstream outage. A 503 is retried with backoff, so
+        # the scan recovers on its own once the catalogue is reachable again.
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "The card catalogue could not be reached, so this photo has not "
+                "been matched yet. It will be retried automatically."
+            ),
+        )
 
     candidate_set_ids = {
         tcg_card_id.rsplit("-", 1)[0]

--- a/backend/api/recognize.py
+++ b/backend/api/recognize.py
@@ -32,6 +32,7 @@ from services.scan_providers import (
 )
 import logging
 from fastapi import APIRouter, UploadFile, File, HTTPException, Depends
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 from api.auth import get_current_user
 from database import get_db
@@ -785,6 +786,63 @@ async def _fill_candidate_details(
         await asyncio.gather(*(fetch(card) for card in missing))
 
 
+def _local_catalogue_candidates(db, card_info, search_pairs) -> list:
+    """Candidates from the locally synced catalogue, in the live search's shape.
+
+    Only used when the remote catalogue could not be reached. Custom cards are
+    excluded: they are this installation's own rows rather than catalogue
+    entries, and matching a scan against one would invent a result the live
+    search could never have produced.
+    """
+    names = []
+    for _language, search_name in search_pairs:
+        if search_name and search_name not in names:
+            names.append(search_name)
+    if not names:
+        return []
+
+    languages = []
+    for language, _search_name in search_pairs:
+        if language not in languages:
+            languages.append(language)
+
+    rows = (
+        db.query(Card)
+        .filter(
+            Card.tcg_card_id.isnot(None),
+            Card.is_custom.is_(False),
+            or_(*[Card.name.ilike(name) for name in names]),
+            Card.lang.in_(languages),
+        )
+        .limit(60)
+        .all()
+    )
+
+    set_names = {}
+    set_ids = {row.set_id for row in rows if row.set_id}
+    if set_ids:
+        for local_set in db.query(Set).filter(Set.tcg_set_id.in_(set_ids)).all():
+            set_names.setdefault((local_set.tcg_set_id, local_set.lang), local_set.name)
+
+    candidates = []
+    for row in rows:
+        language = row.lang or "en"
+        candidates.append({
+            "id": f"{row.tcg_card_id}_{language}",
+            "tcg_card_id": row.tcg_card_id,
+            "name": row.name,
+            "set": set_names.get((row.set_id, language)),
+            "number": row.number,
+            "image": row.images_small or row.custom_image_url,
+            "rarity": row.rarity,
+            "lang": language,
+            "_lang": language,
+            "_number_extra": False,
+            "_from_local_catalogue": True,
+        })
+    return candidates
+
+
 async def _search_and_rank_candidates(
     db: Session,
     card_info: dict,
@@ -870,6 +928,15 @@ async def _search_and_rank_candidates(
                 )
             unreachable += 1
             continue
+
+    if not candidates and unreachable:
+        # The catalogue is unreachable, but this installation already holds a
+        # synced copy of it. Searching that is not as good as a live lookup, it
+        # only knows the sets that have been synced, but it is far better than
+        # telling the user their card does not exist because a remote host is
+        # down. Images come from the synced rows, so they are exactly as
+        # available as they were before.
+        candidates.extend(_local_catalogue_candidates(db, card_info, search_pairs))
 
     if not candidates and attempted and unreachable == attempted:
         # Every lookup failed to reach the catalogue, so we do not know whether

--- a/backend/api/recognize.py
+++ b/backend/api/recognize.py
@@ -814,16 +814,18 @@ async def _search_and_rank_candidates(
     for search_language, search_name in search_pairs:
         if len(candidates) >= 15:
             break
+        attempted += 1
         try:
             async with httpx.AsyncClient(timeout=15) as client:
                 response = await client.get(
                     f"https://api.tcgdex.net/v2/{search_language}/cards",
                     params={"name": search_name},
                 )
-            attempted += 1
-            # A 5xx is the catalogue failing, not an answer. A 4xx is an answer
-            # we should not retry forever, so it is not counted as unreachable.
-            if response.status_code >= 500:
+            # A 5xx is the catalogue failing, not an answer. So are 429 and 408:
+            # the catalogue is declining to answer this request now, which is
+            # not "no such card" either. Any other 4xx is an answer we should
+            # not retry forever, so it is not counted as unreachable.
+            if response.status_code >= 500 or response.status_code in {408, 429}:
                 unreachable += 1
             cards = response.json() if response.status_code == 200 else []
             if trace:
@@ -866,7 +868,6 @@ async def _search_and_rank_candidates(
                     count=None,
                     error=type(exc).__name__,
                 )
-            attempted += 1
             unreachable += 1
             continue
 

--- a/backend/tests/test_catalogue_outage.py
+++ b/backend/tests/test_catalogue_outage.py
@@ -38,7 +38,11 @@ class CatalogueOutageTests(unittest.IsolatedAsyncioTestCase):
 
     def setUp(self):
         self.card_info = {"name": "Sandshrew", "name_en": "Sandshrew", "number_local": "027", "language": "en"}
+        # An empty local catalogue, so these tests still exercise the outage
+        # path rather than the local fallback.
         self.db = Mock()
+        self.db.query.return_value.filter.return_value.limit.return_value.all.return_value = []
+        self.db.query.return_value.filter.return_value.all.return_value = []
 
     async def test_a_network_failure_is_reported_rather_than_returning_no_matches(self):
         # The user-visible problem this fixes: while the catalogue was down,

--- a/backend/tests/test_catalogue_outage.py
+++ b/backend/tests/test_catalogue_outage.py
@@ -59,6 +59,20 @@ class CatalogueOutageTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(raised.exception.status_code, 503)
 
+    async def test_a_body_that_cannot_be_read_is_an_outage_not_an_answer(self):
+        # A gateway serving an error page with a 200 is still the catalogue
+        # being unavailable. This also pins the attempt accounting: the failure
+        # happens after the response arrives, so counting the lookup twice
+        # would leave attempts and failures unequal and silently return no
+        # matches again.
+        response = _response(200, [])
+        response.json = Mock(side_effect=ValueError("not json"))
+        with patch("api.recognize.httpx.AsyncClient", _client_returning(response)):
+            with self.assertRaises(HTTPException) as raised:
+                await _search_and_rank_candidates(self.db, self.card_info, trace=None)
+
+        self.assertEqual(raised.exception.status_code, 503)
+
     async def test_a_genuine_empty_result_still_reports_no_matches(self):
         # The bystander. The catalogue answered; it simply has no such card.
         # Raising here would turn every unknown card into a retry loop.
@@ -66,6 +80,17 @@ class CatalogueOutageTests(unittest.IsolatedAsyncioTestCase):
             candidates, _ = await _search_and_rank_candidates(self.db, self.card_info, trace=None)
 
         self.assertEqual(candidates, [])
+
+    async def test_a_rate_limited_lookup_is_an_outage_not_an_answer(self):
+        # A 429 is the catalogue declining to answer this request, not a
+        # statement that the card does not exist. Treating it as an answer
+        # reproduces the misleading "no matches" under rate limiting, which is
+        # the outcome this change exists to remove.
+        with patch("api.recognize.httpx.AsyncClient", _client_returning(_response(429, []))):
+            with self.assertRaises(HTTPException) as raised:
+                await _search_and_rank_candidates(self.db, self.card_info, trace=None)
+
+        self.assertEqual(raised.exception.status_code, 503)
 
     async def test_a_client_error_is_an_answer_not_an_outage(self):
         # A 4xx is the catalogue rejecting the request. Retrying it forever

--- a/backend/tests/test_catalogue_outage.py
+++ b/backend/tests/test_catalogue_outage.py
@@ -1,0 +1,80 @@
+import unittest
+from unittest.mock import AsyncMock, Mock, patch
+
+try:
+    import httpx  # noqa: F401
+    from fastapi import HTTPException
+
+    from api.recognize import _search_and_rank_candidates
+
+    DEPS_AVAILABLE = True
+except ModuleNotFoundError:  # pragma: no cover
+    DEPS_AVAILABLE = False
+
+
+def _response(status_code, payload):
+    response = Mock()
+    response.status_code = status_code
+    response.json = Mock(return_value=payload)
+    return response
+
+
+def _client_returning(response=None, error=None):
+    """Stand in for the httpx.AsyncClient context manager the search uses."""
+    client = AsyncMock()
+    if error is not None:
+        client.get = AsyncMock(side_effect=error)
+    else:
+        client.get = AsyncMock(return_value=response)
+    context = AsyncMock()
+    context.__aenter__ = AsyncMock(return_value=client)
+    context.__aexit__ = AsyncMock(return_value=False)
+    return Mock(return_value=context)
+
+
+@unittest.skipUnless(DEPS_AVAILABLE, "FastAPI/httpx are not installed in this lightweight test environment")
+class CatalogueOutageTests(unittest.IsolatedAsyncioTestCase):
+    """An unreachable catalogue must not be reported as a card that does not exist."""
+
+    def setUp(self):
+        self.card_info = {"name": "Sandshrew", "name_en": "Sandshrew", "number_local": "027", "language": "en"}
+        self.db = Mock()
+
+    async def test_a_network_failure_is_reported_rather_than_returning_no_matches(self):
+        # The user-visible problem this fixes: while the catalogue was down,
+        # every scan completed with zero matches and no error, which reads as
+        # "this card is not in the database" and sends people looking at their
+        # own installation.
+        with patch("api.recognize.httpx.AsyncClient", _client_returning(error=httpx.ConnectTimeout("timed out"))):
+            with self.assertRaises(HTTPException) as raised:
+                await _search_and_rank_candidates(self.db, self.card_info, trace=None)
+
+        self.assertEqual(raised.exception.status_code, 503)
+        self.assertIn("catalogue", str(raised.exception.detail).lower())
+
+    async def test_a_catalogue_server_error_is_treated_the_same_way(self):
+        with patch("api.recognize.httpx.AsyncClient", _client_returning(_response(503, []))):
+            with self.assertRaises(HTTPException) as raised:
+                await _search_and_rank_candidates(self.db, self.card_info, trace=None)
+
+        self.assertEqual(raised.exception.status_code, 503)
+
+    async def test_a_genuine_empty_result_still_reports_no_matches(self):
+        # The bystander. The catalogue answered; it simply has no such card.
+        # Raising here would turn every unknown card into a retry loop.
+        with patch("api.recognize.httpx.AsyncClient", _client_returning(_response(200, []))):
+            candidates, _ = await _search_and_rank_candidates(self.db, self.card_info, trace=None)
+
+        self.assertEqual(candidates, [])
+
+    async def test_a_client_error_is_an_answer_not_an_outage(self):
+        # A 4xx is the catalogue rejecting the request. Retrying it forever
+        # would not help, so it must not be classed as unreachable.
+        with patch("api.recognize.httpx.AsyncClient", _client_returning(_response(400, []))):
+            candidates, _ = await _search_and_rank_candidates(self.db, self.card_info, trace=None)
+
+        self.assertEqual(candidates, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_catalogue_outage.py
+++ b/backend/tests/test_catalogue_outage.py
@@ -4,8 +4,11 @@ from unittest.mock import AsyncMock, Mock, patch
 try:
     import httpx  # noqa: F401
     from fastapi import HTTPException
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
 
     from api.recognize import _search_and_rank_candidates
+    from database import Base
 
     DEPS_AVAILABLE = True
 except ModuleNotFoundError:  # pragma: no cover
@@ -38,11 +41,14 @@ class CatalogueOutageTests(unittest.IsolatedAsyncioTestCase):
 
     def setUp(self):
         self.card_info = {"name": "Sandshrew", "name_en": "Sandshrew", "number_local": "027", "language": "en"}
-        # An empty local catalogue, so these tests still exercise the outage
-        # path rather than the local fallback.
-        self.db = Mock()
-        self.db.query.return_value.filter.return_value.limit.return_value.all.return_value = []
-        self.db.query.return_value.filter.return_value.all.return_value = []
+        # A real but empty local catalogue, so these tests still exercise the
+        # outage path rather than the local fallback.
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        self.db = sessionmaker(bind=engine)()
+
+    def tearDown(self):
+        self.db.close()
 
     async def test_a_network_failure_is_reported_rather_than_returning_no_matches(self):
         # The user-visible problem this fixes: while the catalogue was down,
@@ -64,11 +70,11 @@ class CatalogueOutageTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(raised.exception.status_code, 503)
 
     async def test_a_body_that_cannot_be_read_is_an_outage_not_an_answer(self):
-        # A gateway serving an error page with a 200 is still the catalogue
-        # being unavailable. This also pins the attempt accounting: the failure
-        # happens after the response arrives, so counting the lookup twice
-        # would leave attempts and failures unequal and silently return no
-        # matches again.
+        # A gateway serving an HTML error page with a 200 is still the
+        # catalogue being unavailable. This also pins the attempt accounting:
+        # the failure happens after the response arrives, so counting the
+        # lookup twice would leave attempts and failures unequal and silently
+        # return no matches again.
         response = _response(200, [])
         response.json = Mock(side_effect=ValueError("not json"))
         with patch("api.recognize.httpx.AsyncClient", _client_returning(response)):
@@ -88,8 +94,8 @@ class CatalogueOutageTests(unittest.IsolatedAsyncioTestCase):
     async def test_a_rate_limited_lookup_is_an_outage_not_an_answer(self):
         # A 429 is the catalogue declining to answer this request, not a
         # statement that the card does not exist. Treating it as an answer
-        # reproduces the misleading "no matches" under rate limiting, which is
-        # the outcome this change exists to remove.
+        # reproduces the original misleading "no matches" under rate limiting,
+        # which is exactly the outcome these commits exist to remove.
         with patch("api.recognize.httpx.AsyncClient", _client_returning(_response(429, []))):
             with self.assertRaises(HTTPException) as raised:
                 await _search_and_rank_candidates(self.db, self.card_info, trace=None)

--- a/backend/tests/test_local_catalogue_fallback.py
+++ b/backend/tests/test_local_catalogue_fallback.py
@@ -1,35 +1,56 @@
+"""During a catalogue outage the synced copy on disk should be used.
+
+A user reported every scan failing to match while the installation held a
+fully synced catalogue in Postgres, because an unreachable remote host was
+being reported as "no matches". These tests cover the fallback that searches
+the local copy instead, and the two ways that fallback could do harm: by
+answering when the catalogue actually replied, and by offering a row the live
+search could never have returned.
+
+The queries run against a real SQLite session rather than a mocked one, so a
+filter that stops being applied changes the rows that come back rather than
+only changing which mock methods were called.
+"""
+
 import unittest
 from unittest.mock import AsyncMock, Mock, patch
 
 try:
     import httpx  # noqa: F401
     from fastapi import HTTPException  # noqa: F401
+    from sqlalchemy import create_engine, text
+    from sqlalchemy.orm import sessionmaker
 
     from api.recognize import _local_catalogue_candidates, _search_and_rank_candidates
+    from database import Base
+    from models import Card, Set
 
     DEPS_AVAILABLE = True
 except ModuleNotFoundError:  # pragma: no cover
     DEPS_AVAILABLE = False
 
 
-def _card(**kwargs):
-    row = Mock()
-    row.tcg_card_id = kwargs.get("tcg_card_id", "sv03.5-027")
-    row.name = kwargs.get("name", "Sandshrew")
-    row.set_id = kwargs.get("set_id", "sv03.5")
-    row.number = kwargs.get("number", "027")
-    row.rarity = kwargs.get("rarity", "Common")
-    row.images_small = kwargs.get("images_small", "https://assets.tcgdex.net/en/sv/sv03.5/27/low.webp")
-    row.custom_image_url = kwargs.get("custom_image_url", None)
-    row.lang = kwargs.get("lang", "en")
+def _add_card(db, **kwargs):
+    tcg_card_id = kwargs.pop("tcg_card_id", "sv03.5-027")
+    lang = kwargs.pop("lang", "en")
+    row = Card(
+        id=kwargs.pop("id", f"{tcg_card_id or 'custom'}_{lang}"),
+        tcg_card_id=tcg_card_id,
+        name=kwargs.pop("name", "Sandshrew"),
+        set_id=kwargs.pop("set_id", "sv03.5"),
+        number=kwargs.pop("number", "027"),
+        rarity=kwargs.pop("rarity", "Common"),
+        images_small=kwargs.pop(
+            "images_small", "https://assets.tcgdex.net/en/sv/sv03.5/27/low.webp"
+        ),
+        custom_image_url=kwargs.pop("custom_image_url", None),
+        is_custom=kwargs.pop("is_custom", False),
+        lang=lang,
+        **kwargs,
+    )
+    db.add(row)
+    db.commit()
     return row
-
-
-def _db_with(cards, sets=None):
-    db = Mock()
-    db.query.return_value.filter.return_value.limit.return_value.all.return_value = cards
-    db.query.return_value.filter.return_value.all.return_value = sets or []
-    return db
 
 
 def _unreachable_client():
@@ -41,20 +62,43 @@ def _unreachable_client():
     return Mock(return_value=context)
 
 
+def _answering_client(payload):
+    response = Mock()
+    response.status_code = 200
+    response.json = Mock(return_value=payload)
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=response)
+    context = AsyncMock()
+    context.__aenter__ = AsyncMock(return_value=client)
+    context.__aexit__ = AsyncMock(return_value=False)
+    return Mock(return_value=context)
+
+
 @unittest.skipUnless(DEPS_AVAILABLE, "FastAPI/httpx are not installed in this lightweight test environment")
 class LocalCatalogueFallbackTests(unittest.IsolatedAsyncioTestCase):
     """A synced catalogue already on disk should not go unused during an outage."""
 
     def setUp(self):
-        self.card_info = {"name": "Sandshrew", "name_en": "Sandshrew", "number_local": "027", "language": "en"}
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        self.db = sessionmaker(bind=engine)()
+        self.card_info = {
+            "name": "Sandshrew",
+            "name_en": "Sandshrew",
+            "number_local": "027",
+            "language": "en",
+        }
+        self.pairs = [("en", "Sandshrew")]
+
+    def tearDown(self):
+        self.db.close()
 
     async def test_an_unreachable_catalogue_falls_back_to_the_synced_copy(self):
-        # The user problem: this installation had all 23,000 synced cards in
-        # Postgres, including the exact card being scanned, and still reported
-        # nothing because a remote host was down.
-        db = _db_with([_card()])
+        # The user problem: this installation held the exact card being
+        # scanned and still reported nothing, because a remote host was down.
+        _add_card(self.db)
         with patch("api.recognize.httpx.AsyncClient", _unreachable_client()):
-            candidates, _ = await _search_and_rank_candidates(db, self.card_info, trace=None)
+            candidates, _ = await _search_and_rank_candidates(self.db, self.card_info, trace=None)
 
         self.assertEqual(len(candidates), 1)
         self.assertEqual(candidates[0]["tcg_card_id"], "sv03.5-027")
@@ -64,40 +108,149 @@ class LocalCatalogueFallbackTests(unittest.IsolatedAsyncioTestCase):
     async def test_the_fallback_is_not_used_when_the_catalogue_answered(self):
         # The bystander. A live empty answer means the card is not there, and
         # must not be quietly replaced by a local guess.
-        db = _db_with([_card()])
+        _add_card(self.db)
+        with patch("api.recognize.httpx.AsyncClient", _answering_client([])):
+            candidates, _ = await _search_and_rank_candidates(self.db, self.card_info, trace=None)
+
+        self.assertEqual(candidates, [])
+
+    async def test_a_partial_outage_does_not_trigger_the_fallback(self):
+        # One lookup answered "no such card" and another timed out. The
+        # catalogue has spoken, so a local guess must not overrule it; the
+        # fallback is only for knowing nothing at all.
+        _add_card(self.db)
         response = Mock()
         response.status_code = 200
         response.json = Mock(return_value=[])
         client = AsyncMock()
-        client.get = AsyncMock(return_value=response)
+        client.get = AsyncMock(side_effect=[response, httpx.ConnectTimeout("timed out")])
         context = AsyncMock()
         context.__aenter__ = AsyncMock(return_value=client)
         context.__aexit__ = AsyncMock(return_value=False)
+        card_info = dict(self.card_info, name="Sabelette", language="fr")
         with patch("api.recognize.httpx.AsyncClient", Mock(return_value=context)):
-            candidates, _ = await _search_and_rank_candidates(db, self.card_info, trace=None)
+            candidates, _ = await _search_and_rank_candidates(self.db, card_info, trace=None)
 
+        self.assertGreaterEqual(client.get.await_count, 2, "both lookups should have been tried")
         self.assertEqual(candidates, [])
 
     def test_custom_cards_are_excluded_from_the_fallback(self):
         # A custom card is this installation's own row, not a catalogue entry.
         # Offering one as a scan match would invent a result the live search
-        # could never return.
-        db = _db_with([])
-        _local_catalogue_candidates(db, self.card_info, [("en", "Sandshrew")])
-        filter_args = db.query.return_value.filter.call_args
-        self.assertIsNotNone(filter_args, "the fallback must filter, not select everything")
+        # could never return. It is stored with the same name and number as the
+        # real card, so only the is_custom filter can keep it out.
+        _add_card(
+            self.db,
+            id="custom-1_en",
+            tcg_card_id="sv03.5-027",
+            is_custom=True,
+            custom_image_url="/uploads/custom-1.jpg",
+        )
+        self.assertEqual(_local_catalogue_candidates(self.db, self.card_info, self.pairs), [])
+
+    def test_rows_predating_the_custom_flag_are_still_catalogue_rows(self):
+        # is_custom is nullable, and the card-id migration in database.py
+        # already treats "NULL or false" as catalogue data. A synced row left
+        # NULL must not become invisible to the fallback, which would put the
+        # user back where they started: their own catalogue on disk, unused.
+        row = _add_card(self.db)
+        # The column carries a Python-side default of False, which SQLAlchemy
+        # applies to a None on insert, so the NULL has to be written directly.
+        self.db.execute(text("UPDATE cards SET is_custom = NULL WHERE id = :id"), {"id": row.id})
+        self.db.commit()
+        stored = self.db.execute(text("SELECT is_custom FROM cards WHERE id = :id"), {"id": row.id}).scalar()
+        self.assertIsNone(stored, "this test is worthless unless the row really is NULL")
+
+        candidates = _local_catalogue_candidates(self.db, self.card_info, self.pairs)
+        self.assertEqual([card["tcg_card_id"] for card in candidates], ["sv03.5-027"])
+
+    def test_rows_without_a_catalogue_id_are_excluded(self):
+        # A row with no tcg_card_id cannot be resolved by anything downstream,
+        # so returning it would produce a candidate that fails to add.
+        _add_card(self.db, id="orphan_en", tcg_card_id=None)
+        self.assertEqual(_local_catalogue_candidates(self.db, self.card_info, self.pairs), [])
+
+    def test_a_different_printed_number_is_not_offered(self):
+        # The dangerous case. Another printing of the same name must not be
+        # returned for this number: the ranker reads a lone result as a unique
+        # number and marks it confident, so "add all confident" would file the
+        # wrong card. Worse than no match at all.
+        _add_card(self.db, id="sv03.5-104_en", tcg_card_id="sv03.5-104", number="104")
+        self.assertEqual(_local_catalogue_candidates(self.db, self.card_info, self.pairs), [])
+
+    def test_the_right_printing_survives_a_crowded_name(self):
+        # The failure the ordering and the window exist to prevent. A name with
+        # many printings must not have the scanned one truncated away, leaving
+        # a different number behind for the ranker to read as unique and mark
+        # confident. The wanted row sorts last here on purpose.
+        for index in range(80):
+            _add_card(
+                self.db,
+                id=f"sv0{index}-{index}_en",
+                tcg_card_id=f"sv0{index}-{index}",
+                set_id=f"sv0{index}",
+                number=str(100 + index),
+            )
+        _add_card(self.db, id="zz-027_en", tcg_card_id="zz-027", set_id="zz", number="027")
+
+        candidates = _local_catalogue_candidates(self.db, self.card_info, self.pairs)
+        self.assertEqual([card["tcg_card_id"] for card in candidates], ["zz-027"])
+
+    def test_the_padded_form_of_the_printed_number_matches(self):
+        # "27" on the card and "027" in the catalogue are the same printing.
+        _add_card(self.db, id="sv03.5-27_en", tcg_card_id="sv03.5-27", number="27")
+        candidates = _local_catalogue_candidates(self.db, self.card_info, self.pairs)
+        self.assertEqual([card["number"] for card in candidates], ["27"])
+
+    def test_a_different_language_is_not_offered(self):
+        _add_card(self.db, id="sv03.5-027_fr", lang="fr")
+        self.assertEqual(_local_catalogue_candidates(self.db, self.card_info, self.pairs), [])
+
+    def test_a_name_is_only_matched_in_the_language_it_was_searched_in(self):
+        # The real collision: swsh2-201 is Milo in English and Yarrow in
+        # Italian, and swsh7-201 is Milo in Italian, all printed 201. Scanning
+        # the Italian Yarrow searches ("it", "Yarrow") and ("en", "Milo"). If
+        # the pairs are split into a list of names and a list of languages,
+        # their product admits the Italian Milo, which no live search would
+        # ever have returned.
+        _add_card(
+            self.db,
+            id="swsh7-201_it",
+            tcg_card_id="swsh7-201",
+            name="Milo",
+            set_id="swsh7",
+            number="201",
+            lang="it",
+        )
+        _add_card(
+            self.db,
+            id="swsh2-201_it",
+            tcg_card_id="swsh2-201",
+            name="Yarrow",
+            set_id="swsh2",
+            number="201",
+            lang="it",
+        )
+        card_info = {"name": "Yarrow", "name_en": "Milo", "number_local": "201", "language": "it"}
+        candidates = _local_catalogue_candidates(
+            self.db, card_info, [("it", "Yarrow"), ("en", "Milo")]
+        )
+        self.assertEqual([card["tcg_card_id"] for card in candidates], ["swsh2-201"])
 
     def test_the_fallback_shape_matches_the_live_search(self):
         # Downstream ranking reads these keys, so a mismatch would rank the
         # local results wrongly rather than fail loudly.
-        db = _db_with([_card()])
-        candidates = _local_catalogue_candidates(db, self.card_info, [("en", "Sandshrew")])
+        _add_card(self.db)
+        self.db.add(Set(id="sv03.5_en", tcg_set_id="sv03.5", name="151", lang="en"))
+        self.db.commit()
+        candidates = _local_catalogue_candidates(self.db, self.card_info, self.pairs)
         for key in ("id", "tcg_card_id", "name", "set", "number", "image", "rarity", "lang", "_lang"):
             self.assertIn(key, candidates[0], key)
+        self.assertEqual(candidates[0]["set"], "151")
 
     def test_nothing_is_returned_without_a_name_to_search(self):
-        db = _db_with([_card()])
-        self.assertEqual(_local_catalogue_candidates(db, self.card_info, []), [])
+        _add_card(self.db)
+        self.assertEqual(_local_catalogue_candidates(self.db, self.card_info, []), [])
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_local_catalogue_fallback.py
+++ b/backend/tests/test_local_catalogue_fallback.py
@@ -1,0 +1,104 @@
+import unittest
+from unittest.mock import AsyncMock, Mock, patch
+
+try:
+    import httpx  # noqa: F401
+    from fastapi import HTTPException  # noqa: F401
+
+    from api.recognize import _local_catalogue_candidates, _search_and_rank_candidates
+
+    DEPS_AVAILABLE = True
+except ModuleNotFoundError:  # pragma: no cover
+    DEPS_AVAILABLE = False
+
+
+def _card(**kwargs):
+    row = Mock()
+    row.tcg_card_id = kwargs.get("tcg_card_id", "sv03.5-027")
+    row.name = kwargs.get("name", "Sandshrew")
+    row.set_id = kwargs.get("set_id", "sv03.5")
+    row.number = kwargs.get("number", "027")
+    row.rarity = kwargs.get("rarity", "Common")
+    row.images_small = kwargs.get("images_small", "https://assets.tcgdex.net/en/sv/sv03.5/27/low.webp")
+    row.custom_image_url = kwargs.get("custom_image_url", None)
+    row.lang = kwargs.get("lang", "en")
+    return row
+
+
+def _db_with(cards, sets=None):
+    db = Mock()
+    db.query.return_value.filter.return_value.limit.return_value.all.return_value = cards
+    db.query.return_value.filter.return_value.all.return_value = sets or []
+    return db
+
+
+def _unreachable_client():
+    client = AsyncMock()
+    client.get = AsyncMock(side_effect=httpx.ConnectTimeout("timed out"))
+    context = AsyncMock()
+    context.__aenter__ = AsyncMock(return_value=client)
+    context.__aexit__ = AsyncMock(return_value=False)
+    return Mock(return_value=context)
+
+
+@unittest.skipUnless(DEPS_AVAILABLE, "FastAPI/httpx are not installed in this lightweight test environment")
+class LocalCatalogueFallbackTests(unittest.IsolatedAsyncioTestCase):
+    """A synced catalogue already on disk should not go unused during an outage."""
+
+    def setUp(self):
+        self.card_info = {"name": "Sandshrew", "name_en": "Sandshrew", "number_local": "027", "language": "en"}
+
+    async def test_an_unreachable_catalogue_falls_back_to_the_synced_copy(self):
+        # The user problem: this installation had all 23,000 synced cards in
+        # Postgres, including the exact card being scanned, and still reported
+        # nothing because a remote host was down.
+        db = _db_with([_card()])
+        with patch("api.recognize.httpx.AsyncClient", _unreachable_client()):
+            candidates, _ = await _search_and_rank_candidates(db, self.card_info, trace=None)
+
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(candidates[0]["tcg_card_id"], "sv03.5-027")
+        self.assertEqual(candidates[0]["number"], "027")
+        self.assertTrue(candidates[0]["image"])
+
+    async def test_the_fallback_is_not_used_when_the_catalogue_answered(self):
+        # The bystander. A live empty answer means the card is not there, and
+        # must not be quietly replaced by a local guess.
+        db = _db_with([_card()])
+        response = Mock()
+        response.status_code = 200
+        response.json = Mock(return_value=[])
+        client = AsyncMock()
+        client.get = AsyncMock(return_value=response)
+        context = AsyncMock()
+        context.__aenter__ = AsyncMock(return_value=client)
+        context.__aexit__ = AsyncMock(return_value=False)
+        with patch("api.recognize.httpx.AsyncClient", Mock(return_value=context)):
+            candidates, _ = await _search_and_rank_candidates(db, self.card_info, trace=None)
+
+        self.assertEqual(candidates, [])
+
+    def test_custom_cards_are_excluded_from_the_fallback(self):
+        # A custom card is this installation's own row, not a catalogue entry.
+        # Offering one as a scan match would invent a result the live search
+        # could never return.
+        db = _db_with([])
+        _local_catalogue_candidates(db, self.card_info, [("en", "Sandshrew")])
+        filter_args = db.query.return_value.filter.call_args
+        self.assertIsNotNone(filter_args, "the fallback must filter, not select everything")
+
+    def test_the_fallback_shape_matches_the_live_search(self):
+        # Downstream ranking reads these keys, so a mismatch would rank the
+        # local results wrongly rather than fail loudly.
+        db = _db_with([_card()])
+        candidates = _local_catalogue_candidates(db, self.card_info, [("en", "Sandshrew")])
+        for key in ("id", "tcg_card_id", "name", "set", "number", "image", "rarity", "lang", "_lang"):
+            self.assertIn(key, candidates[0], key)
+
+    def test_nothing_is_returned_without_a_name_to_search(self):
+        db = _db_with([_card()])
+        self.assertEqual(_local_catalogue_candidates(db, self.card_info, []), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #390.

Builds on #387 — please merge that first, as both touch `_search_and_rank_candidates` and this branch contains its commit.

### The user problem

An installation that has synced the catalogue already holds the card data locally. Candidate search only ever queried `api.tcgdex.net`, so when that host was unreachable, scans reported nothing even though the exact card was sitting in the local `cards` table.

Concretely, during the recent outage: a scan read *Sandshrew 027/165* correctly, `recognized` was populated, and the local database contained `sv03.5-027_en` — and the result was still zero matches.

### The change

When every remote lookup fails to reach the catalogue, the synced copy is searched instead, returning candidates in the same shape so ranking and downstream handling are unchanged. Images come from the synced rows, so they are exactly as available as they were before.

Two deliberate limits:

- **A live answer is never second-guessed.** If the catalogue replied and had nothing, that is still no match. Substituting a local guess there would hide genuine gaps in the catalogue.
- **Custom cards are excluded.** They are the installation's own rows rather than catalogue entries, and offering one as a scan match would invent a result the live search could never produce.

The 503 from #387 still applies when the remote catalogue is unreachable *and* the local one has nothing to offer either.

### Tests

Five tests, including two bystanders: that a live empty answer is not replaced by a local guess, and that the candidate shape matches the live search so ranking cannot silently misread it. The fallback test fails when the fallback is disabled.

### Note on the suite

`test_own_photo_priority.test_equivalent_prints_flags_the_owned_photographed_variant` errors on `main` with or without this change, and takes ~60s because it calls `api.tcgdex.net` for real. Same pre-existing issue I mentioned in #387.