### PR TITLE
Fix 500 on /collection/stats/summary: import card_values helpers

### DIFF
--- a/backend/api/collection.py
+++ b/backend/api/collection.py
@@ -16,6 +16,7 @@ from services.digital_sets import digital_sets_enabled
 from services.standard_legality import is_standard_legal_card, is_standard_regulation_mark
 from services.tcgdex_languages import SUPPORTED_TCGDEX_LANGUAGES, has_lang_suffix, is_supported_tcgdex_language, normalize_tcgdex_language
 from services.collection_csv import collection_import_key, is_valid_collection_purchase_price, merge_collection_import_item, normalize_collection_variant
+from services.card_values import effective_market_price, normalize_price_field
 import datetime
 import csv
 import io

--- a/backend/tests/test_collection_stats_imports.py
+++ b/backend/tests/test_collection_stats_imports.py
@@ -1,0 +1,17 @@
+import unittest
+
+
+class CollectionStatsImportTests(unittest.TestCase):
+    """get_collection_stats() calls these two helpers, so the module must import
+    them. A merge once dropped the import while keeping both call sites, which
+    made GET /collection/stats/summary raise NameError on every request."""
+
+    def test_price_helpers_are_importable_from_collection_module(self):
+        import api.collection as collection
+
+        self.assertTrue(callable(getattr(collection, 'normalize_price_field', None)))
+        self.assertTrue(callable(getattr(collection, 'effective_market_price', None)))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
_Upfront and with apologies: this patch was written by an AI assistant (Claude), working from my PokéCollector instance. I've reviewed and tested it, but please read it with that in mind — and tell me if you'd rather not receive AI-assisted contributions, and I'll respect that._

Fixes #393.

### Problem

`GET /api/collection/stats/summary` returns 500 on every request:

```
NameError: name 'normalize_price_field' is not defined     # collection.py:1006
NameError: name 'effective_market_price' is not defined    # collection.py:42
```

`get_collection_stats()` calls both helpers, but `backend/api/collection.py` imports neither. Line 1006 is unconditional, so it fails regardless of `price_field` or collection size.

### Cause

Merge commit `130c9ccb` dropped the import while keeping both call sites. Both of its parents had it:

| commit | `card_values` import | call sites |
|---|---|---|
| `f21823a9` (parent 1) | ✅ | 2 |
| `6e34debf` (parent 2) | ✅ | 2 |
| `130c9ccb` (merge) | ❌ | 2 |

Every other caller — `analytics`, `binders`, `dashboard`, `export`, `products`, `social`, `trades` — imports these from `services.card_values`; `collection.py` was the only one that didn't.

### Change

One import line, plus a regression test asserting both names resolve in the module. An AST pass over the file finds exactly these two undefined names and no star imports, so the import is a complete fix.

### Verification

- New test fails on `main` (`AssertionError: False is not true`), passes with the fix.
- `test_collection_csv`, `test_card_values`, `test_custom_card_ownership`, `test_analytics` — 21 tests, all pass with the fix applied.
- Endpoint verified against a real 252-card collection: `total_cards=252, unique_cards=251, total_value=2270.90, total_cost=1616.47, pnl=654.43`.

Only `/collection/stats/summary` is affected; `_get_item_price` has no other caller.
